### PR TITLE
Logic layer refactorings

### DIFF
--- a/src/logic/Publisher.js
+++ b/src/logic/Publisher.js
@@ -3,7 +3,7 @@ const debug = require('debug')('streamr:publisher')
 const encoder = require('../helpers/MessageEncoder')
 const { generateClientId } = require('../util')
 
-module.exports = class Node extends EventEmitter {
+module.exports = class Publisher extends EventEmitter {
     constructor(connection, nodeAddress) {
         super()
 

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -17,12 +17,12 @@ module.exports = class Tracker extends EventEmitter {
         }
 
         this.connection.once('node:ready', () => this.trackerReady())
-        this.listners.trackerServerListner.on('streamr:tracker:find-stream', ({ node, streamId }) => {
-            this.sendStreamInfo(node, streamId)
+        this.listners.trackerServerListner.on('streamr:tracker:find-stream', ({ sender, streamId }) => { // TODO: rename sender to requester/node
+            this.sendStreamInfo(sender, streamId)
         })
         this.listners.trackerServerListner.on('streamr:tracker:send-peers', (node) => this.sendListOfNodes(node))
-        this.listners.trackerServerListner.on('streamr:tracker:peer-status', ({ node, status }) => {
-            this.processNodeStatus(node, status)
+        this.listners.trackerServerListner.on('streamr:tracker:peer-status', ({ peer, status }) => { // TODO: rename peer to node
+            this.processNodeStatus(peer, status)
         })
     }
 

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -10,19 +10,19 @@ module.exports = class Tracker extends EventEmitter {
         super()
 
         this.connection = connection
-        this.peers = new Map()
+        this.nodes = new Map()
         this.trackerId = generateClientId('tracker')
         this.listners = {
             trackerServerListner: new TrackerServer(this.connection)
         }
 
         this.connection.once('node:ready', () => this.trackerReady())
-        this.listners.trackerServerListner.on('streamr:tracker:find-stream', ({ sender, streamId }) => {
-            this.findStream(sender, streamId)
+        this.listners.trackerServerListner.on('streamr:tracker:find-stream', ({ node, streamId }) => {
+            this.sendStreamInfo(node, streamId)
         })
-        this.listners.trackerServerListner.on('streamr:tracker:send-peers', (peer) => this.sendPeers(peer))
-        this.listners.trackerServerListner.on('streamr:tracker:peer-status', ({ peer, status }) => {
-            this.statusPeer(peer, status)
+        this.listners.trackerServerListner.on('streamr:tracker:send-peers', (node) => this.sendListOfNodes(node))
+        this.listners.trackerServerListner.on('streamr:tracker:peer-status', ({ node, status }) => {
+            this.processNodeStatus(node, status)
         })
     }
 
@@ -30,24 +30,24 @@ module.exports = class Tracker extends EventEmitter {
         debug('tracker: %s is running', this.trackerId)
     }
 
-    sendPeers(peer) {
-        debug('sending peers')
+    sendListOfNodes(node) {
+        debug('sending list of nodes')
 
-        const peers = getPeersTopology(this.peers, getAddress(peer))
-        this.connection.send(peer, encoder.peersMessage(peers))
+        const listOfNodes = getPeersTopology(this.nodes, getAddress(node))
+        this.connection.send(node, encoder.peersMessage(listOfNodes))
     }
 
-    statusPeer(peer, status) {
-        debug('received from %s status %s', getAddress(peer), JSON.stringify(status))
-        this.peers.set(getAddress(peer), status)
+    processNodeStatus(node, status) {
+        debug('received from %s status %s', getAddress(node), JSON.stringify(status))
+        this.nodes.set(getAddress(node), status)
     }
 
-    findStream(sender, streamId) {
+    sendStreamInfo(node, streamId) {
         debug('tracker looking for the stream %s', streamId)
 
-        this.peers.forEach((status, nodeAddress) => {
+        this.nodes.forEach((status, nodeAddress) => {
             if (status.streams.includes(streamId)) {
-                this.connection.send(sender, encoder.streamMessage(streamId, nodeAddress))
+                this.connection.send(node, encoder.streamMessage(streamId, nodeAddress))
             }
         })
     }

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -4,16 +4,13 @@ const debug = require('debug')('streamr:node-node')
 module.exports = class NodeToNode extends EventEmitter {
     constructor(connection) {
         super()
-
         this.connection = connection
-
-        this.on('streamr:node-node:connect', (peers) => this.onConnectNodes(peers))
     }
 
-    onConnectNodes(peers) {
-        peers.forEach((peer) => {
-            debug('connecting to new node %s', peer)
-            this.connection.connect(peer)
+    connectToNodes(nodes) {
+        nodes.forEach((node) => {
+            debug('connecting to new node %s', node)
+            this.connection.connect(node)
         })
     }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -30,10 +30,7 @@ const getAddress = (peerInfo) => {
     throw new Error('Expected instance of PeerInfo')
 }
 
-const generateClientId = (prefix = '') => {
-    const prefixFixed = prefix ? '-' + prefix : ''
-    return `streamr${prefixFixed}/v${version}/${os.platform()}-${os.arch()}/nodejs`
-}
+const generateClientId = (suffix) => `streamr-${suffix}/v${version}/${os.platform()}-${os.arch()}/nodejs`
 
 const isTracker = (tracker) => BOOTNODES.includes(tracker)
 

--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,7 @@ const getAddress = (peerInfo) => {
     if (peerInfo instanceof PeerInfo) {
         return peerInfo.multiaddrs.toArray()[0].toString()
     }
-    throw new Error('Expected instance of PeerInfo')
+    throw new Error('Expected instance of PeerInfo, got ' + peerInfo)
 }
 
 const generateClientId = (suffix) => `streamr-${suffix}/v${version}/${os.platform()}-${os.arch()}/nodejs`


### PR DESCRIPTION
- Rename `peer` to `node` when appropriate.
- Rename a few functions to better reflect their use or what causes them
- Other small changes