### PR TITLE
Communicate from Logic Layer via Protocol Layer

### DIFF
--- a/src/logic/Publisher.js
+++ b/src/logic/Publisher.js
@@ -1,36 +1,35 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('streamr:publisher')
-const encoder = require('../helpers/MessageEncoder')
+const NodeToNode = require('../protocol/NodeToNode')
 const { generateClientId } = require('../util')
 
 module.exports = class Publisher extends EventEmitter {
     constructor(connection, nodeAddress) {
         super()
 
-        this.connection = connection
         this.publisherId = generateClientId('publisher')
         this.nodeAddress = nodeAddress
+        this.listeners = {
+            nodeToNode: new NodeToNode(connection)
+        }
 
-        this.connection.once('node:ready', () => this.onNodeReady())
+        connection.once('node:ready', () => this._onNodeReady())
     }
 
-    onNodeReady() {
+    _onNodeReady() {
         debug('node: %s is running\n\n\n', this.publisherId)
     }
 
-    publishLibP2P(streamdId, data) {
-        debug('publishing data', streamdId, data)
-        this.connection.node.pubsub.publish(
-            streamdId,
-            Buffer.from(data),
-            () => {}
-        )
+    publishLibP2P(streamId, data) {
+        debug('publishing data', streamId, data)
+        this.listeners.nodeToNode.publishToStream(streamId, data, () => {})
     }
 
-    publish(streamdId, data) {
+    publish(streamId, data) {
         if (this.nodeAddress) {
-            debug('publishing data', streamdId, data)
-            this.connection.send(this.nodeAddress, encoder.dataMessage(streamdId, data))
+            debug('publishing data', streamId, data)
+            this.listeners.nodeToNode.sendData(this.nodeAddress, streamId, data)
         }
+        throw new Error('Failed to publish because this.nodeAddress not defined.')
     }
 }

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -22,4 +22,8 @@ module.exports = class NodeToNode extends EventEmitter {
     subscribeToStream(streamId, messageHandler, doneHandler) {
         this.connection.node.pubsub.subscribe(streamId, messageHandler, doneHandler) // TODO: leaky abstraction
     }
+
+    publishToStream(streamId, data, cb) {
+        this.connection.node.pubsub.publish(streamId, Buffer.from(data), cb)
+    }
 }

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -1,5 +1,6 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('streamr:node-node')
+const encoder = require('../helpers/MessageEncoder')
 
 module.exports = class NodeToNode extends EventEmitter {
     constructor(connection) {
@@ -12,5 +13,13 @@ module.exports = class NodeToNode extends EventEmitter {
             debug('connecting to new node %s', node)
             this.connection.connect(node)
         })
+    }
+
+    sendData(receiverNode, streamId, data) {
+        this.connection.send(receiverNode, encoder.dataMessage(streamId, data))
+    }
+
+    subscribeToStream(streamId, messageHandler, doneHandler) {
+        this.connection.node.pubsub.subscribe(streamId, messageHandler, doneHandler) // TODO: leaky abstraction
     }
 }

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -16,11 +16,19 @@ module.exports = class TrackerNode extends EventEmitter {
 
         this.connection = connection
 
-        this.connection.on('streamr:peer:discovery', (tracker) => this.onConnectToTracker(tracker))
-        this.connection.on('streamr:message-received', ({ sender, message }) => this.onReceive(sender, message))
+        this.connection.on('streamr:peer:discovery', (tracker) => this._onConnectToTracker(tracker))
+        this.connection.on('streamr:message-received', ({ sender, message }) => this._onReceive(sender, message))
     }
 
-    async onConnectToTracker(tracker) {
+    sendStatus(tracker, status) {
+        this.connection.send(tracker, encoder.statusMessage(status))
+    }
+
+    requestStreamInfo(tracker, streamId) {
+        this.connection.send(tracker, encoder.streamMessage(streamId, ''))
+    }
+
+    async _onConnectToTracker(tracker) {
         if (isTracker(getAddress(tracker)) && !this.connection.isConnected(tracker)) {
             await this.connection.connect(tracker)
 
@@ -29,7 +37,7 @@ module.exports = class TrackerNode extends EventEmitter {
         }
     }
 
-    onReceive(sender, message) {
+    _onReceive(sender, message) {
         const { code, data } = encoder.decode(message)
 
         switch (code) {

--- a/src/protocol/TrackerServer.js
+++ b/src/protocol/TrackerServer.js
@@ -16,17 +16,25 @@ module.exports = class TrackerServer extends EventEmitter {
 
         this.connection = connection
 
-        this.connection.on('streamr:peer:connect', (peer) => this.onNewConnection(peer))
-        this.connection.on('streamr:message-received', ({ sender, message }) => this.onReceive(sender, message))
+        this.connection.on('streamr:peer:connect', (peer) => this._onNewConnection(peer))
+        this.connection.on('streamr:message-received', ({ sender, message }) => this._onReceive(sender, message))
     }
 
-    onNewConnection(peer) {
+    sendNodeList(receiverNode, nodeList) {
+        this.connection.send(receiverNode, encoder.peersMessage(nodeList))
+    }
+
+    sendStreamInfo(receiverNode, streamId, nodeAddress) {
+        this.connection.send(receiverNode, encoder.streamMessage(streamId, nodeAddress))
+    }
+
+    _onNewConnection(peer) {
         if (!isTracker(peer)) {
             this.emit(events.NODE_CONNECTED, peer)
         }
     }
 
-    onReceive(peer, message) {
+    _onReceive(peer, message) {
         const { code, data } = encoder.decode(message)
 
         switch (code) {


### PR DESCRIPTION
Changed code so that sending messages from Logic layer happens via interfaces provided by Protocol layer instead of Connection layer directly.

#30 