### PR TITLE
Create connection asynchronously

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,14 +1,10 @@
-const Connection = require('./src/connection/Connection')
+const { createConnection } = require('./src/connection/Connection')
 const Node = require('./src/logic/Node')
 
 const port = process.argv[2] || 30301
-// const ms = require('ms')
 
-const connection = new Connection('127.0.0.1', port, '', true)
-const node = new Node(connection)
-
-// setInterval(() => {
-//     const nodesConnected = peer.getNodes().length
-
-//     console.log(`Total nodes connected: ${nodesConnected}`)
-// }, ms('10s'))
+createConnection('127.0.0.1', port, '', true).then((connection) => {
+    return new Node(connection)
+}).catch((err) => {
+    throw err
+})

--- a/publisher-libp2p.js
+++ b/publisher-libp2p.js
@@ -1,22 +1,20 @@
 const ms = require('ms')
-const Connection = require('./src/connection/Connection')
+const { createConnection } = require('./src/connection/Connection')
 const Publisher = require('./src/logic/Publisher')
 
 const port = process.argv[2] || 30301
 const nodeAddress = process.argv[3] || ''
 const streamId = process.argv[4] || ''
 
-const connection = new Connection('127.0.0.1', port, '', true)
-connection.once('node:ready', () => {
+createConnection('127.0.0.1', port, '', true).then((connection) => {
     connection.connect(nodeAddress)
 
     const publisher = new Publisher(connection)
 
     setInterval(() => {
         const msg = `Hello world, ${new Date().toLocaleString()}`
-
-        if (publisher.connection.isReady()) {
-            publisher.publishLibP2P(streamId, Buffer.from(msg), () => {})
-        }
+        publisher.publishLibP2P(streamId, Buffer.from(msg), () => {})
     }, ms('1s'))
+}).catch((err) => {
+    throw err
 })

--- a/publisher.js
+++ b/publisher.js
@@ -1,22 +1,20 @@
 const ms = require('ms')
-const Connection = require('./src/connection/Connection')
+const { createConnection } = require('./src/connection/Connection')
 const Publisher = require('./src/logic/Publisher')
 
 const port = process.argv[2] || 30301
 const nodeAddress = process.argv[3] || ''
 const streamId = process.argv[4] || ''
 
-const connection = new Connection('127.0.0.1', port, '', true)
-connection.once('node:ready', () => {
+createConnection('127.0.0.1', port, '', true).then((connection) => {
     connection.connect(nodeAddress)
 
     const publisher = new Publisher(connection, nodeAddress)
 
     setInterval(() => {
         const msg = 'Hello world, ' + new Date().toLocaleString()
-
-        if (publisher.connection.isReady()) {
-            publisher.publish(streamId, msg, () => {})
-        }
+        publisher.publish(streamId, msg, () => {})
     }, ms('1s'))
+}).catch((err) => {
+    throw err
 })

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -24,9 +24,7 @@ module.exports = class Node extends EventEmitter {
         this.protocols.trackerNode.on('streamr:node-node:stream-data', ({ streamId, data }) => this.onDataReceived(streamId, data))
         this.protocols.trackerNode.on('streamr:node-node:connect', (nodes) => this.protocols.nodeToNode.connectToNodes(nodes))
         this.protocols.trackerNode.on('streamr:node:found-stream', ({ streamId, nodeAddress }) => this.addKnownStreams(streamId, nodeAddress))
-    }
 
-    onNodeReady() {
         debug('node: %s is running', this.nodeId)
         debug('handling streams: %s\n\n\n', JSON.stringify(this.status.streams))
         this.status.started = new Date().toLocaleString()

--- a/src/logic/Publisher.js
+++ b/src/logic/Publisher.js
@@ -13,10 +13,6 @@ module.exports = class Publisher extends EventEmitter {
             nodeToNode: new NodeToNode(connection)
         }
 
-        connection.once('node:ready', () => this._onNodeReady())
-    }
-
-    _onNodeReady() {
         debug('node: %s is running\n\n\n', this.publisherId)
     }
 

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -14,7 +14,6 @@ module.exports = class Tracker extends EventEmitter {
             trackerServer: new TrackerServer(connection)
         }
 
-        connection.once('node:ready', () => this.trackerReady())
         this.protocols.trackerServer.on('streamr:tracker:find-stream', ({ sender, streamId }) => { // TODO: rename sender to requester/node
             this.sendStreamInfo(sender, streamId)
         })
@@ -22,9 +21,7 @@ module.exports = class Tracker extends EventEmitter {
         this.protocols.trackerServer.on('streamr:tracker:peer-status', ({ peer, status }) => { // TODO: rename peer to node
             this.processNodeStatus(peer, status)
         })
-    }
 
-    trackerReady() {
         debug('tracker: %s is running', this.trackerId)
     }
 

--- a/tracker.js
+++ b/tracker.js
@@ -1,15 +1,11 @@
-const Connection = require('./src/connection/Connection')
+const { createConnection } = require('./src/connection/Connection')
 const Tracker = require('./src/logic/Tracker')
 // const ms = require('ms')
 
 const PRIVATE_KEY = 'CAASpgkwggSiAgEAAoIBAQC2SKo/HMFZeBml1AF3XijzrxrfQXdJzjePBZAbdxqKR1Mc6juRHXij6HXYPjlAk01BhF1S3Ll4Lwi0cAHhggf457sMg55UWyeGKeUv0ucgvCpBwlR5cQ020i0MgzjPWOLWq1rtvSbNcAi2ZEVn6+Q2EcHo3wUvWRtLeKz+DZSZfw2PEDC+DGPJPl7f8g7zl56YymmmzH9liZLNrzg/qidokUv5u1pdGrcpLuPNeTODk0cqKB+OUbuKj9GShYECCEjaybJDl9276oalL9ghBtSeEv20kugatTvYy590wFlJkkvyl+nPxIH0EEYMKK9XRWlu9XYnoSfboiwcv8M3SlsjAgMBAAECggEAZtju/bcKvKFPz0mkHiaJcpycy9STKphorpCT83srBVQi59CdFU6Mj+aL/xt0kCPMVigJw8P3/YCEJ9J+rS8BsoWE+xWUEsJvtXoT7vzPHaAtM3ci1HZd302Mz1+GgS8Epdx+7F5p80XAFLDUnELzOzKftvWGZmWfSeDnslwVONkL/1VAzwKy7Ce6hk4SxRE7l2NE2OklSHOzCGU1f78ZzVYKSnS5Ag9YrGjOAmTOXDbKNKN/qIorAQ1bovzGoCwx3iGIatQKFOxyVCyO1PsJYT7JO+kZbhBWRRE+L7l+ppPER9bdLFxs1t5CrKc078h+wuUr05S1P1JjXk68pk3+kQKBgQDeK8AR11373Mzib6uzpjGzgNRMzdYNuExWjxyxAzz53NAR7zrPHvXvfIqjDScLJ4NcRO2TddhXAfZoOPVH5k4PJHKLBPKuXZpWlookCAyENY7+Pd55S8r+a+MusrMagYNljb5WbVTgN8cgdpim9lbbIFlpN6SZaVjLQL3J8TWH6wKBgQDSChzItkqWX11CNstJ9zJyUE20I7LrpyBJNgG1gtvz3ZMUQCn3PxxHtQzN9n1P0mSSYs+jBKPuoSyYLt1wwe10/lpgL4rkKWU3/m1Myt0tveJ9WcqHh6tzcAbb/fXpUFT/o4SWDimWkPkuCb+8j//2yiXk0a/T2f36zKMuZvujqQKBgC6B7BAQDG2H2B/ijofp12ejJU36nL98gAZyqOfpLJ+FeMz4TlBDQ+phIMhnHXA5UkdDapQ+zA3SrFk+6yGk9Vw4Hf46B+82SvOrSbmnMa+PYqKYIvUzR4gg34rL/7AhwnbEyD5hXq4dHwMNsIDq+l2elPjwm/U9V0gdAl2+r50HAoGALtsKqMvhv8HucAMBPrLikhXP/8um8mMKFMrzfqZ+otxfHzlhI0L08Bo3jQrb0Z7ByNY6M8epOmbCKADsbWcVre/AAY0ZkuSZK/CaOXNX/AhMKmKJh8qAOPRY02LIJRBCpfS4czEdnfUhYV/TYiFNnKRj57PPYZdTzUsxa/yVTmECgYBr7slQEjb5Onn5mZnGDh+72BxLNdgwBkhO0OCdpdISqk0F0Pxby22DFOKXZEpiyI9XYP1C8wPiJsShGm2yEwBPWXnrrZNWczaVuCbXHrZkWQogBDG3HGXNdU4MAWCyiYlyinIBpPpoAJZSzpGLmWbMWh28+RJS6AQX6KHrK1o2uw=='
 
-const connection = new Connection('127.0.0.1', 30300, PRIVATE_KEY)
-const tracker = new Tracker(connection)
-
-// setInterval(() => {
-//     const peersCount = tracker.getPeers().length
-
-//     console.log(`Total nodes in tracker: ${peersCount}`)
-//     console.log(tracker.getPeersAndStreams())
-// }, ms('10s'))
+createConnection('127.0.0.1', 30300, PRIVATE_KEY).then((connection) => {
+    return new Tracker(connection)
+}).catch((err) => {
+    throw err
+})


### PR DESCRIPTION
Addresses issue #9.

Now connection is created async so that user can `await` or `.then()` for the connection to be ready. No need for `READY` event or isReady boolean anymore.