### PR TITLE
Export static events

### DIFF
--- a/src/connection/Connection.js
+++ b/src/connection/Connection.js
@@ -144,6 +144,7 @@ async function startLibp2pNode(host, port, privateKey, isNode) {
 }
 
 module.exports = {
+    events,
     async createConnection(host, port, privateKey, isNode = false) {
         return startLibp2pNode(host, port, privateKey, isNode).then((n) => new Connection(n))
     }

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -20,10 +20,12 @@ module.exports = class Node extends EventEmitter {
         }
 
         connection.once('node:ready', () => this.onNodeReady())
-        this.protocols.trackerNode.on('streamr:peer:send-status', (tracker) => this.onConnectedToTracker(tracker))
-        this.protocols.trackerNode.on('streamr:node-node:stream-data', ({ streamId, data }) => this.onDataReceived(streamId, data))
-        this.protocols.trackerNode.on('streamr:node-node:connect', (nodes) => this.protocols.nodeToNode.connectToNodes(nodes))
-        this.protocols.trackerNode.on('streamr:node:found-stream', ({ streamId, nodeAddress }) => this.addKnownStreams(streamId, nodeAddress))
+        this.protocols.trackerNode.on(TrackerNode.events.CONNECTED_TO_TRACKER, (tracker) => this.onConnectedToTracker(tracker))
+        this.protocols.trackerNode.on(TrackerNode.events.DATA_RECEIVED, ({ streamId, data }) => this.onDataReceived(streamId, data))
+        this.protocols.trackerNode.on(TrackerNode.events.NODE_LIST_RECEIVED, (nodes) => this.protocols.nodeToNode.connectToNodes(nodes))
+        this.protocols.trackerNode.on(TrackerNode.events.STREAM_INFO_RECEIVED, ({ streamId, nodeAddress }) => {
+            this.addKnownStreams(streamId, nodeAddress)
+        })
 
         debug('node: %s is running', this.nodeId)
         debug('handling streams: %s\n\n\n', JSON.stringify(this.status.streams))

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -14,11 +14,11 @@ module.exports = class Tracker extends EventEmitter {
             trackerServer: new TrackerServer(connection)
         }
 
-        this.protocols.trackerServer.on('streamr:tracker:find-stream', ({ sender, streamId }) => { // TODO: rename sender to requester/node
+        this.protocols.trackerServer.on(TrackerServer.events.STREAM_INFO_REQUESTED, ({ sender, streamId }) => { // TODO: rename sender to requester/node
             this.sendStreamInfo(sender, streamId)
         })
-        this.protocols.trackerServer.on('streamr:tracker:send-peers', (node) => this.sendListOfNodes(node))
-        this.protocols.trackerServer.on('streamr:tracker:peer-status', ({ peer, status }) => { // TODO: rename peer to node
+        this.protocols.trackerServer.on(TrackerServer.events.NODE_LIST_REQUESTED, (node) => this.sendListOfNodes(node))
+        this.protocols.trackerServer.on(TrackerServer.events.NODE_STATUS_RECEIVED, ({ peer, status }) => { // TODO: rename peer to node
             this.processNodeStatus(peer, status)
         })
 

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -10,7 +10,7 @@ const events = Object.freeze({
     STREAM_INFO_RECEIVED: 'streamr:node:found-stream'
 })
 
-module.exports = class TrackerNode extends EventEmitter {
+class TrackerNode extends EventEmitter {
     constructor(connection) {
         super()
 
@@ -74,3 +74,7 @@ module.exports = class TrackerNode extends EventEmitter {
         }
     }
 }
+
+TrackerNode.events = events
+
+module.exports = TrackerNode

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -1,5 +1,6 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('streamr:tracker-node')
+const connectionEvents = require('../connection/Connection').events
 const { isTracker, getAddress } = require('../util')
 const encoder = require('../helpers/MessageEncoder')
 
@@ -16,8 +17,8 @@ class TrackerNode extends EventEmitter {
 
         this.connection = connection
 
-        this.connection.on('streamr:peer:discovery', (tracker) => this._onConnectToTracker(tracker))
-        this.connection.on('streamr:message-received', ({ sender, message }) => this._onReceive(sender, message))
+        this.connection.on(connectionEvents.MESSAGE_RECEIVED, ({ sender, message }) => this._onReceive(sender, message))
+        this.connection.on(connectionEvents.PEER_DISCOVERED, (tracker) => this._onConnectToTracker(tracker))
     }
 
     sendStatus(tracker, status) {

--- a/src/protocol/TrackerServer.js
+++ b/src/protocol/TrackerServer.js
@@ -1,5 +1,6 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('streamr:tracker-server')
+const connectionEvents = require('../connection/Connection').events
 const { isTracker } = require('../util')
 const encoder = require('../helpers/MessageEncoder')
 
@@ -16,8 +17,8 @@ class TrackerServer extends EventEmitter {
 
         this.connection = connection
 
-        this.connection.on('streamr:peer:connect', (peer) => this._onNewConnection(peer))
-        this.connection.on('streamr:message-received', ({ sender, message }) => this._onReceive(sender, message))
+        this.connection.on(connectionEvents.PEER_CONNECTED, (peer) => this._onNewConnection(peer))
+        this.connection.on(connectionEvents.MESSAGE_RECEIVED, ({ sender, message }) => this._onReceive(sender, message))
     }
 
     sendNodeList(receiverNode, nodeList) {

--- a/src/protocol/TrackerServer.js
+++ b/src/protocol/TrackerServer.js
@@ -10,7 +10,7 @@ const events = Object.freeze({
     NODE_LIST_REQUESTED: 'streamr:tracker:send-peers'
 })
 
-module.exports = class TrackerServer extends EventEmitter {
+class TrackerServer extends EventEmitter {
     constructor(connection) {
         super()
 
@@ -61,3 +61,7 @@ module.exports = class TrackerServer extends EventEmitter {
         }
     }
 }
+
+TrackerServer.events = events
+
+module.exports = TrackerServer


### PR DESCRIPTION
fixes #36 

- Exported event constants from protocol layer and connection layer so that higher levels can use them. 
- Refer to events in higher levels by their constant instead of string name.

## TODO
- Integrate with #38 
