### PR TITLE
Convenience wrapper for broker

### DIFF
--- a/NetworkNode.js
+++ b/NetworkNode.js
@@ -1,0 +1,46 @@
+const { EventEmitter } = require('events')
+const { createConnection } = require('./src/connection/Connection')
+const Node = require('./src/logic/Node')
+
+/*
+Convenience wrapper for broker/data-api. We can replace this with something else later.
+ */
+class NetworkNode extends EventEmitter {
+    constructor(node) {
+        super()
+        this.node = node
+    }
+
+    publish(streamId, streamPartition, content) {
+        if (streamPartition !== 0) {
+            throw new Error('Stream partitions not yet supported.')
+        }
+        this.node.onDataReceived(streamId, content)
+    }
+
+    subscribe(streamId, streamPartition) {
+        if (streamPartition !== 0) {
+            throw new Error('Stream partitions not yet supported.')
+        }
+        this.subscribed = true
+        // TODO: Do we even need?
+    }
+
+    unsubscribe(streamId, streamPartition) {
+        if (streamPartition !== 0) {
+            throw new Error('Stream partitions not yet supported.')
+        }
+        this.unsubscribed = true
+        // TODO: Do we even need?
+    }
+
+    addMessageListener(cb) {
+        this.node.on(Node.events.MESSAGE_RECEIVED, (streamId, content) => cb(streamId, 0, content))
+    }
+}
+
+module.exports = async (host, port, key = '') => {
+    const connection = await createConnection(host, port, key, true)
+    const node = new Node(connection)
+    return new NetworkNode(node)
+}

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -4,7 +4,11 @@ const TrackerNode = require('../protocol/TrackerNode')
 const NodeToNode = require('../protocol/NodeToNode')
 const { generateClientId, getStreams } = require('../util')
 
-module.exports = class Node extends EventEmitter {
+const events = Object.freeze({
+    MESSAGE_RECEIVED: 'streamr:node:message-received',
+})
+
+class Node extends EventEmitter {
     constructor(connection) {
         super()
 
@@ -57,6 +61,7 @@ module.exports = class Node extends EventEmitter {
     onDataReceived(streamId, data) {
         if (this._isOwnStream(streamId)) {
             debug('received data for own streamId %s', streamId)
+            this.emit(events.DATA_RECEIVED, streamId, data)
         } else if (this._isKnownStream(streamId)) {
             const receiverNode = this.knownStreams.get(streamId)
             this.protocols.nodeToNode.sendData(receiverNode, streamId, data)
@@ -74,3 +79,7 @@ module.exports = class Node extends EventEmitter {
         return this.knownStreams.get(streamId) !== undefined
     }
 }
+
+Node.events = events
+
+module.exports = Node


### PR DESCRIPTION
- logic/Node.js emits `MESSAGE_RECEIVED` when it receives a message for a stream it is responsible for.
- Made a quick wrapper/glue piece for broker.