### PR TITLE
speed up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
   - "/^v\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/"
 before_install:
 - npm i -g npm@6.4.1
+cache:
+  directories:
+  - node_modules
 jobs:
   include:
   - stage: eslint


### PR DESCRIPTION
Make Travis CI faster by caching `node_modules`. This avoids having to `npm install` from scratch on every run.