### PR TITLE
Improve debugging

### DIFF
--- a/src/connection/Connection.js
+++ b/src/connection/Connection.js
@@ -24,16 +24,22 @@ class Connection extends EventEmitter {
         node.peerInfo.multiaddrs.forEach((ma) => debug('listening on: %s', ma.toString()))
 
         node.handle(HANDLER, (protocol, conn) => this.onReceive(protocol, conn))
-        node.on('peer:discovery', (peer) => this.emit(events.PEER_DISCOVERED, peer))
+        node.on('peer:discovery', (peer) => {
+            debug('peer %s discovered', getAddress(peer))
+            this.emit(events.PEER_DISCOVERED, peer)
+        })
         node.on('peer:connect', (peer) => {
-            debug('new connection')
+            debug('peer %s connected', getAddress(peer))
             this.emit(events.PEER_CONNECTED, peer)
         })
-        node.on('peer:disconnect', (peer) => this.emit(events.PEER_DISCONNECTED, peer))
+        node.on('peer:disconnect', (peer) => {
+            debug('peer %s disconnected', getAddress(peer))
+            this.emit(events.PEER_DISCONNECTED, peer)
+        })
     }
 
     send(recipient, message) {
-        debug('sending to the %s, message with data "%s"', recipient instanceof PeerInfo ? getAddress(recipient) : '', message)
+        debug('sending to peer %s message with data "%s"', recipient instanceof PeerInfo ? getAddress(recipient) : '', message)
         this.node.dialProtocol(recipient, HANDLER, (err, conn) => {
             if (err) {
                 throw err
@@ -56,7 +62,7 @@ class Connection extends EventEmitter {
                 conn,
                 pull.map((message) => message.toString('utf8')),
                 pull.drain((message) => {
-                    debug('received from %s, message with data "%s"', sender instanceof PeerInfo ? getAddress(sender) : '', message)
+                    debug('received from peer %s message with data "%s"', sender instanceof PeerInfo ? getAddress(sender) : '', message)
 
                     this.emit(events.MESSAGE_RECEIVED, {
                         sender,

--- a/src/connection/Libp2pBundle.js
+++ b/src/connection/Libp2pBundle.js
@@ -43,6 +43,7 @@ module.exports = class Libp2pBundle extends libp2p {
 
         super(defaultsDeep(params, defaults))
 
-        debug('libp2p bundle created')
+        debug('libp2p bundle created with %s', enablePeerDiscovery ? `boostrap nodes ${bootstrapNodes}`
+            : 'no peer discovery')
     }
 }

--- a/src/logic/Publisher.js
+++ b/src/logic/Publisher.js
@@ -1,24 +1,24 @@
 const { EventEmitter } = require('events')
-const debug = require('debug')('streamr:logic:publisher')
-const NodeToNode = require('../protocol/NodeToNode')
-const { generateClientId } = require('../util')
+const createDebug = require('debug')
+const { getIdShort } = require('../util')
 
 module.exports = class Publisher extends EventEmitter {
     constructor(nodeToNode, nodeAddress) {
         super()
 
-        this.id = generateClientId('publisher')
+        this.id = getIdShort(nodeToNode.connection.node.peerInfo) // TODO: better way?
         this.nodeAddress = nodeAddress
         this.protocols = {
             nodeToNode
         }
 
-        debug('node: %s is running\n\n\n', this.id)
+        this.debug = createDebug(`streamr:logic:publisher:${this.id}`)
+        this.debug('node: %s is running', this.id)
     }
 
     publish(streamId, data) {
         if (this.nodeAddress) {
-            debug('publishing data', streamId, data)
+            this.debug('publishing data to stream  %s', streamId)
             this.protocols.nodeToNode.sendData(this.nodeAddress, streamId, data)
         } else {
             throw new Error('Failed to publish because this.nodeAddress not defined.')

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -1,6 +1,6 @@
 const { EventEmitter } = require('events')
-const debug = require('debug')('streamr:logic:tracker')
-const { generateClientId, getAddress } = require('../util')
+const createDebug = require('debug')
+const { getAddress, getIdShort } = require('../util')
 const TrackerServer = require('../protocol/TrackerServer')
 const { getPeersTopology } = require('../helpers/TopologyStrategy')
 
@@ -9,7 +9,7 @@ module.exports = class Tracker extends EventEmitter {
         super()
 
         this.nodes = new Map()
-        this.id = generateClientId('tracker')
+        this.id = getIdShort(trackerServer.connection.node.peerInfo) // TODO: Better way?
         this.protocols = {
             trackerServer
         }
@@ -22,27 +22,28 @@ module.exports = class Tracker extends EventEmitter {
             this.processNodeStatus(peer, status)
         })
 
-        debug('tracker: %s is running\n\n\n', this.id)
+        this.debug = createDebug(`streamr:logic:tracker:${this.id}`)
+        this.debug('started %s', this.id)
     }
 
     sendListOfNodes(node) {
         const listOfNodes = getPeersTopology([...this.nodes.keys()], getAddress(node))
 
         if (listOfNodes.length) {
-            debug('sending list of nodes')
+            this.debug('sending list of %d nodes to %s', listOfNodes.length, getIdShort(node))
             this.protocols.trackerServer.sendNodeList(node, listOfNodes)
         } else {
-            debug('no available nodes to send')
+            this.debug('no available nodes to send to %s', getIdShort(node))
         }
     }
 
     processNodeStatus(node, status) {
-        debug('received from %s status %s', getAddress(node), JSON.stringify(status))
+        this.debug('received from %s status %s', getIdShort(node), JSON.stringify(status))
         this.nodes.set(getAddress(node), status)
     }
 
     sendStreamInfo(node, streamId) {
-        debug('tracker looking for the stream %s', streamId)
+        this.debug('looking for stream %s', streamId)
 
         let nodeAddress
         this.nodes.forEach((status, knownNodeAddress) => {
@@ -52,14 +53,17 @@ module.exports = class Tracker extends EventEmitter {
         })
 
         if (nodeAddress === undefined) {
-            debug('author of request will be responsible for the streamId')
+            this.debug('stream %s assigned to %s', streamId, getIdShort(node))
             nodeAddress = getAddress(node)
+        } else {
+            this.debug('stream %s found, responding to %s', streamId, getIdShort(node))
         }
 
         this.protocols.trackerServer.sendStreamInfo(node, streamId, nodeAddress)
     }
 
     stop(cb) {
+        this.debug('stopping')
         this.protocols.trackerServer.stop(cb)
     }
 

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -39,7 +39,7 @@ class TrackerNode extends EventEmitter {
                 this.emit(events.CONNECTED_TO_TRACKER, tracker)
             }).catch((err) => {
                 if (err) {
-                    debug('cannot connect to the tracker, probably not started')
+                    debug('cannot connect to the tracker: ' + err)
                 }
             })
         }

--- a/src/util.js
+++ b/src/util.js
@@ -19,13 +19,24 @@ const getAddress = (peerInfo) => {
     throw new Error('Expected instance of PeerInfo, got ' + peerInfo)
 }
 
-const generateClientId = (suffix) => `streamr-${suffix}/v${version}/${os.platform()}-${os.arch()}/nodejs`
+const getId = (peerInfo) => {
+    if (peerInfo instanceof PeerInfo) {
+        return peerInfo.id.toB58String()
+    }
+    throw new Error('Expected instance of PeerInfo, got ' + peerInfo)
+}
+
+const getIdShort = (peerInfo) => getId(peerInfo).slice(-4)
+
+const generateClientId = (suffix) => `${suffix}/v${version}/${os.platform()}-${os.arch()}/nodejs`
 
 const isTracker = (tracker) => BOOTNODES.includes(tracker)
 
 module.exports = {
     callbackToPromise,
     getAddress,
+    getId,
+    getIdShort,
     generateClientId,
     isTracker,
     BOOTNODES


### PR DESCRIPTION
I required some more detailed debugging to understand why my integration test is not working.

Some Changes
- Slightly re-worded some debug messages and added in values of variables
- Logic layer debug messages: added identity of peer to debug messages, so we see who is reporting. This is important for tests that are running multiple nodes for example. 
- Use the 4 last characters of PeerInfo id for peer identity.

Example of how logic layer logging looks like now:
```
  streamr:logic:tracker:5AuC started 5AuC +0ms
  streamr:logic:node:joEY started joEY +0ms
  streamr:logic:node:8V2S started 8V2S +0ms
  streamr:logic:node:46N4 started 46N4 +0ms
  streamr:logic:node:WjkE started WjkE +0ms
  streamr:logic:node:joEY connected to tracker 5AuC +5s
  streamr:logic:node:joEY sending status to tracker 5AuC +0ms
  streamr:logic:node:joEY requesting more peers from tracker 5AuC +0ms
  streamr:logic:node:8V2S connected to tracker 5AuC +5s
  streamr:logic:node:8V2S sending status to tracker 5AuC +0ms
  streamr:logic:node:8V2S requesting more peers from tracker 5AuC +0ms
  streamr:logic:node:46N4 connected to tracker 5AuC +5s
  streamr:logic:node:46N4 sending status to tracker 5AuC +0ms
  streamr:logic:node:46N4 requesting more peers from tracker 5AuC +0ms
  streamr:logic:node:WjkE connected to tracker 5AuC +5s
  streamr:logic:node:WjkE sending status to tracker 5AuC +0ms
  streamr:logic:node:WjkE requesting more peers from tracker 5AuC +0ms
  streamr:logic:tracker:5AuC no available nodes to send to joEY +12s
  streamr:logic:tracker:5AuC no available nodes to send to 8V2S +4ms
  streamr:logic:tracker:5AuC no available nodes to send to 46N4 +1ms
  streamr:logic:tracker:5AuC no available nodes to send to WjkE +0ms
  streamr:logic:tracker:5AuC received from joEY status {"streams":[],"started":"2018-9-19 11:10:41"} +69ms
  streamr:logic:tracker:5AuC received from 8V2S status {"streams":[],"started":"2018-9-19 11:10:41"} +3ms
  streamr:logic:tracker:5AuC received from 46N4 status {"streams":[],"started":"2018-9-19 11:10:41"} +1ms
  streamr:logic:tracker:5AuC received from WjkE status {"streams":[],"started":"2018-9-19 11:10:41"} +0ms
  streamr:logic:tracker:5AuC sending list of 3 nodes to joEY +15ms
  streamr:logic:tracker:5AuC sending list of 3 nodes to 8V2S +2ms
  streamr:logic:tracker:5AuC sending list of 3 nodes to 46N4 +0ms
  streamr:logic:tracker:5AuC sending list of 3 nodes to WjkE +0ms
  streamr:logic:node:joEY ask tracker 5AuC who is responsible for stream stream-1 +219ms
  streamr:logic:node:WjkE ask tracker 5AuC who is responsible for stream stream-2 +213ms
  streamr:logic:node:joEY ask tracker 5AuC who is responsible for stream stream-1 +1ms
  streamr:logic:node:WjkE ask tracker 5AuC who is responsible for stream stream-2 +1ms
  streamr:logic:node:joEY ask tracker 5AuC who is responsible for stream stream-1 +0ms
  streamr:logic:node:WjkE ask tracker 5AuC who is responsible for stream stream-2 +0ms
  streamr:logic:node:joEY ask tracker 5AuC who is responsible for stream stream-1 +0ms
  streamr:logic:node:WjkE ask tracker 5AuC who is responsible for stream stream-2 +0ms
  streamr:logic:node:joEY ask tracker 5AuC who is responsible for stream stream-1 +1ms
  streamr:logic:node:WjkE ask tracker 5AuC who is responsible for stream stream-2 +1ms
  streamr:logic:tracker:5AuC looking for stream stream-1 +529ms
  streamr:logic:tracker:5AuC stream stream-1 assigned to joEY +0ms
  streamr:logic:tracker:5AuC looking for stream stream-2 +0ms
  streamr:logic:tracker:5AuC stream stream-2 assigned to WjkE +0ms
  streamr:logic:tracker:5AuC looking for stream stream-1 +10ms
  streamr:logic:tracker:5AuC stream stream-1 assigned to joEY +0ms
  streamr:logic:tracker:5AuC looking for stream stream-2 +0ms
  streamr:logic:tracker:5AuC stream stream-2 assigned to WjkE +0ms
  streamr:logic:tracker:5AuC looking for stream stream-1 +11ms
  streamr:logic:tracker:5AuC stream stream-1 assigned to joEY +0ms
  streamr:logic:tracker:5AuC looking for stream stream-2 +0ms
  streamr:logic:tracker:5AuC stream stream-2 assigned to WjkE +0ms
  streamr:logic:tracker:5AuC looking for stream stream-1 +15ms
  streamr:logic:tracker:5AuC stream stream-1 assigned to joEY +0ms
  streamr:logic:tracker:5AuC looking for stream stream-2 +0ms
  streamr:logic:tracker:5AuC stream stream-2 assigned to WjkE +1ms
  streamr:logic:tracker:5AuC looking for stream stream-1 +10ms
  streamr:logic:tracker:5AuC stream stream-1 assigned to joEY +0ms
  streamr:logic:tracker:5AuC looking for stream stream-2 +0ms
  streamr:logic:tracker:5AuC stream stream-2 assigned to WjkE +0ms
  streamr:logic:node:joEY stream stream-1 added to own streams +565ms
  streamr:logic:node:joEY sending status to tracker 5AuC +0ms
  streamr:logic:node:WjkE stream stream-2 added to own streams +566ms
  streamr:logic:node:WjkE sending status to tracker 5AuC +0ms
  streamr:logic:node:joEY stream stream-1 added to own streams +10ms
  streamr:logic:node:joEY sending status to tracker 5AuC +0ms
  streamr:logic:node:WjkE stream stream-2 added to own streams +9ms
  streamr:logic:node:WjkE sending status to tracker 5AuC +0ms
  streamr:logic:node:joEY stream stream-1 added to own streams +10ms
  streamr:logic:node:joEY sending status to tracker 5AuC +0ms
  streamr:logic:node:WjkE stream stream-2 added to own streams +10ms
  streamr:logic:node:WjkE sending status to tracker 5AuC +0ms
  streamr:logic:node:joEY stream stream-1 added to own streams +7ms
  streamr:logic:node:joEY sending status to tracker 5AuC +0ms
  streamr:logic:node:WjkE stream stream-2 added to own streams +7ms
  streamr:logic:node:WjkE sending status to tracker 5AuC +0ms
  streamr:logic:node:joEY stream stream-1 added to own streams +16ms
  streamr:logic:node:joEY sending status to tracker 5AuC +0ms
  streamr:logic:node:WjkE stream stream-2 added to own streams +16ms
  streamr:logic:node:WjkE sending status to tracker 5AuC +0ms
  streamr:logic:tracker:5AuC received from joEY status {"streams":["stream-1"],"started":"2018-9-19 11:10:41"} +211ms
  streamr:logic:tracker:5AuC received from WjkE status {"streams":["stream-2"],"started":"2018-9-19 11:10:41"} +0ms
  streamr:logic:tracker:5AuC received from joEY status {"streams":["stream-1"],"started":"2018-9-19 11:10:41"} +8ms
  streamr:logic:tracker:5AuC received from WjkE status {"streams":["stream-2"],"started":"2018-9-19 11:10:41"} +0ms
  streamr:logic:tracker:5AuC received from joEY status {"streams":["stream-1"],"started":"2018-9-19 11:10:41"} +12ms
  streamr:logic:tracker:5AuC received from WjkE status {"streams":["stream-2"],"started":"2018-9-19 11:10:41"} +0ms
  streamr:logic:tracker:5AuC received from joEY status {"streams":["stream-1"],"started":"2018-9-19 11:10:41"} +8ms
  streamr:logic:tracker:5AuC received from WjkE status {"streams":["stream-2"],"started":"2018-9-19 11:10:41"} +0ms
  streamr:logic:tracker:5AuC received from joEY status {"streams":["stream-1"],"started":"2018-9-19 11:10:41"} +9ms
  streamr:logic:tracker:5AuC received from WjkE status {"streams":["stream-2"],"started":"2018-9-19 11:10:41"} +1ms
  streamr:logic:tracker:5AuC stopping +215ms
```