### PR TITLE
Streamline protocol layer classes, issue #67

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = exports = {
             numbers: true
         }],
         'semi': [ERROR, 'never'],
-        'max-len': DISABLED,
+        'max-len': WARN,
         'class-methods-use-this': DISABLED,
         'no-empty-function': WARN,
     }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,5 +56,8 @@ module.exports = exports = {
             numbers: true
         }],
         'semi': [ERROR, 'never'],
+        'max-len': DISABLED,
+        'class-methods-use-this': DISABLED,
+        'no-empty-function': WARN,
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ typings/
 .idea/httpRequests
 
 .vscode
+
+.DS_Store

--- a/src/protocol/EndpointListener.js
+++ b/src/protocol/EndpointListener.js
@@ -1,0 +1,19 @@
+const endpointEvents = require('../connection/Libp2pEndpoint').events
+
+module.exports = class EndpointListener {
+    implement(implementor, endpoint) {
+        if (typeof implementor.onPeerConnected !== 'function') {
+            throw new Error('onPeerConnected() method not found in class implementing EndpointListener')
+        }
+        if (typeof implementor.onMessageReceived !== 'function') {
+            throw new Error('onMessageReceived() method not found in class implementing EndpointListener')
+        }
+        if (typeof implementor.onPeerDiscovered !== 'function') {
+            throw new Error('onPeerDiscovered() method not found in class implementing EndpointListener')
+        }
+
+        endpoint.on(endpointEvents.PEER_CONNECTED, (peer) => implementor.onPeerConnected(peer))
+        endpoint.on(endpointEvents.MESSAGE_RECEIVED, ({ sender, message }) => implementor.onMessageReceived(sender, message))
+        endpoint.on(endpointEvents.PEER_DISCOVERED, (peer) => implementor.onPeerDiscovered(peer))
+    }
+}

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -2,11 +2,15 @@ const { EventEmitter } = require('events')
 const debug = require('debug')('streamr:protocol:node-node')
 const encoder = require('../helpers/MessageEncoder')
 const { getAddress } = require('../util')
+const EndpointListener = require('./EndpointListener')
 
 module.exports = class NodeToNode extends EventEmitter {
     constructor(endpoint) {
         super()
         this.endpoint = endpoint
+
+        this._endpointListener = new EndpointListener()
+        this._endpointListener.implement(this, endpoint)
     }
 
     connectToNodes(nodes) {
@@ -26,5 +30,16 @@ module.exports = class NodeToNode extends EventEmitter {
 
     stop(cb) {
         this.endpoint.node.stop(() => cb())
+    }
+
+    // EndpointListener implementation
+
+    onPeerConnected(peer) {
+    }
+
+    onMessageReceived(sender, message) {
+    }
+
+    async onPeerDiscovered(peer) {
     }
 }


### PR DESCRIPTION
Implemented EndpointListener interface as a Javascript class, and made all protocol classes to implement this interface. This removes duplicated code (importing and binding Endpoint events) from the protocol classes, and makes sure that the protocol classes listen to all the events coming from the lower layer.

The "implement(implementor, endpoint)" method of EndpointListener class checks whether the implementor has actually implemented the interface's methods and throws an exception otherwise. If the methods exist as claimed, it binds the corresponding endpoint events to the methods.

Jslint config was slightly modified to only give a warning when empty placeholder methods are encountered. I also removed the warning about exceeding the line length, which happens in almost all the files in the project. 