### PR TITLE
logic/Node: buffer messages with unknown streamId

### DIFF
--- a/src/helpers/MessageBuffer.js
+++ b/src/helpers/MessageBuffer.js
@@ -1,0 +1,40 @@
+module.exports = class MessageBuffer {
+    constructor(timeoutInMs, onTimeout = () => {}) {
+        this.buffer = {}
+        this.timeoutRefs = {}
+        this.timeoutInMs = timeoutInMs
+        this.onTimeout = onTimeout
+    }
+
+    put(id, message) {
+        if (!this._hasBufferFor(id)) {
+            this.buffer[id] = []
+            this.timeoutRefs[id] = []
+        }
+        this.buffer[id].push(message)
+        this.timeoutRefs[id].push(setTimeout(() => {
+            this.buffer[id].shift()
+            this.timeoutRefs[id].shift()
+            this.onTimeout(id)
+        }, this.timeoutInMs))
+    }
+
+    popAll(id) {
+        if (this._hasBufferFor(id)) {
+            const messages = this.buffer[id]
+            this.timeoutRefs[id].forEach((ref) => clearTimeout(ref))
+            delete this.timeoutRefs[id]
+            delete this.buffer[id]
+            return messages
+        }
+        return []
+    }
+
+    clear() {
+        Object.keys(this.buffer).forEach((id) => this.popAll(id))
+    }
+
+    _hasBufferFor(id) {
+        return this.buffer[id]
+    }
+}

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -3,9 +3,11 @@ const createDebug = require('debug')
 const TrackerNode = require('../protocol/TrackerNode')
 const NodeToNode = require('../protocol/NodeToNode')
 const { getIdShort } = require('../util')
+const MessageBuffer = require('../helpers/MessageBuffer')
 
 const events = Object.freeze({
     MESSAGE_RECEIVED: 'streamr:node:message-received',
+    MESSAGE_DELIVERY_FAILED: 'streamr:node:message-delivery-failed',
     NO_AVAILABLE_TRACKERS: 'streamr:node:no-trackers',
 })
 
@@ -15,6 +17,10 @@ class Node extends EventEmitter {
 
         this.knownStreams = new Map()
         this.ownStreams = new Set()
+        this.messageBuffer = new MessageBuffer(60 * 1000, (streamId) => {
+            this.debug('failed to deliver buffered messages of stream %s because leader not found', streamId)
+            this.emit(events.MESSAGE_DELIVERY_FAILED, streamId)
+        })
 
         this.id = getIdShort(nodeToNode.endpoint.node.peerInfo) // TODO: better way?
         this.tracker = null
@@ -50,12 +56,14 @@ class Node extends EventEmitter {
         this.debug('stream %s added to own streams', streamId)
         this.ownStreams.add(streamId)
         this._sendStatus(this.tracker)
+        this._handleBufferedMessages(streamId)
     }
 
     // add to cache of streams
     addKnownStreams(streamId, nodeAddress) {
         this.debug('stream %s added to known streams for address %s', streamId, nodeAddress)
         this.knownStreams.set(streamId, nodeAddress)
+        this._handleBufferedMessages(streamId)
     }
 
     onDataReceived(streamId, data) {
@@ -70,6 +78,7 @@ class Node extends EventEmitter {
             this.debug('no trackers available; attempted to ask about stream %s', streamId)
             this.emit(events.NO_AVAILABLE_TRACKERS)
         } else {
+            this.messageBuffer.put(streamId, data)
             this.debug('ask tracker %s who is responsible for stream %s', getIdShort(this.tracker), streamId)
             this.protocols.trackerNode.requestStreamInfo(this.tracker, streamId)
         }
@@ -85,6 +94,7 @@ class Node extends EventEmitter {
 
     stop(cb) {
         this.debug('stopping')
+        this.messageBuffer.clear()
         this.protocols.trackerNode.stop(cb)
         this.protocols.nodeToNode.stop(cb)
     }
@@ -101,6 +111,11 @@ class Node extends EventEmitter {
         if (tracker) {
             this.protocols.trackerNode.sendStatus(tracker, this._getStatus())
         }
+    }
+
+    _handleBufferedMessages(streamId) {
+        this.messageBuffer.popAll(streamId)
+            .forEach((data) => this.onDataReceived(streamId, data))
     }
 }
 

--- a/test/integration/nodeMessageBuffering.test.js
+++ b/test/integration/nodeMessageBuffering.test.js
@@ -1,0 +1,51 @@
+const { startNode, startTracker } = require('../../src/composition')
+const Node = require('../../src/logic/Node')
+const { callbackToPromise } = require('../../src/util')
+const { PRIVATE_KEY } = require('../util')
+
+jest.setTimeout(30 * 1000)
+
+/**
+ * When a node receives a message for a stream it doesn't recognize, it asks the
+ * tracker who is responsible for that stream. In this test we verify that the
+ * initial message that causes this is also eventually delivered.
+ */
+describe('message buffering of Node', () => {
+    let tracker
+    let sourceNode
+    let destinationNode
+
+    beforeAll(async (done) => {
+        tracker = await startTracker('127.0.0.1', 30300, PRIVATE_KEY)
+        sourceNode = await startNode('127.0.0.1', 30321)
+        destinationNode = await startNode('127.0.0.1', 30322)
+
+        // TODO: use p-event to listen to TrackerNode.events.NODE_LIST_RECEIVED when issue #86 merged
+        setTimeout(done, 8000)
+    })
+
+    afterAll(async (done) => {
+        await callbackToPromise(sourceNode.stop.bind(sourceNode))
+        await callbackToPromise(destinationNode.stop.bind(destinationNode))
+        tracker.stop(done)
+    })
+
+    test('first message to unknown stream eventually gets delivered', async (done) => {
+        destinationNode.addOwnStream('stream-id')
+        destinationNode.on(Node.events.MESSAGE_RECEIVED, (streamId, data) => {
+            expect(streamId).toEqual('stream-id')
+            expect(data).toEqual({
+                hello: 'world'
+            })
+            done()
+        })
+
+        // TODO: use p-event to listen to Tracker.events.STATUS_RECEIVED when issue #86 merged
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+
+        // "Client" pushes data
+        sourceNode.onDataReceived('stream-id', {
+            hello: 'world'
+        })
+    })
+})

--- a/test/unit/MessageBuffer.test.js
+++ b/test/unit/MessageBuffer.test.js
@@ -57,9 +57,8 @@ test('timeoutCb(id) is invoked on timeout', (done) => {
 })
 
 test('timeoutCb(id) is not invoked if messages popped before timeout', () => {
-    const buffer = new MessageBuffer(1000, (id) => {
-        fail('should not be invoked')
-    })
+    const timeoutCb = jest.fn()
+    const buffer = new MessageBuffer(1000, timeoutCb)
 
     buffer.put('stream-1', {})
     buffer.put('stream-1', {})
@@ -69,6 +68,7 @@ test('timeoutCb(id) is not invoked if messages popped before timeout', () => {
     buffer.popAll('stream-2')
 
     jest.runAllTimers()
+    expect(timeoutCb).not.toHaveBeenCalled()
 })
 
 test('messages are deleted after timeout', () => {
@@ -83,9 +83,8 @@ test('messages are deleted after timeout', () => {
 })
 
 test('clear() removes all messages and timeout callbacks', () => {
-    const buffer = new MessageBuffer(100, (id) => {
-        fail('should not be invoked')
-    })
+    const timeoutCb = jest.fn()
+    const buffer = new MessageBuffer(100, timeoutCb)
     buffer.put('stream-1', {})
     buffer.put('stream-1', {})
     buffer.put('stream-2', {})
@@ -96,6 +95,7 @@ test('clear() removes all messages and timeout callbacks', () => {
 
     expect(buffer.popAll('stream-1')).toEqual([])
     expect(buffer.popAll('stream-2')).toEqual([])
+    expect(timeoutCb).not.toHaveBeenCalled()
 })
 
 test('clearing and pushing to ids do not affect other ids', () => {

--- a/test/unit/MessageBuffer.test.js
+++ b/test/unit/MessageBuffer.test.js
@@ -1,0 +1,150 @@
+const MessageBuffer = require('../../src/helpers/MessageBuffer')
+
+jest.useFakeTimers()
+
+test('put and popAll work as expected (no timeouts scenario)', () => {
+    const buffer = new MessageBuffer(999999999)
+
+    buffer.put('stream-1', {
+        id: 'stream-1',
+        data: 'hello'
+    })
+    buffer.put('stream-1', {
+        id: 'stream-1',
+        data: 'world'
+    })
+    buffer.put('stream-2', {
+        id: 'stream-2',
+        data: 'DESTROY!'
+    })
+    buffer.put('stream-1', {
+        id: 'stream-1',
+        data: '!'
+    })
+
+    expect(buffer.popAll('non-existing-stream')).toEqual([])
+    expect(buffer.popAll('stream-1')).toEqual([
+        {
+            id: 'stream-1',
+            data: 'hello'
+        },
+        {
+            id: 'stream-1',
+            data: 'world'
+        },
+        {
+            id: 'stream-1',
+            data: '!'
+        },
+    ])
+    expect(buffer.popAll('stream-2')).toEqual([
+        {
+            id: 'stream-2',
+            data: 'DESTROY!'
+        },
+    ])
+    expect(buffer.popAll('stream-1')).toEqual([])
+})
+
+test('timeoutCb(id) is invoked on timeout', (done) => {
+    const buffer = new MessageBuffer(1000, (id) => {
+        expect(id).toEqual('stream-id')
+        done()
+    })
+
+    buffer.put('stream-id', {})
+    jest.runAllTimers()
+})
+
+test('timeoutCb(id) is not invoked if messages popped before timeout', () => {
+    const buffer = new MessageBuffer(1000, (id) => {
+        fail('should not be invoked')
+    })
+
+    buffer.put('stream-1', {})
+    buffer.put('stream-1', {})
+    buffer.put('stream-2', {})
+    buffer.put('stream-2', {})
+    buffer.popAll('stream-1')
+    buffer.popAll('stream-2')
+
+    jest.runAllTimers()
+})
+
+test('messages are deleted after timeout', () => {
+    const buffer = new MessageBuffer(100)
+    buffer.put('stream-1', {})
+    buffer.put('stream-2', {})
+
+    jest.runAllTimers()
+
+    expect(buffer.popAll('stream-1')).toEqual([])
+    expect(buffer.popAll('stream-2')).toEqual([])
+})
+
+test('clear() removes all messages and timeout callbacks', () => {
+    const buffer = new MessageBuffer(100, (id) => {
+        fail('should not be invoked')
+    })
+    buffer.put('stream-1', {})
+    buffer.put('stream-1', {})
+    buffer.put('stream-2', {})
+    buffer.put('stream-2', {})
+
+    buffer.clear()
+    jest.runAllTimers()
+
+    expect(buffer.popAll('stream-1')).toEqual([])
+    expect(buffer.popAll('stream-2')).toEqual([])
+})
+
+test('clearing and pushing to ids do not affect other ids', () => {
+    const buffer = new MessageBuffer(100)
+
+    buffer.put('stream-1', {})
+    buffer.put('stream-1', {})
+
+    jest.advanceTimersByTime(50)
+
+    buffer.put('stream-2', {
+        a: 'a'
+    })
+    buffer.put('stream-3', {
+        b: 'b'
+    })
+    buffer.put('stream-3', {
+        c: 'c'
+    })
+
+    jest.advanceTimersByTime(50)
+
+    expect(buffer.popAll('stream-1')).toEqual([])
+    expect(buffer.popAll('stream-2')).toEqual([{
+        a: 'a'
+    }])
+    expect(buffer.popAll('stream-3')).toEqual([
+        {
+            b: 'b'
+        },
+        {
+            c: 'c'
+        }
+    ])
+})
+
+test('only expired messages are deleted on timeout', () => {
+    const buffer = new MessageBuffer(100)
+
+    buffer.put('stream-1', {})
+    buffer.put('stream-1', {})
+    buffer.put('stream-1', {})
+
+    jest.advanceTimersByTime(50)
+
+    buffer.put('stream-1', {})
+    buffer.put('stream-1', {})
+
+    jest.advanceTimersByTime(50) // first 3 messages deleted
+
+    expect(buffer.popAll('stream-1').length).toEqual(2)
+})


### PR DESCRIPTION
When a Node receives a message with a stream it hasn't seen before, it will buffer that message for later sending. Two things can occur hence after.  

1. Node receives information of who is responsible for the stream (or it is assigned that responsibility). It will then proceed to send all messages of that stream from the buffer (or in the case where it itself is responsible, it will emit events to listeners.)
2. Node fails to deliver messages in given timeframe (60 seconds currently), after which it emits a `MESSAGE_DELIVERY_FAILED` event that users can react to.

Also included is an integration test verifying that initial messages are delivered.

(Fixes #85)