### PR TITLE
Allow node to subscribe and fix message buffering test

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -91,7 +91,9 @@ class Node extends EventEmitter {
             this._sendToSubscribers(streamId, data)
         } else if (this._isKnownStream(streamId)) {
             this.debug('received data for known stream %s', streamId)
-            this._sendToSubscribers(streamId, data)
+            const receiverNode = this.knownStreams.get(streamId)
+            this.protocols.nodeToNode.sendData(receiverNode, streamId, data) // TODO: only send to leader if not numbered
+            this._sendToSubscribers(streamId, data) // TODO: should only send if numbered
         } else if (this.tracker === null) {
             this.debug('no trackers available; attempted to ask about stream %s', streamId)
             this.emit(events.NO_AVAILABLE_TRACKERS)

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -20,7 +20,7 @@ class Node extends EventEmitter {
         this.knownStreams = new Map()
         this.ownStreams = new Set()
         this.subscribers = new SubscriberManager(
-            this._subscribeToStream.bind(this),
+            this.subscribeToStream.bind(this),
             this._unsubscribeFromStream.bind(this)
         )
         this.subscriptions = new SubscriptionManager()
@@ -126,8 +126,10 @@ class Node extends EventEmitter {
         this.debug('node %s unsubscribed from the stream %s', nodeAddress, streamId)
     }
 
-    _subscribeToStream(streamId) {
-        if (this.isOwnStream(streamId)) {
+    subscribeToStream(streamId) {
+        if (this.subscriptions.hasSubscription(streamId)) {
+            this.debug('already subscribed to stream %s', streamId)
+        } else if (this.isOwnStream(streamId)) {
             this.debug('stream %s is own stream; new subscriber will receive data', streamId)
             this.subscriptions.addSubscription(streamId) // Subscription to "self"
         } else if (this._isKnownStream(streamId)) {
@@ -192,13 +194,13 @@ class Node extends EventEmitter {
 
     _handlePendingSubscriptions() {
         this.subscriptions.getPendingSubscriptions().forEach((pendingStreamId) => {
-            this._subscribeToStream(pendingStreamId)
+            this.subscribeToStream(pendingStreamId)
         })
     }
 
     _handlePossiblePendingSubscription(pendingStreamId) {
         if (this.subscriptions.hasPendingSubscription(pendingStreamId)) {
-            this._subscribeToStream(pendingStreamId)
+            this.subscribeToStream(pendingStreamId)
         }
     }
 }

--- a/src/logic/SubscriberManager.js
+++ b/src/logic/SubscriberManager.js
@@ -1,0 +1,49 @@
+module.exports = class SubscriberManager {
+    constructor(onFirstSubscriber = () => {}, onNoMoreListeners = () => {}) {
+        this.subscribers = new Map()
+        this.onFirstSubscriber = onFirstSubscriber
+        this.onNoMoreListeners = onNoMoreListeners
+    }
+
+    subscribersForStream(streamId) {
+        return this.subscribers.get(streamId) || []
+    }
+
+    addSubscriber(streamId, nodeAddress) {
+        if (this._checkPermissions(streamId, nodeAddress)) {
+            if (this.subscribers.has(streamId)) {
+                const currentSubscribersForTheStream = this.subscribers.get(streamId)
+
+                if (!currentSubscribersForTheStream.includes(nodeAddress)) {
+                    this.subscribers.set(streamId, [...currentSubscribersForTheStream, nodeAddress])
+                }
+            } else {
+                this.subscribers.set(streamId, [nodeAddress])
+                this.onFirstSubscriber(streamId)
+            }
+        }
+    }
+
+    removeSubscriberFromAllStreams(nodeAddress) {
+        this.subscribers.forEach((streamId) => {
+            this.removeSubscriber(streamId, nodeAddress)
+        })
+    }
+
+    removeSubscriber(streamId, nodeAddress) {
+        if (this.subscribers.has(streamId)) {
+            const newList = [...this.subscribers.get(streamId)]
+                .filter((node) => node !== nodeAddress)
+            this.subscribers.set(streamId, newList)
+
+            if (newList.length === 0) {
+                this.subscribers.delete(streamId)
+                this.onNoMoreListeners(streamId)
+            }
+        }
+    }
+
+    _checkPermissions(streamId, nodeAddress) {
+        return true
+    }
+}

--- a/src/logic/SubscriberManager.js
+++ b/src/logic/SubscriberManager.js
@@ -25,7 +25,7 @@ module.exports = class SubscriberManager {
     }
 
     removeSubscriberFromAllStreams(nodeAddress) {
-        this.subscribers.forEach((streamId) => {
+        this.subscribers.forEach((_, streamId) => {
             this.removeSubscriber(streamId, nodeAddress)
         })
     }

--- a/src/logic/SubscriberManager.js
+++ b/src/logic/SubscriberManager.js
@@ -1,8 +1,8 @@
 module.exports = class SubscriberManager {
-    constructor(onFirstSubscriber = () => {}, onNoMoreListeners = () => {}) {
+    constructor(onFirstSubscriber = () => {}, onNoMoreSubscribers = () => {}) {
         this.subscribers = new Map()
         this.onFirstSubscriber = onFirstSubscriber
-        this.onNoMoreListeners = onNoMoreListeners
+        this.onNoMoreSubscribers = onNoMoreSubscribers
     }
 
     subscribersForStream(streamId) {
@@ -38,7 +38,7 @@ module.exports = class SubscriberManager {
 
             if (newList.length === 0) {
                 this.subscribers.delete(streamId)
-                this.onNoMoreListeners(streamId)
+                this.onNoMoreSubscribers(streamId)
             }
         }
     }

--- a/src/logic/SubscriptionManager.js
+++ b/src/logic/SubscriptionManager.js
@@ -13,15 +13,19 @@ module.exports = class SubscriptionManager {
         this.pendingSubscriptions.add(streamId)
     }
 
-    getPendingSubscriptions() {
-        return [...this.pendingSubscriptions]
+    removeSubscription(streamId) {
+        this.subscriptions.delete(streamId)
+    }
+
+    hasSubscription(streamId) {
+        return this.subscriptions.has(streamId)
     }
 
     hasPendingSubscription(streamId) {
         return this.pendingSubscriptions.has(streamId)
     }
 
-    removeSubscription(streamId) {
-        this.subscriptions.delete(streamId)
+    getPendingSubscriptions() {
+        return [...this.pendingSubscriptions]
     }
 }

--- a/src/logic/SubscriptionManager.js
+++ b/src/logic/SubscriptionManager.js
@@ -1,0 +1,27 @@
+module.exports = class SubscriptionManager {
+    constructor() {
+        this.subscriptions = new Set()
+        this.pendingSubscriptions = new Set()
+    }
+
+    addSubscription(streamId) {
+        this.pendingSubscriptions.delete(streamId)
+        this.subscriptions.add(streamId)
+    }
+
+    addPendingSubscription(streamId) {
+        this.pendingSubscriptions.add(streamId)
+    }
+
+    getPendingSubscriptions() {
+        return [...this.pendingSubscriptions]
+    }
+
+    hasPendingSubscription(streamId) {
+        return this.pendingSubscriptions.has(streamId)
+    }
+
+    removeSubscription(streamId) {
+        this.subscriptions.delete(streamId)
+    }
+}

--- a/test/integration/nodeMessageBuffering.test.js
+++ b/test/integration/nodeMessageBuffering.test.js
@@ -1,7 +1,9 @@
 const { startNode, startTracker } = require('../../src/composition')
 const Node = require('../../src/logic/Node')
 const { callbackToPromise } = require('../../src/util')
-const { waitForEvent, wait, LOCALHOST, DEFAULT_TIMEOUT, PRIVATE_KEY } = require('../util')
+const {
+    waitForEvent, wait, LOCALHOST, DEFAULT_TIMEOUT, PRIVATE_KEY
+} = require('../util')
 const TrackerNode = require('../../src/protocol/TrackerNode')
 const TrackerServer = require('../../src/protocol/TrackerServer')
 const NodeToNode = require('../../src/protocol/NodeToNode')

--- a/test/integration/nodeMessageBuffering.test.js
+++ b/test/integration/nodeMessageBuffering.test.js
@@ -1,9 +1,10 @@
 const { startNode, startTracker } = require('../../src/composition')
 const Node = require('../../src/logic/Node')
 const { callbackToPromise } = require('../../src/util')
-const { waitForEvent, LOCALHOST, DEFAULT_TIMEOUT, PRIVATE_KEY } = require('../util')
+const { waitForEvent, wait, LOCALHOST, DEFAULT_TIMEOUT, PRIVATE_KEY } = require('../util')
 const TrackerNode = require('../../src/protocol/TrackerNode')
 const TrackerServer = require('../../src/protocol/TrackerServer')
+const NodeToNode = require('../../src/protocol/NodeToNode')
 
 jest.setTimeout(DEFAULT_TIMEOUT)
 
@@ -17,40 +18,38 @@ describe('message buffering of Node', () => {
     let sourceNode
     let destinationNode
 
-    // TODO fix
-    // beforeAll(async (done) => {
-    //     tracker = await startTracker(LOCALHOST, 30300, PRIVATE_KEY)
-    //     sourceNode = await startNode(LOCALHOST, 30321)
-    //     destinationNode = await startNode(LOCALHOST, 30322)
-    //
-    //     await Promise.all([
-    //         waitForEvent(sourceNode.protocols.trackerNode, TrackerNode.events.NODE_LIST_RECEIVED),
-    //         waitForEvent(destinationNode.protocols.trackerNode, TrackerNode.events.NODE_LIST_RECEIVED)
-    //     ])
-    // })
-    //
-    // afterAll(async (done) => {
-    //     await callbackToPromise(sourceNode.stop.bind(sourceNode))
-    //     await callbackToPromise(destinationNode.stop.bind(destinationNode))
-    //     tracker.stop(done)
-    // })
-    //
+    beforeAll(async () => {
+        tracker = await startTracker(LOCALHOST, 30300, PRIVATE_KEY)
+        sourceNode = await startNode(LOCALHOST, 30321)
+        destinationNode = await startNode(LOCALHOST, 30322)
+
+        await Promise.all([
+            waitForEvent(sourceNode.protocols.trackerNode, TrackerNode.events.NODE_LIST_RECEIVED),
+            waitForEvent(destinationNode.protocols.trackerNode, TrackerNode.events.NODE_LIST_RECEIVED)
+        ])
+    })
+
+    afterAll(async (done) => {
+        await callbackToPromise(sourceNode.stop.bind(sourceNode))
+        await callbackToPromise(destinationNode.stop.bind(destinationNode))
+        tracker.stop(done)
+    })
+
     test('first message to unknown stream eventually gets delivered', async (done) => {
-        done()
-        // destinationNode.addOwnStream('stream-id')
-        // destinationNode.on(Node.events.MESSAGE_RECEIVED, (streamId, data) => {
-        //     expect(streamId).toEqual('stream-id')
-        //     expect(data).toEqual({
-        //         hello: 'world'
-        //     })
-        //     done()
-        // })
-        //
-        // await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.STATUS_RECEIVED)
-        //
-        // // "Client" pushes data
-        // sourceNode.onDataReceived('stream-id', {
-        //     hello: 'world'
-        // })
+        destinationNode.on(Node.events.MESSAGE_RECEIVED, (streamId, data) => {
+            expect(streamId).toEqual('stream-id')
+            expect(data).toEqual({
+                hello: 'world'
+            })
+            done()
+        })
+
+        destinationNode._subscribeToStream('stream-id')
+        await wait(2000)
+
+        // "Client" pushes data
+        sourceNode.onDataReceived('stream-id', {
+            hello: 'world'
+        })
     })
 })

--- a/test/integration/nodeMessageBuffering.test.js
+++ b/test/integration/nodeMessageBuffering.test.js
@@ -44,8 +44,8 @@ describe('message buffering of Node', () => {
             done()
         })
 
-        destinationNode._subscribeToStream('stream-id')
-        await wait(2000)
+        destinationNode.subscribeToStream('stream-id')
+        await wait(500) // TODO: required to not encounter issue #99 (concurrent subscription)
 
         // "Client" pushes data
         sourceNode.onDataReceived('stream-id', {

--- a/test/integration/subscriber.test.js
+++ b/test/integration/subscriber.test.js
@@ -50,13 +50,8 @@ describe('Selecting leader for the stream and sending messages to two subscriber
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.STREAM_INFO_REQUESTED)
         await waitForEvent(nodeOne.protocols.trackerNode, TrackerNode.events.STREAM_ASSIGNED)
 
-        const subscribeInterval1 = setInterval(() => {
-            subscriber1.subscribe(streamId)
-        }, 1000)
-
-        const subscribeInterval2 = setInterval(() => {
-            subscriber2.subscribe(streamId)
-        }, 1000)
+        subscriber1.subscribe(streamId)
+        subscriber2.subscribe(streamId)
 
         await Promise.all([
             waitForEvent(subscriber1.protocols.nodeToNode, NodeToNode.events.DATA_RECEIVED),
@@ -64,8 +59,6 @@ describe('Selecting leader for the stream and sending messages to two subscriber
         ]).then((res) => {
             console.log('==================================')
             expect(nodeTwo.subscribers.subscribersForStream(streamId).length).toEqual(2)
-            clearInterval(subscribeInterval1)
-            clearInterval(subscribeInterval2)
             clearInterval(publisherInterval)
 
             done()

--- a/test/integration/subscriber.test.js
+++ b/test/integration/subscriber.test.js
@@ -63,7 +63,7 @@ describe('Selecting leader for the stream and sending messages to two subscriber
             waitForEvent(subscriber2.protocols.nodeToNode, NodeToNode.events.DATA_RECEIVED)
         ]).then((res) => {
             console.log('==================================')
-            expect(nodeTwo.subscribers.get(streamId).length).toEqual(2)
+            expect(nodeTwo.subscribers.subscribersForStream(streamId).length).toEqual(2)
             clearInterval(subscribeInterval1)
             clearInterval(subscribeInterval2)
             clearInterval(publisherInterval)

--- a/test/unit/SubscriberManager.test.js
+++ b/test/unit/SubscriberManager.test.js
@@ -1,0 +1,103 @@
+const SubscriberManager = require('../../src/logic/SubscriberManager')
+
+test('adding and requesting subscribers works', () => {
+    const manager = new SubscriberManager()
+    manager.addSubscriber('stream-1', '192.168.0.1')
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.addSubscriber('stream-1', '192.168.0.3')
+    manager.addSubscriber('stream-2', '192.168.0.1')
+    manager.addSubscriber('stream-2', '192.168.0.2')
+    manager.addSubscriber('stream-3', '192.168.0.3')
+
+    expect(manager.subscribersForStream('stream-1')).toEqual(['192.168.0.1', '192.168.0.2', '192.168.0.3'])
+    expect(manager.subscribersForStream('stream-2')).toEqual(['192.168.0.1', '192.168.0.2'])
+    expect(manager.subscribersForStream('stream-3')).toEqual(['192.168.0.3'])
+    expect(manager.subscribersForStream('non-existing-stream')).toEqual([])
+})
+
+test('removing subscribers work', () => {
+    const manager = new SubscriberManager()
+    manager.addSubscriber('stream-1', '192.168.0.1')
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.addSubscriber('stream-1', '192.168.0.3')
+    manager.addSubscriber('stream-2', '192.168.0.1')
+    manager.addSubscriber('stream-2', '192.168.0.2')
+    manager.addSubscriber('stream-3', '192.168.0.3')
+
+    manager.removeSubscriber('stream-1', '192.168.0.2')
+    manager.removeSubscriberFromAllStreams('192.168.0.3')
+
+    expect(manager.subscribersForStream('stream-1')).toEqual(['192.168.0.1'])
+    expect(manager.subscribersForStream('stream-3')).toEqual([])
+})
+
+test('cb onFirstSubscriber is invoked first time subscriber is added to stream', () => {
+    const onFirstSubscriber = jest.fn()
+    const manager = new SubscriberManager(onFirstSubscriber)
+
+    manager.addSubscriber('stream-1', '192.168.0.1')
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.addSubscriber('stream-1', '192.168.0.3')
+
+    expect(onFirstSubscriber).toBeCalledTimes(1)
+    expect(onFirstSubscriber).toBeCalledWith('stream-1')
+})
+
+test('cb onFirstSubscriber is reset if all subscribers are removed', () => {
+    const onFirstSubscriber = jest.fn()
+    const manager = new SubscriberManager(onFirstSubscriber)
+
+    manager.addSubscriber('stream-1', '192.168.0.1')
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.addSubscriber('stream-1', '192.168.0.3')
+    expect(onFirstSubscriber).toBeCalledTimes(1)
+
+    manager.removeSubscriber('stream-1', '192.168.0.1')
+    manager.removeSubscriber('stream-1', '192.168.0.2')
+    manager.removeSubscriber('stream-1', '192.168.0.3')
+
+    manager.addSubscriber('stream-1', '192.168.0.1')
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.addSubscriber('stream-1', '192.168.0.3')
+    expect(onFirstSubscriber).toBeCalledTimes(2)
+})
+
+test('cb onNoMoreSubscribers is invoked when last subscriber leaves stream', () => {
+    const onNoMoreSubscribers = jest.fn()
+    const manager = new SubscriberManager(() => {}, onNoMoreSubscribers)
+
+    manager.addSubscriber('stream-1', '192.168.0.1')
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.addSubscriber('stream-1', '192.168.0.3')
+    expect(onNoMoreSubscribers).toBeCalledTimes(0)
+
+    manager.removeSubscriber('stream-1', '192.168.0.1')
+    manager.removeSubscriber('stream-1', '192.168.0.3')
+    expect(onNoMoreSubscribers).toBeCalledTimes(0)
+
+    manager.removeSubscriber('stream-1', '192.168.0.2')
+    expect(onNoMoreSubscribers).toBeCalledTimes(1)
+    expect(onNoMoreSubscribers).toBeCalledWith('stream-1')
+})
+
+test('cb onNoMoreSubscribers is reset when new subscribers join', () => {
+    const onNoMoreSubscribers = jest.fn()
+    const manager = new SubscriberManager(() => {}, onNoMoreSubscribers)
+
+    manager.addSubscriber('stream-1', '192.168.0.1')
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.addSubscriber('stream-1', '192.168.0.3')
+
+    manager.removeSubscriber('stream-1', '192.168.0.1')
+    manager.removeSubscriber('stream-1', '192.168.0.3')
+    manager.removeSubscriber('stream-1', '192.168.0.2')
+    expect(onNoMoreSubscribers).toBeCalledTimes(1)
+
+    manager.removeSubscriber('stream-1', '192.168.0.1')
+    manager.removeSubscriber('stream-1', '192.168.0.3')
+    expect(onNoMoreSubscribers).toBeCalledTimes(1)
+
+    manager.addSubscriber('stream-1', '192.168.0.2')
+    manager.removeSubscriber('stream-1', '192.168.0.2')
+    expect(onNoMoreSubscribers).toBeCalledTimes(2)
+})

--- a/test/unit/SubscriptionManager.test.js
+++ b/test/unit/SubscriptionManager.test.js
@@ -1,0 +1,57 @@
+const SubscriptionManager = require('../../src/logic/SubscriptionManager')
+
+describe('SubscriptionManager', () => {
+    let manager
+
+    beforeEach(() => {
+        manager = new SubscriptionManager()
+    })
+
+    test('addPendingSubscription adds pending subscription', () => {
+        manager.addPendingSubscription('stream-id')
+        expect(manager.hasPendingSubscription('stream-id')).toBe(true)
+    })
+
+    test('addPendingSubscription does not add (non-pending) subscription', () => {
+        manager.addPendingSubscription('stream-id')
+        expect(manager.hasSubscription('stream-id')).toBe(false)
+    })
+
+    test('addSubscription adds (non-pending) subscription', () => {
+        manager.addSubscription('stream-id')
+        expect(manager.hasSubscription('stream-id')).toBe(true)
+    })
+
+    test('addSubscription does not add pending subscription', () => {
+        manager.addSubscription('stream-id')
+        expect(manager.hasPendingSubscription('stream-id')).toBe(false)
+    })
+
+    test('addSubscription removes pending subscription with same name if exists', () => {
+        manager.addPendingSubscription('stream-id')
+        expect(manager.hasPendingSubscription('stream-id')).toBe(true)
+
+        manager.addSubscription('stream-id')
+        expect(manager.hasPendingSubscription('stream-id')).toBe(false)
+    })
+
+    test('removeSubscription removes (non-pending) subscription', () => {
+        manager.addSubscription('stream-id')
+        manager.removeSubscription('stream-id')
+        expect(manager.hasSubscription('stream-id')).toBe(false)
+    })
+
+    test('removeSubscription does not remove pending subscription', () => {
+        manager.addPendingSubscription('stream-id')
+        manager.removeSubscription('stream-id')
+        expect(manager.hasPendingSubscription('stream-id')).toBe(true)
+    })
+
+    test('can list pending subscriptions', () => {
+        manager.addPendingSubscription('stream-1')
+        manager.addPendingSubscription('stream-2')
+        manager.addPendingSubscription('stream-3')
+        manager.addSubscription('should-not-appear')
+        expect(manager.getPendingSubscriptions()).toEqual(['stream-1', 'stream-2', 'stream-3'])
+    })
+})


### PR DESCRIPTION
- Introduced two new classes that are used by `logic/Node`.
  - `SubscriberManager` is responsible for keeping track of who is subscribed to this node. It fires callbacks when a) first subscriber to a stream appears, and b) last one leaves. Most of the existing subscriber logic is moved to this class.
  - `SubscriptionManager` is responsible for keeping track of this node's subscriptions to other nodes.
- Allow for pending subscriptions via `SubscriptionManager`. If either tracker is not available or stream is still unknown, subscription cannot happen. We save these as pending and try later when stream info becomes available or tracker is connected to.
- `Node#onDataReceived` sends data to leader for (eventual) numbering. Added some TODOs for numbering branch.
- Allow Node to subscribe to a stream without client subscribers.

All this allowed for the fixing of test `nodeMessageBuffering.test.js`

TODO:
- Write unit tests for new classes