### PR TITLE
Encapsulate stream management logic to own class

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -6,6 +6,7 @@ const SubscriberManager = require('../logic/SubscriberManager')
 const SubscriptionManager = require('../logic/SubscriptionManager')
 const MessageBuffer = require('../helpers/MessageBuffer')
 const { getAddress, getIdShort } = require('../util')
+const StreamManager = require('./StreamManager')
 
 const events = Object.freeze({
     MESSAGE_RECEIVED: 'streamr:node:message-received',
@@ -17,8 +18,7 @@ class Node extends EventEmitter {
     constructor(trackerNode, nodeToNode) {
         super()
 
-        this.knownStreams = new Map()
-        this.ownStreams = new Set()
+        this.streams = new StreamManager()
         this.subscribers = new SubscriberManager(
             this.subscribeToStream.bind(this),
             this._unsubscribeFromStream.bind(this)
@@ -70,7 +70,7 @@ class Node extends EventEmitter {
 
     addOwnStream(streamId) {
         this.debug('stream %s added to own streams', streamId)
-        this.ownStreams.add(streamId)
+        this.streams.addOwnStream(streamId)
         this._sendStatus(this.tracker)
         this._handlePossiblePendingSubscription(streamId)
         this._handleBufferedMessages(streamId)
@@ -79,19 +79,19 @@ class Node extends EventEmitter {
     // add to cache of streams
     addKnownStreams(streamId, nodeAddress) {
         this.debug('stream %s added to known streams for address %s', streamId, nodeAddress)
-        this.knownStreams.set(streamId, nodeAddress)
+        this.streams.addKnownStream(streamId, nodeAddress)
         this._handlePossiblePendingSubscription(streamId)
         this._handleBufferedMessages(streamId)
     }
 
     onDataReceived(streamId, data) {
-        if (this.isOwnStream(streamId)) {
+        if (this.streams.isOwnStream(streamId)) {
             this.debug('received data for own stream %s', streamId)
             this.emit(events.MESSAGE_RECEIVED, streamId, data)
             this._sendToSubscribers(streamId, data)
-        } else if (this._isKnownStream(streamId)) {
+        } else if (this.streams.isKnownStream(streamId)) {
             this.debug('received data for known stream %s', streamId)
-            const receiverNode = this.knownStreams.get(streamId)
+            const receiverNode = this.streams.getAddressForStream(streamId)
             this.protocols.nodeToNode.sendData(receiverNode, streamId, data) // TODO: only send to leader if not numbered
             this._sendToSubscribers(streamId, data) // TODO: should only send if numbered
         } else if (this.tracker === null) {
@@ -129,12 +129,13 @@ class Node extends EventEmitter {
     subscribeToStream(streamId) {
         if (this.subscriptions.hasSubscription(streamId)) {
             this.debug('already subscribed to stream %s', streamId)
-        } else if (this.isOwnStream(streamId)) {
+        } else if (this.streams.isOwnStream(streamId)) {
             this.debug('stream %s is own stream; new subscriber will receive data', streamId)
             this.subscriptions.addSubscription(streamId) // Subscription to "self"
-        } else if (this._isKnownStream(streamId)) {
-            this.debug('stream %s is in known; sending subscribe request to nodeAddress %s', streamId, this.knownStreams.get(streamId))
-            this.protocols.nodeToNode.sendSubscribe(this.knownStreams.get(streamId), streamId)
+        } else if (this.streams.isKnownStream(streamId)) {
+            const receiverAddress = this.streams.getAddressForStream(streamId)
+            this.debug('stream %s is in known; sending subscribe request to nodeAddress %s', streamId, receiverAddress)
+            this.protocols.nodeToNode.sendSubscribe(receiverAddress, streamId)
             this.subscriptions.addSubscription(streamId) // Assuming subscribe went through
         } else if (this.tracker === null) {
             this.debug('no trackers available; attempted to ask about stream %s', streamId)
@@ -151,14 +152,6 @@ class Node extends EventEmitter {
         this.subscriptions.removeSubscription(streamId)
     }
 
-    isOwnStream(streamId) {
-        return this.ownStreams.has(streamId)
-    }
-
-    _isKnownStream(streamId) {
-        return this.knownStreams.get(streamId) !== undefined
-    }
-
     stop(cb) {
         this.debug('stopping')
         this.messageBuffer.clear()
@@ -168,7 +161,7 @@ class Node extends EventEmitter {
 
     _getStatus() {
         return {
-            streams: [...this.ownStreams],
+            streams: this.streams.getOwnStreams(),
             started: this.started
         }
     }

--- a/src/logic/StreamManager.js
+++ b/src/logic/StreamManager.js
@@ -4,23 +4,25 @@ module.exports = class StreamManager {
         this.knownStreams = new Map() // streamId => nodeAddress
     }
 
-    addOwnStream(streamId) {
+    markCurrentNodeAsLeaderOf(streamId) {
+        this.knownStreams.delete(streamId)
         this.ownStreams.add(streamId)
     }
 
-    addKnownStream(streamId, nodeAddress) {
+    markOtherNodeAsLeader(streamId, nodeAddress) {
+        this.ownStreams.delete(streamId)
         this.knownStreams.set(streamId, nodeAddress)
     }
 
-    getAddressForStream(streamId) {
+    getLeaderAddressFor(streamId) {
         return this.knownStreams.get(streamId)
     }
 
-    isOwnStream(streamId) {
+    isLeaderOf(streamId) {
         return this.ownStreams.has(streamId)
     }
 
-    isKnownStream(streamId) {
+    isOtherNodeLeaderOf(streamId) {
         return this.knownStreams.has(streamId)
     }
 

--- a/src/logic/StreamManager.js
+++ b/src/logic/StreamManager.js
@@ -1,0 +1,30 @@
+module.exports = class StreamManager {
+    constructor() {
+        this.ownStreams = new Set()
+        this.knownStreams = new Map() // streamId => nodeAddress
+    }
+
+    addOwnStream(streamId) {
+        this.ownStreams.add(streamId)
+    }
+
+    addKnownStream(streamId, nodeAddress) {
+        this.knownStreams.set(streamId, nodeAddress)
+    }
+
+    getAddressForStream(streamId) {
+        return this.knownStreams.get(streamId)
+    }
+
+    isOwnStream(streamId) {
+        return this.ownStreams.has(streamId)
+    }
+
+    isKnownStream(streamId) {
+        return this.knownStreams.has(streamId)
+    }
+
+    getOwnStreams() {
+        return [...this.ownStreams]
+    }
+}

--- a/test/integration/publisher.test.js
+++ b/test/integration/publisher.test.js
@@ -23,13 +23,13 @@ describe('publisher and node connection', () => {
         const client = new Client(new NodeToNode(endpoint2), endpoint1.node.peerInfo)
         const streamId = 'streamd-id'
 
-        assert(!node.streams.isOwnStream(streamId))
+        assert(!node.streams.isLeaderOf(streamId))
 
         client.publish(streamId, 'Hello world, from Publisher ' + endpoint2.node.peerInfo.id.toB58String(), () => {})
 
         endpoint1.on(endpointEvents.MESSAGE_RECEIVED, ({ sender, message }) => {
             assert.equal(message, `{"version":"${version}","code":2,"data":["${streamId}","Hello world, from Publisher ${endpoint2.node.peerInfo.id.toB58String()}"]}`)
-            assert(!node.streams.isOwnStream(streamId))
+            assert(!node.streams.isLeaderOf(streamId))
 
             endpoint1.node.stop(() => {
                 endpoint2.node.stop(() => done())

--- a/test/integration/publisher.test.js
+++ b/test/integration/publisher.test.js
@@ -23,13 +23,13 @@ describe('publisher and node connection', () => {
         const client = new Client(new NodeToNode(endpoint2), endpoint1.node.peerInfo)
         const streamId = 'streamd-id'
 
-        assert(!node.isOwnStream(streamId))
+        assert(!node.streams.isOwnStream(streamId))
 
         client.publish(streamId, 'Hello world, from Publisher ' + endpoint2.node.peerInfo.id.toB58String(), () => {})
 
         endpoint1.on(endpointEvents.MESSAGE_RECEIVED, ({ sender, message }) => {
             assert.equal(message, `{"version":"${version}","code":2,"data":["${streamId}","Hello world, from Publisher ${endpoint2.node.peerInfo.id.toB58String()}"]}`)
-            assert(!node.isOwnStream(streamId))
+            assert(!node.streams.isOwnStream(streamId))
 
             endpoint1.node.stop(() => {
                 endpoint2.node.stop(() => done())

--- a/test/unit/StreamManager.test.js
+++ b/test/unit/StreamManager.test.js
@@ -1,0 +1,45 @@
+const StreamManager = require('../../src/logic/StreamManager')
+
+describe('StreamManager', () => {
+    let manager
+
+    beforeEach(() => {
+        manager = new StreamManager()
+    })
+
+    test('starts out empty', () => {
+        expect(manager.isLeaderOf('stream-id')).toEqual(false)
+        expect(manager.isOtherNodeLeaderOf('stream-id')).toEqual(false)
+        expect(manager.getOwnStreams()).toEqual([])
+        expect(manager.getLeaderAddressFor('stream-id')).toBeUndefined()
+    })
+
+    test('can mark and query leader\'s streams', () => {
+        manager.markCurrentNodeAsLeaderOf('stream-1')
+        manager.markCurrentNodeAsLeaderOf('stream-2')
+
+        expect(manager.isLeaderOf('stream-1')).toEqual(true)
+        expect(manager.isLeaderOf('stream-2')).toEqual(true)
+        expect(manager.getOwnStreams()).toEqual(['stream-1', 'stream-2'])
+    })
+
+    test('can mark and query other leaders\' streams', () => {
+        manager.markOtherNodeAsLeader('stream-1', '192.168.0.5')
+        manager.markOtherNodeAsLeader('stream-2', '192.168.0.6')
+
+        expect(manager.isOtherNodeLeaderOf('stream-1')).toEqual(true)
+        expect(manager.isOtherNodeLeaderOf('stream-2')).toEqual(true)
+        expect(manager.getLeaderAddressFor('stream-1')).toEqual('192.168.0.5')
+        expect(manager.getLeaderAddressFor('stream-2')).toEqual('192.168.0.6')
+    })
+
+    test('a stream can only have one leader', () => {
+        manager.markCurrentNodeAsLeaderOf('stream-id')
+        manager.markOtherNodeAsLeader('stream-id', '192.168.0.8')
+        manager.markOtherNodeAsLeader('stream-id', '192.168.0.212')
+
+        expect(manager.isLeaderOf('stream-id')).toEqual(false)
+        expect(manager.isOtherNodeLeaderOf('stream-id')).toEqual(true)
+        expect(manager.getLeaderAddressFor('stream-id')).toEqual('192.168.0.212')
+    })
+})


### PR DESCRIPTION
Fixes #95 

- Encapsulate stream management logic from `logic/Node` to its own class `StreamManager`.
- Use leader terminology