### PR TITLE
Removed protocol layer dependency on Libp2pEndpoint

### DIFF
--- a/src/connection/Endpoint.js
+++ b/src/connection/Endpoint.js
@@ -1,0 +1,25 @@
+const events = Object.freeze({
+    PEER_DISCOVERED: 'streamr:peer:discovery',
+    PEER_CONNECTED: 'streamr:peer:connect',
+    PEER_DISCONNECTED: 'streamr:peer:disconnect',
+    MESSAGE_SENT: 'streamr:message-sent',
+    MESSAGE_RECEIVED: 'streamr:message-received'
+})
+
+class Endpoint {
+    implement(implementor) {
+        if (typeof implementor.send !== 'function') {
+            throw new Error('send() method not found in class implementing Endpoint')
+        }
+        if (typeof implementor.connect !== 'function') {
+            throw new Error('connect() method not found in class implementing Endpoint')
+        }
+        if (typeof implementor.stop !== 'function') {
+            throw new Error('stop() method not found in class implementing Endpoint')
+        }
+    }
+}
+
+Endpoint.events = events
+
+module.exports = Endpoint

--- a/src/connection/Libp2pEndpoint.js
+++ b/src/connection/Libp2pEndpoint.js
@@ -4,37 +4,33 @@ const PeerInfo = require('peer-info')
 const pull = require('pull-stream')
 const debug = require('debug')('streamr:connection:libp2pendpoint')
 const { callbackToPromise, getAddress } = require('../util')
+const Endpoint = require('./Endpoint')
 const Libp2pBundle = require('./Libp2pBundle')
 
 const HANDLER = '/streamr/v1/'
-
-const events = Object.freeze({
-    PEER_DISCOVERED: 'streamr:peer:discovery',
-    PEER_CONNECTED: 'streamr:peer:connect',
-    PEER_DISCONNECTED: 'streamr:peer:disconnect',
-    MESSAGE_SENT: 'streamr:message-sent',
-    MESSAGE_RECEIVED: 'streamr:message-received'
-})
 
 class Libp2pEndpoint extends EventEmitter {
     constructor(node) {
         super()
         this.node = node
 
+        this.endpoint = new Endpoint()
+        this.endpoint.implement(this)
+
         node.peerInfo.multiaddrs.forEach((ma) => debug('listening on: %s', ma.toString()))
 
         node.handle(HANDLER, (protocol, conn) => this.onReceive(protocol, conn))
         node.on('peer:discovery', (peer) => {
             debug('peer %s discovered', getAddress(peer))
-            this.emit(events.PEER_DISCOVERED, peer)
+            this.emit(Endpoint.events.PEER_DISCOVERED, peer)
         })
         node.on('peer:connect', (peer) => {
             debug('peer %s connected', getAddress(peer))
-            this.emit(events.PEER_CONNECTED, peer)
+            this.emit(Endpoint.events.PEER_CONNECTED, peer)
         })
         node.on('peer:disconnect', (peer) => {
             debug('peer %s disconnected', getAddress(peer))
-            this.emit(events.PEER_DISCONNECTED, peer)
+            this.emit(Endpoint.events.PEER_DISCONNECTED, peer)
         })
     }
 
@@ -47,7 +43,7 @@ class Libp2pEndpoint extends EventEmitter {
 
             pull(pull.values([message]), conn)
 
-            this.emit(events.MESSAGE_SENT, {
+            this.emit(Endpoint.events.MESSAGE_SENT, {
                 recipient,
                 message
             })
@@ -64,7 +60,7 @@ class Libp2pEndpoint extends EventEmitter {
                 pull.drain((message) => {
                     debug('received from peer %s message with data "%s"', sender instanceof PeerInfo ? getAddress(sender) : '', message)
 
-                    this.emit(events.MESSAGE_RECEIVED, {
+                    this.emit(Endpoint.events.MESSAGE_RECEIVED, {
                         sender,
                         message
                     })
@@ -152,7 +148,6 @@ async function startLibp2pNode(host, port, privateKey, enablePeerDiscovery, boot
 }
 
 module.exports = {
-    events,
     async createEndpoint(host, port, privateKey, enablePeerDiscovery = false, bootstrapNodes) {
         return startLibp2pNode(host, port, privateKey, enablePeerDiscovery, bootstrapNodes).then((n) => new Libp2pEndpoint(n))
     }

--- a/src/protocol/EndpointListener.js
+++ b/src/protocol/EndpointListener.js
@@ -1,4 +1,4 @@
-const endpointEvents = require('../connection/Libp2pEndpoint').events
+const endpointEvents = require('../connection/Endpoint').events
 const encoder = require('../helpers/MessageEncoder')
 
 module.exports = class EndpointListener {

--- a/src/protocol/TrackerServer.js
+++ b/src/protocol/TrackerServer.js
@@ -1,7 +1,6 @@
 const { EventEmitter } = require('events')
 const { isTracker, getAddress } = require('../util')
 const encoder = require('../helpers/MessageEncoder')
-const endpointEvents = require('../connection/Libp2pEndpoint').events
 const EndpointListener = require('./EndpointListener')
 
 const events = Object.freeze({
@@ -20,8 +19,6 @@ class TrackerServer extends EventEmitter {
 
         this._endpointListener = new EndpointListener()
         this._endpointListener.implement(this, endpoint)
-
-        this.endpoint.on(endpointEvents.PEER_DISCONNECTED, (peer) => this.onPeerDisconnected(peer))
     }
 
     sendNodeList(receiverNode, nodeList) {

--- a/test/integration/libp2pendpoint.test.js
+++ b/test/integration/libp2pendpoint.test.js
@@ -1,5 +1,5 @@
 const { DEFAULT_TIMEOUT, LOCALHOST, waitForEvent, wait } = require('../util')
-const endpointEvents = require('../../src/connection/Libp2pEndpoint').events
+const endpointEvents = require('../../src/connection/Endpoint').events
 const { createEndpoint } = require('../../src/connection/Libp2pEndpoint')
 
 jest.setTimeout(DEFAULT_TIMEOUT)


### PR DESCRIPTION
Moved event definitions from Libp2pEndpoint to Endpoint interface class that Libp2pEndpoint implements. Now protocol layer is not dependent on a specific Endpoint type, and for example, implementing a WebsocketEndpoint is possible. Fix Issue #118.