### PR TITLE
Exchange peer identities

### DIFF
--- a/src/PeerBook.js
+++ b/src/PeerBook.js
@@ -9,4 +9,8 @@ module.exports = class PeerBook {
             this.addressToType[peer] = customHeaders['streamr-peer-type']
         })
     }
+
+    getShortId(address) {
+        return this.addressToId[address]
+    }
 }

--- a/src/PeerBook.js
+++ b/src/PeerBook.js
@@ -1,0 +1,12 @@
+const Endpoint = require('./connection/Endpoint')
+
+module.exports = class PeerBook {
+    constructor(endpoint) {
+        this.addressToId = {}
+        this.addressToType = {}
+        endpoint.on(Endpoint.events.PEER_CONNECTED, (peer, customHeaders) => {
+            this.addressToId[peer] = customHeaders['streamr-peer-id']
+            this.addressToType[peer] = customHeaders['streamr-peer-type']
+        })
+    }
+}

--- a/src/composition.js
+++ b/src/composition.js
@@ -1,3 +1,4 @@
+const uuidv4 = require('uuid/v4')
 const TrackerServer = require('./protocol/TrackerServer')
 const TrackerNode = require('./protocol/TrackerNode')
 const NodeToNode = require('./protocol/NodeToNode')
@@ -7,7 +8,7 @@ const Client = require('./logic/Client')
 const NetworkNode = require('./NetworkNode')
 const { startEndpoint } = require('./connection/WsEndpoint')
 
-async function startTracker(host, port, id) {
+async function startTracker(host, port, id = uuidv4()) {
     return startEndpoint(host, port).then((endpoint) => {
         return new Tracker(id, new TrackerServer(endpoint))
     }).catch((err) => {
@@ -15,7 +16,7 @@ async function startTracker(host, port, id) {
     })
 }
 
-async function startNode(host, port, id) {
+async function startNode(host, port, id = uuidv4()) {
     return startEndpoint(host, port).then((endpoint) => {
         return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
     }).catch((err) => {
@@ -23,7 +24,7 @@ async function startNode(host, port, id) {
     })
 }
 
-async function startClient(host, port, id, nodeAddress) {
+async function startClient(host, port, id = uuidv4(), nodeAddress) {
     return startEndpoint(host, port).then((endpoint) => {
         return new Client(id, new NodeToNode(endpoint), nodeAddress)
     }).catch((err) => {
@@ -31,7 +32,7 @@ async function startClient(host, port, id, nodeAddress) {
     })
 }
 
-async function startNetworkNode(host, port, id) {
+async function startNetworkNode(host, port, id = uuidv4()) {
     return startEndpoint(host, port).then((endpoint) => {
         return new NetworkNode(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
     }).catch((err) => {

--- a/src/composition.js
+++ b/src/composition.js
@@ -6,6 +6,7 @@ const Tracker = require('./logic/Tracker')
 const Node = require('./logic/Node')
 const Client = require('./logic/Client')
 const NetworkNode = require('./NetworkNode')
+const PeerBook = require('./PeerBook')
 const { startEndpoint } = require('./connection/WsEndpoint')
 
 async function startTracker(host, port, id = uuidv4()) {
@@ -14,7 +15,7 @@ async function startTracker(host, port, id = uuidv4()) {
         'streamr-peer-type': 'tracker'
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new Tracker(id, new TrackerServer(endpoint))
+        return new Tracker(id, new PeerBook(endpoint), new TrackerServer(endpoint))
     }).catch((err) => {
         throw err
     })
@@ -26,7 +27,7 @@ async function startNode(host, port, id = uuidv4()) {
         'streamr-peer-type': 'node'
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
+        return new Node(id, new PeerBook(endpoint), new TrackerNode(endpoint), new NodeToNode(endpoint))
     }).catch((err) => {
         throw err
     })
@@ -38,7 +39,7 @@ async function startClient(host, port, id = uuidv4(), nodeAddress) {
         'streamr-peer-type': 'client'
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new Client(id, new NodeToNode(endpoint), nodeAddress)
+        return new Client(id, new PeerBook(endpoint), new NodeToNode(endpoint), nodeAddress)
     }).catch((err) => {
         throw err
     })
@@ -50,7 +51,7 @@ async function startNetworkNode(host, port, id = uuidv4()) {
         'streamr-peer-type': 'node'
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new NetworkNode(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
+        return new NetworkNode(id, new PeerBook(endpoint), new TrackerNode(endpoint), new NodeToNode(endpoint))
     }).catch((err) => {
         throw err
     })

--- a/src/composition.js
+++ b/src/composition.js
@@ -9,7 +9,11 @@ const NetworkNode = require('./NetworkNode')
 const { startEndpoint } = require('./connection/WsEndpoint')
 
 async function startTracker(host, port, id = uuidv4()) {
-    return startEndpoint(host, port).then((endpoint) => {
+    const identity = {
+        'streamr-peer-id': id,
+        'streamr-peer-type': 'tracker'
+    }
+    return startEndpoint(host, port, identity).then((endpoint) => {
         return new Tracker(id, new TrackerServer(endpoint))
     }).catch((err) => {
         throw err
@@ -17,7 +21,11 @@ async function startTracker(host, port, id = uuidv4()) {
 }
 
 async function startNode(host, port, id = uuidv4()) {
-    return startEndpoint(host, port).then((endpoint) => {
+    const identity = {
+        'streamr-peer-id': id,
+        'streamr-peer-type': 'node'
+    }
+    return startEndpoint(host, port, identity).then((endpoint) => {
         return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
     }).catch((err) => {
         throw err
@@ -25,7 +33,11 @@ async function startNode(host, port, id = uuidv4()) {
 }
 
 async function startClient(host, port, id = uuidv4(), nodeAddress) {
-    return startEndpoint(host, port).then((endpoint) => {
+    const identity = {
+        'streamr-peer-id': id,
+        'streamr-peer-type': 'client'
+    }
+    return startEndpoint(host, port, identity).then((endpoint) => {
         return new Client(id, new NodeToNode(endpoint), nodeAddress)
     }).catch((err) => {
         throw err
@@ -33,7 +45,11 @@ async function startClient(host, port, id = uuidv4(), nodeAddress) {
 }
 
 async function startNetworkNode(host, port, id = uuidv4()) {
-    return startEndpoint(host, port).then((endpoint) => {
+    const identity = {
+        'streamr-peer-id': id,
+        'streamr-peer-type': 'node'
+    }
+    return startEndpoint(host, port, identity).then((endpoint) => {
         return new NetworkNode(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
     }).catch((err) => {
         throw err

--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -38,6 +38,14 @@ class WsEndpoint extends EventEmitter {
             }
         })
 
+        // Add identity to server response headers before they are sent to client
+        this.wss.on('headers', (headers) => {
+            Object.keys(this.customHeaders).forEach((headerName) => {
+                const headerValue = this.customHeaders[headerName]
+                headers.push(`${headerName}: ${headerValue}`)
+            })
+        })
+
         debug('node started')
         debug('listening on: %s', this.getAddress())
     }

--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -7,9 +7,18 @@ const WebSocket = require('ws')
 const Endpoint = require('./Endpoint')
 
 class WsEndpoint extends EventEmitter {
-    constructor(wss) {
+    constructor(wss, customHeaders) {
         super()
+
+        if (!wss) {
+            throw new Error('wss not given')
+        }
+        if (!customHeaders) {
+            throw new Error('customHeaders not given')
+        }
+
         this.wss = wss
+        this.customHeaders = customHeaders
 
         this.endpoint = new Endpoint()
         this.endpoint.implement(this)
@@ -75,7 +84,9 @@ class WsEndpoint extends EventEmitter {
                 resolve()
             } else {
                 try {
-                    const ws = new WebSocket(`${peerAddress}?address=${this.getAddress()}`)
+                    const ws = new WebSocket(`${peerAddress}?address=${this.getAddress()}`, {
+                        headers: this.customHeaders
+                    })
 
                     ws.on('open', () => {
                         this._onConnected(ws, peerAddress)
@@ -152,8 +163,8 @@ async function startWebsocketServer(host, port) {
     })
 }
 
-async function startEndpoint(host, port) {
-    return startWebsocketServer(host, port).then((n) => new WsEndpoint(n))
+async function startEndpoint(host, port, customHeaders) {
+    return startWebsocketServer(host, port).then((n) => new WsEndpoint(n, customHeaders))
 }
 
 module.exports = {

--- a/src/logic/Client.js
+++ b/src/logic/Client.js
@@ -1,5 +1,4 @@
 const { EventEmitter } = require('events')
-const uuidv4 = require('uuid/v4')
 const createDebug = require('debug')
 const { getIdShort } = require('../util')
 
@@ -7,7 +6,7 @@ module.exports = class Client extends EventEmitter {
     constructor(id, nodeToNode, nodeAddress) {
         super()
 
-        this.id = id || uuidv4()
+        this.id = id
         this.nodeAddress = nodeAddress
         this.protocols = {
             nodeToNode

--- a/src/logic/Client.js
+++ b/src/logic/Client.js
@@ -1,6 +1,5 @@
 const { EventEmitter } = require('events')
 const createDebug = require('debug')
-const { getIdShort } = require('../util')
 
 module.exports = class Client extends EventEmitter {
     constructor(id, peerBook, nodeToNode, nodeAddress) {

--- a/src/logic/Client.js
+++ b/src/logic/Client.js
@@ -3,10 +3,11 @@ const createDebug = require('debug')
 const { getIdShort } = require('../util')
 
 module.exports = class Client extends EventEmitter {
-    constructor(id, nodeToNode, nodeAddress) {
+    constructor(id, peerBook, nodeToNode, nodeAddress) {
         super()
 
         this.id = id
+        this.peerBook = peerBook
         this.nodeAddress = nodeAddress
         this.protocols = {
             nodeToNode

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -6,7 +6,6 @@ const SubscriberManager = require('../logic/SubscriberManager')
 const SubscriptionManager = require('../logic/SubscriptionManager')
 const MessageBuffer = require('../helpers/MessageBuffer')
 const DataMessage = require('../messages/DataMessage')
-const { getAddress, getIdShort } = require('../util')
 const StreamManager = require('./StreamManager')
 
 const events = Object.freeze({
@@ -70,10 +69,10 @@ class Node extends EventEmitter {
 
     onConnectedToTracker(tracker) {
         if (this._isTracker(tracker)) {
-            this.debug('connected to tracker %s', getIdShort(tracker))
+            this.debug('connected to tracker %s', this.peerBook.getShortId(tracker))
             this.trackers.set(tracker, tracker)
             this._sendStatus(tracker)
-            this.debug('requesting more peers from tracker %s', getIdShort(tracker))
+            this.debug('requesting more peers from tracker %s', this.peerBook.getShortId(tracker))
             this.requestMorePeers()
             this._handlePendingSubscriptions()
         }
@@ -93,9 +92,9 @@ class Node extends EventEmitter {
         const repeaterAddresses = streamMessage.getRepeaterAddresses()
 
         this.streams.markOtherNodeAsLeader(streamId, leaderAddress)
-        this.debug('stream %s leader set to %s', streamId, getIdShort(leaderAddress))
+        this.debug('stream %s leader set to %s', streamId, this.peerBook.getShortId(leaderAddress))
         this.streams.markRepeaterNodes(streamId, repeaterAddresses)
-        this.debug('stream %s repeater nodes set to %j', streamId, repeaterAddresses.map((a) => getIdShort(a)))
+        this.debug('stream %s repeater nodes set to %j', streamId, repeaterAddresses.map((a) => this.peerBook.getShortId(a)))
 
         this._handlePossiblePendingSubscription(streamId)
         this._handleBufferedMessages(streamId)
@@ -144,7 +143,7 @@ class Node extends EventEmitter {
                 number,
                 previousNumber
             })
-            this.debug('ask tracker %s who is responsible for stream %s', getIdShort(tracker), streamId)
+            this.debug('ask tracker %s who is responsible for stream %s', this.peerBook.getShortId(tracker), streamId)
             this.protocols.trackerNode.requestStreamInfo(tracker, streamId)
         }
     }
@@ -166,8 +165,8 @@ class Node extends EventEmitter {
     }
 
     onSubscribeRequest(subscribeMessage) {
-        this.subscribers.addSubscriber(subscribeMessage.getStreamId(), getAddress(subscribeMessage.getSource()))
-        this.debug('node %s added as a subscriber for stream %s', getIdShort(subscribeMessage.getSource()), subscribeMessage.getStreamId())
+        this.subscribers.addSubscriber(subscribeMessage.getStreamId(), subscribeMessage.getSource())
+        this.debug('node %s added as a subscriber for stream %s', this.peerBook.getShortId(subscribeMessage.getSource()), subscribeMessage.getStreamId())
     }
 
     onUnsubscribeRequest(unsubscribeMessage) {
@@ -193,7 +192,7 @@ class Node extends EventEmitter {
         } else if (this.streams.isAnyRepeaterKnownFor(streamId)) {
             const repeaterAddresses = this.streams.getRepeatersFor(streamId)
             this.debug('stream %s is known; sending subscribe requests to repeaters %j', streamId,
-                repeaterAddresses.map((a) => getIdShort(a)))
+                repeaterAddresses.map((a) => this.peerBook.getShortId(a)))
             repeaterAddresses.forEach((address) => {
                 this.protocols.nodeToNode.sendSubscribe(address, streamId)
             })
@@ -236,15 +235,15 @@ class Node extends EventEmitter {
     }
 
     _sendStatus(tracker) {
-        this.debug('sending status to tracker %s', getIdShort(tracker))
+        this.debug('sending status to tracker %s', this.peerBook.getShortId(tracker))
         this.protocols.trackerNode.sendStatus(tracker, this._getStatus())
     }
 
     onNodeDisconnected(node) {
         if (this._isNode(node)) {
-            const nodeAddress = getAddress(node)
+            const nodeAddress = node
             this.subscribers.removeSubscriberFromAllStreams(nodeAddress)
-            this.debug('removed all subscriptions of node %s', getIdShort(node))
+            this.debug('removed all subscriptions of node %s', this.peerBook.getShortId(node))
         }
     }
 

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -1,5 +1,4 @@
 const { EventEmitter } = require('events')
-const uuidv4 = require('uuid/v4')
 const createDebug = require('debug')
 const NodeToNode = require('../protocol/NodeToNode')
 const TrackerNode = require('../protocol/TrackerNode')
@@ -36,7 +35,7 @@ class Node extends EventEmitter {
             this.emit(events.MESSAGE_DELIVERY_FAILED, streamId)
         })
 
-        this.id = id || uuidv4()
+        this.id = id
         this.trackers = new Map()
 
         this.protocols = {

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -17,7 +17,7 @@ const events = Object.freeze({
 })
 
 class Node extends EventEmitter {
-    constructor(id, trackerNode, nodeToNode) {
+    constructor(id, peerBook, trackerNode, nodeToNode) {
         super()
 
         this.nodeRequestInterval = null
@@ -36,6 +36,7 @@ class Node extends EventEmitter {
         })
 
         this.id = id
+        this.peerBook = peerBook
         this.trackers = new Map()
 
         this.protocols = {

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -5,12 +5,13 @@ const TrackerServer = require('../protocol/TrackerServer')
 const { getPeersTopology } = require('../helpers/TopologyStrategy')
 
 module.exports = class Tracker extends EventEmitter {
-    constructor(id, trackerServer) {
+    constructor(id, peerBook, trackerServer) {
         super()
 
         this.nodes = new Map()
 
         this.id = id
+        this.peerBook = peerBook
         this.protocols = {
             trackerServer
         }

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -1,6 +1,5 @@
 const { EventEmitter } = require('events')
 const createDebug = require('debug')
-const { getAddress, getIdShort } = require('../util')
 const TrackerServer = require('../protocol/TrackerServer')
 const { getPeersTopology } = require('../helpers/TopologyStrategy')
 
@@ -26,24 +25,24 @@ module.exports = class Tracker extends EventEmitter {
     }
 
     sendListOfNodes(node) {
-        const listOfNodes = getPeersTopology([...this.nodes.keys()], getAddress(node))
+        const listOfNodes = getPeersTopology([...this.nodes.keys()], node)
 
         if (listOfNodes.length) {
-            this.debug('sending list of %d nodes to %s', listOfNodes.length, getIdShort(node))
+            this.debug('sending list of %d nodes to %s', listOfNodes.length, this.peerBook.getShortId(node))
             this.protocols.trackerServer.sendNodeList(node, listOfNodes)
         } else {
-            this.debug('no available nodes to send to %s', getIdShort(node))
+            this.debug('no available nodes to send to %s', this.peerBook.getShortId(node))
         }
     }
 
     processNodeStatus(statusMessage) {
-        this.debug('received from %s status %s', getIdShort(statusMessage.getSource()), JSON.stringify(statusMessage.getStatus()))
+        this.debug('received from %s status %s', this.peerBook.getShortId(statusMessage.getSource()), JSON.stringify(statusMessage.getStatus()))
         this.nodes.set(statusMessage.getSource(), statusMessage.getStatus())
     }
 
     onNodeDisconnected(node) {
-        this.debug('removing node %s from tracker node list', getIdShort(node))
-        this.nodes.delete(getAddress(node))
+        this.debug('removing node %s from tracker node list', this.peerBook.getShortId(node))
+        this.nodes.delete(node)
     }
 
     sendStreamInfo(streamMessage) {
@@ -68,13 +67,16 @@ module.exports = class Tracker extends EventEmitter {
 
         let selectedRepeaters
         if (leaderNode === null) {
-            leaderNode = getAddress(source)
+            leaderNode = source
             selectedRepeaters = [leaderNode]
-            this.debug('stream %s not found; assigning %s as leader', streamId, getIdShort(source))
+            this.debug('stream %s not found; assigning %s as leader', streamId, this.peerBook.getShortId(source))
         } else {
             selectedRepeaters = getPeersTopology(repeaterNodes, source)
             this.debug('stream %s found; responding to %s with leader %s and repeaters %j',
-                streamId, getIdShort(source), getIdShort(leaderNode), selectedRepeaters.map((s) => getIdShort(s)))
+                streamId,
+                this.peerBook.getShortId(source),
+                this.peerBook.getShortId(leaderNode),
+                selectedRepeaters.map((s) => this.peerBook.getShortId(s)))
         }
 
         this.protocols.trackerServer.sendStreamInfo(source, streamId, leaderNode, selectedRepeaters)

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -1,5 +1,4 @@
 const { EventEmitter } = require('events')
-const uuidv4 = require('uuid/v4')
 const createDebug = require('debug')
 const { getAddress, getIdShort } = require('../util')
 const TrackerServer = require('../protocol/TrackerServer')
@@ -11,7 +10,7 @@ module.exports = class Tracker extends EventEmitter {
 
         this.nodes = new Map()
 
-        this.id = id || uuidv4()
+        this.id = id
         this.protocols = {
             trackerServer
         }

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -1,7 +1,6 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('streamr:protocol:node-node')
 const encoder = require('../helpers/MessageEncoder')
-const { getAddress } = require('../util')
 const EndpointListener = require('./EndpointListener')
 
 const events = Object.freeze({
@@ -43,7 +42,7 @@ class NodeToNode extends EventEmitter {
     }
 
     getAddress() {
-        return getAddress(this.endpoint.getAddress())
+        return this.endpoint.getAddress()
     }
 
     stop(cb) {

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -1,6 +1,5 @@
 const { EventEmitter } = require('events')
 const debug = require('debug')('streamr:protocol:tracker-node')
-const { getAddress } = require('../util')
 const encoder = require('../helpers/MessageEncoder')
 const EndpointListener = require('./EndpointListener')
 
@@ -47,7 +46,7 @@ class TrackerNode extends EventEmitter {
                 break
 
             case encoder.STREAM:
-                if (message.getLeaderAddress() === getAddress(this.endpoint.getAddress())) {
+                if (message.getLeaderAddress() === this.endpoint.getAddress()) {
                     this.emit(events.STREAM_ASSIGNED, message.getStreamId())
                 } else {
                     this.emit(events.STREAM_INFO_RECEIVED, message)

--- a/src/util.js
+++ b/src/util.js
@@ -8,15 +8,7 @@ const callbackToPromise = (method, ...args) => {
 
 const BOOTNODES = require('../bootstrapNodes.json').map((node) => node.path)
 
-// TODO remove both
-const getAddress = (peerInfo) => peerInfo
-
-const getIdShort = (input) => input
-// (input.length > 15 ? input.slice(-4) : input)
-
 module.exports = {
     callbackToPromise,
-    getAddress,
-    getIdShort,
     BOOTNODES
 }

--- a/test/integration/message-propagation.test.js
+++ b/test/integration/message-propagation.test.js
@@ -18,14 +18,14 @@ describe('message propagation in network', () => {
     const BOOTNODES = []
 
     beforeAll(async () => {
-        tracker = await startTracker(LOCALHOST, 33300)
+        tracker = await startTracker(LOCALHOST, 33300, 'tracker')
         BOOTNODES.push(tracker.getAddress())
 
         await Promise.all([
-            startNode('127.0.0.1', 33312, null),
-            startNode('127.0.0.1', 33313, null),
-            startNode('127.0.0.1', 33314, null),
-            startNode('127.0.0.1', 33315, null)
+            startNode('127.0.0.1', 33312, 'node-1'),
+            startNode('127.0.0.1', 33313, 'node-2'),
+            startNode('127.0.0.1', 33314, 'node-3'),
+            startNode('127.0.0.1', 33315, 'node-4')
         ]).then((res) => {
             [n1, n2, n3, n4] = res
             n1.setBootstrapTrackers(BOOTNODES)

--- a/test/integration/ws-endpoint.test.js
+++ b/test/integration/ws-endpoint.test.js
@@ -46,4 +46,37 @@ describe('create five endpoints and init connection between them', () => {
             await endpoints[i].stop(console.log(`closing ${i} endpoint`))
         }
     })
+
+    it('address and custom headers are exchanged between connecting endpoints', async () => {
+        const endpointOne = await startEndpoint(LOCALHOST, 30695, {
+            'my-identity': 'endpoint-1'
+        })
+        const endpointTwo = await startEndpoint(LOCALHOST, 30696, {
+            'my-identity': 'endpoint-2'
+        })
+
+        const e1 = waitForEvent(endpointOne, endpointEvents.PEER_CONNECTED)
+        const e2 = waitForEvent(endpointTwo, endpointEvents.PEER_CONNECTED)
+
+        endpointOne.connect(endpointTwo.getAddress())
+
+        const endpointOneArguments = await e1
+        const endpointTwoArguments = await e2
+
+        expect(endpointOneArguments).toEqual([
+            'ws://127.0.0.1:30696',
+            {
+                'my-identity': 'endpoint-2'
+            }
+        ])
+        expect(endpointTwoArguments).toEqual([
+            'ws://127.0.0.1:30695',
+            {
+                'my-identity': 'endpoint-1'
+            }
+        ])
+
+        await endpointOne.stop()
+        await endpointTwo.stop()
+    })
 })

--- a/test/integration/ws-endpoint.test.js
+++ b/test/integration/ws-endpoint.test.js
@@ -12,7 +12,7 @@ describe('create five endpoints and init connection between them', () => {
     it('should be able to start and stop successfully', async () => {
         for (let i = 0; i < MAX; i++) {
             // eslint-disable-next-line no-await-in-loop
-            const endpoint = await startEndpoint(LOCALHOST, 30690 + i, '', true).catch((err) => { throw err })
+            const endpoint = await startEndpoint(LOCALHOST, 30690 + i, {}).catch((err) => { throw err })
             endpoints.push(endpoint)
         }
 

--- a/test/unit/CustomHeaders.test.js
+++ b/test/unit/CustomHeaders.test.js
@@ -1,0 +1,33 @@
+const { CustomHeaders } = require('../../src/connection/WsEndpoint')
+
+test('empty custom headers works', () => {
+    const emptyHeaders = new CustomHeaders({})
+
+    expect(emptyHeaders.asObject()).toEqual({})
+    expect(emptyHeaders.asArray()).toEqual([])
+    expect(emptyHeaders.pluckCustomHeadersFromObject({
+        Authorization: 'hello world'
+    })).toEqual({})
+})
+
+test('custom headers work', () => {
+    const headers = new CustomHeaders({
+        'StreaMR-Peer-Id': 'my-ID',
+        foo: 'bar'
+    })
+
+    expect(headers.asObject()).toEqual({
+        'streamr-peer-id': 'my-ID',
+        foo: 'bar'
+    })
+    expect(headers.asArray()).toEqual([
+        'streamr-peer-id: my-ID',
+        'foo: bar'
+    ])
+    expect(headers.pluckCustomHeadersFromObject({
+        'STREAMR-PEER-ID': 'other-ID',
+        somethingCompletelyDifferent: 'shouldNotAppear',
+    })).toEqual({
+        'streamr-peer-id': 'other-ID'
+    })
+})

--- a/test/util.js
+++ b/test/util.js
@@ -6,7 +6,8 @@ const LOCALHOST = '127.0.0.1'
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const waitForEvent = (emitter, event, timeout = 20 * 1000) => pEvent(emitter, event, {
-    timeout
+    timeout,
+    multiArgs: true
 })
 
 const getPeers = (max) => Array.from(Array(max), (d, i) => 'address-' + i)


### PR DESCRIPTION
- Exchange peer id (UUID by default) and peer type (either `tracker`, `node`, or `client`) in Connection layer via WebSocket HTTP headers.
- Keep track of other peers' ids and types in `PeerBook`
- Use ids of other nodes peers in debug messages

WebSocket URLs are stilled used in logic layer in this branch. In a later branch we might want to make it so that only ids are used in logic layer.

Fixes #133 