### PR TITLE
Optimization: do not propagate to sender

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -7,6 +7,7 @@ const StreamManager = require('./StreamManager')
 
 const events = Object.freeze({
     MESSAGE_RECEIVED: 'streamr:node:message-received',
+    SUBSCRIPTION_RECEIVED: 'streamr:node:subscription-received',
     MESSAGE_DELIVERY_FAILED: 'streamr:node:message-delivery-failed'
 })
 
@@ -127,6 +128,7 @@ class Node extends EventEmitter {
         }
         this._handleBufferedMessages(streamId)
         this.debug('node %s subscribed to stream %s', source, streamId)
+        this.emit(events.SUBSCRIPTION_RECEIVED, streamId, source)
     }
 
     onUnsubscribeRequest(unsubscribeMessage) {

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -102,12 +102,13 @@ class Node extends EventEmitter {
     }
 
     _propagateMessage(dataMessage) {
+        const source = dataMessage.getSource()
         const streamId = dataMessage.getStreamId()
         const data = dataMessage.getData()
         const number = dataMessage.getNumber()
         const previousNumber = dataMessage.getPreviousNumber()
 
-        const subscribers = this.streams.getOutboundNodesForStream(streamId)
+        const subscribers = this.streams.getOutboundNodesForStream(streamId).filter((n) => n !== source)
         subscribers.forEach((subscriber) => {
             this.protocols.nodeToNode.sendData(subscriber, streamId, data, number, previousNumber)
         })

--- a/test/integration/do-not-propagate-to-sender-optimization.test.js
+++ b/test/integration/do-not-propagate-to-sender-optimization.test.js
@@ -1,0 +1,58 @@
+const { startNetworkNode, startTracker } = require('../../src/composition')
+const { callbackToPromise } = require('../../src/util')
+const Node = require('../../src/logic/Node')
+const { wait, waitForEvent, LOCALHOST, DEFAULT_TIMEOUT } = require('../util')
+
+jest.setTimeout(DEFAULT_TIMEOUT)
+
+/**
+ * This test verifies that on receiving a message, the receiver will not propagate the message to the sender as they
+ * obviously already know about the message.
+ */
+describe('optimization: do not propagate to sender', () => {
+    let tracker
+    let n1
+    let n2
+    let n3
+
+    beforeAll(async () => {
+        tracker = await startTracker(LOCALHOST, 30410, 'tracker')
+        n1 = await startNetworkNode(LOCALHOST, 30411, 'node-1')
+        n2 = await startNetworkNode(LOCALHOST, 30412, 'node-2')
+        n3 = await startNetworkNode(LOCALHOST, 30413, 'node-3')
+
+        await Promise.all([
+            n1.addBootstrapTracker(tracker.getAddress()),
+            n2.addBootstrapTracker(tracker.getAddress()),
+            n3.addBootstrapTracker(tracker.getAddress())
+        ])
+
+        // Become subscribers (one-by-one, for well connected graph)
+        n1.subscribe('stream-id', 0)
+        n2.subscribe('stream-id', 0)
+        n3.subscribe('stream-id', 0)
+
+        await waitForEvent(n1, Node.events.SUBSCRIPTION_RECEIVED)
+        await waitForEvent(n1, Node.events.SUBSCRIPTION_RECEIVED)
+        await waitForEvent(n2, Node.events.SUBSCRIPTION_RECEIVED)
+    })
+
+    afterAll(async () => {
+        await callbackToPromise(n1.stop.bind(n1))
+        await callbackToPromise(n2.stop.bind(n2))
+        await callbackToPromise(n3.stop.bind(n3))
+        await callbackToPromise(tracker.stop.bind(tracker))
+    })
+
+    // In a fully-connected network the number of duplicates should be (n-1)(n-2) instead of (n-1)^2 when not
+    // propagating received messages back to their source
+    test('total duplicates == 2 in a fully-connected network of 3 nodes', async () => {
+        n1.publish('stream-id', 0, {
+            hello: 'world'
+        }, 100, null)
+        await wait(250)
+
+        expect(n1.metrics.received.duplicates + n2.metrics.received.duplicates + n3.metrics.received.duplicates)
+            .toEqual(2)
+    })
+})


### PR DESCRIPTION
A node receiving a valid message (i.e. not a duplicate) will remove the sender of the message from the list of nodes to propagate the message further to. There is no obvious point in sending the message back to the source we already received it from.

Included is an integration test that sets up a network of 3 fully-connected nodes, sends a single message, waits for the message to propagate through the network, and then checks that the total number of duplicate messages was 2 (instead of 4).

![duplicates](https://user-images.githubusercontent.com/149682/49872890-20a82100-fe23-11e8-97c2-a93d25382162.jpg)
 