### PR TITLE
Actively maintain subscriptions to other nodes

### DIFF
--- a/src/logic/StreamManager.js
+++ b/src/logic/StreamManager.js
@@ -65,6 +65,16 @@ module.exports = class StreamManager {
         return [...this.streams.get(streamId).inboundNodes]
     }
 
+    hasOutboundNode(streamId, node) {
+        this._verifyThatIsSetUp(streamId)
+        return this.streams.get(streamId).outboundNodes.has(node)
+    }
+
+    hasInboundNode(streamId, node) {
+        this._verifyThatIsSetUp(streamId)
+        return this.streams.get(streamId).inboundNodes.has(node)
+    }
+
     _verifyThatIsSetUp(streamId) {
         if (!this.isSetUp(streamId)) {
             throw new Error(`Stream ${streamId} is not set up`)

--- a/test/unit/StreamManager.test.js
+++ b/test/unit/StreamManager.test.js
@@ -61,7 +61,6 @@ describe('StreamManager', () => {
         expect(manager.hasInboundNode('stream-id', 'node-3')).toEqual(false)
         expect(manager.hasOutboundNode('stream-id', 'node-3')).toEqual(true)
         expect(manager.hasOutboundNode('stream-id', 'node-2')).toEqual(false)
-
     })
 
     test('removing node from stream removes it from both inbound and outbound nodes', () => {

--- a/test/unit/StreamManager.test.js
+++ b/test/unit/StreamManager.test.js
@@ -56,6 +56,12 @@ describe('StreamManager', () => {
 
         expect(manager.getInboundNodesForStream('stream-id')).toEqual(['node-1', 'node-2'])
         expect(manager.getOutboundNodesForStream('stream-id')).toEqual(['node-1', 'node-3'])
+
+        expect(manager.hasInboundNode('stream-id', 'node-1')).toEqual(true)
+        expect(manager.hasInboundNode('stream-id', 'node-3')).toEqual(false)
+        expect(manager.hasOutboundNode('stream-id', 'node-3')).toEqual(true)
+        expect(manager.hasOutboundNode('stream-id', 'node-2')).toEqual(false)
+
     })
 
     test('removing node from stream removes it from both inbound and outbound nodes', () => {
@@ -69,6 +75,9 @@ describe('StreamManager', () => {
 
         expect(manager.getInboundNodesForStream('stream-id')).toEqual(['node-2'])
         expect(manager.getOutboundNodesForStream('stream-id')).toEqual(['node-3'])
+
+        expect(manager.hasInboundNode('stream-id', 'node-1')).toEqual(false)
+        expect(manager.hasOutboundNode('stream-id', 'node-1')).toEqual(false)
     })
 
     test('remove node from all streams', () => {
@@ -87,5 +96,8 @@ describe('StreamManager', () => {
         expect(manager.getInboundNodesForStream('stream-2')).toEqual(['should-not-be-removed'])
         expect(manager.getOutboundNodesForStream('stream-1')).toEqual(['should-not-be-removed'])
         expect(manager.getOutboundNodesForStream('stream-2')).toEqual([])
+
+        expect(manager.hasInboundNode('stream-1', 'node')).toEqual(false)
+        expect(manager.hasOutboundNode('stream-2', 'node')).toEqual(false)
     })
 })


### PR DESCRIPTION
Every 10 seconds a node will go through its list of streams and filter those that have less than 3 inbound nodes. It will then ask the tracker for more nodes for those streams.

The aim is to have 3 or more inbound nodes per stream whenever possible.