### PR TITLE
WsEndpoint: prevent duplicate sockets

### DIFF
--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -193,8 +193,8 @@ class WsEndpoint extends EventEmitter {
 
     _onNewConnection(ws, address, customHeaders) {
         // Handle scenario where two peers have opened a socket to each other at the same time.
-        // Second condition is a tiebreaker to avoid both peers of simulatenously disconnecting their socket,
-        // thereby leaving no condition behind.
+        // Second condition is a tiebreaker to avoid both peers of simultaneously disconnecting their socket,
+        // thereby leaving no connection behind.
         if (this.isConnected(address) && this.getAddress().localeCompare(address) === 1) {
             debug('dropped new connection with %s because an existing connection already exists', address)
             this.close(address, 'streamr:endpoint:duplicate-connection')

--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -192,6 +192,14 @@ class WsEndpoint extends EventEmitter {
     }
 
     _onNewConnection(ws, address, customHeaders) {
+        // Handle scenario where two peers have opened a socket to each other at the same time. First socket opened will
+        // be kept, second closed.
+        if (this.isConnected(address)) {
+            debug('dropped new connection with %s because an existing connection already exists', address)
+            this.close(address, 'streamr:endpoint:duplicate-connection')
+            return
+        }
+
         ws.on('message', (message) => {
             // TODO check message.type [utf8|binary]
             this.onReceive(address, message)

--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -192,9 +192,10 @@ class WsEndpoint extends EventEmitter {
     }
 
     _onNewConnection(ws, address, customHeaders) {
-        // Handle scenario where two peers have opened a socket to each other at the same time. First socket opened will
-        // be kept, second closed.
-        if (this.isConnected(address)) {
+        // Handle scenario where two peers have opened a socket to each other at the same time.
+        // Second condition is a tiebreaker to avoid both peers of simulatenously disconnecting their socket,
+        // thereby leaving no condition behind.
+        if (this.isConnected(address) && this.getAddress().localeCompare(address) === 1) {
             debug('dropped new connection with %s because an existing connection already exists', address)
             this.close(address, 'streamr:endpoint:duplicate-connection')
             return
@@ -246,5 +247,7 @@ async function startEndpoint(host, port, customHeaders) {
 
 module.exports = {
     CustomHeaders,
+    WsEndpoint,
+    startWebSocketServer,
     startEndpoint
 }

--- a/test/integration/duplicate-connections-are-closed.test.js
+++ b/test/integration/duplicate-connections-are-closed.test.js
@@ -1,0 +1,50 @@
+const { wait } = require('../util')
+const { startWebSocketServer, WsEndpoint } = require('../../src/connection/WsEndpoint')
+
+jest.setTimeout(5000)
+
+describe('duplicate connections are closed', () => {
+    let wss1
+    let wss2
+    let wsEndpoint1
+    let wsEndpoint2
+
+    beforeEach(async () => {
+        wss1 = await startWebSocketServer('127.0.0.1', 28501, {})
+        wss2 = await startWebSocketServer('127.0.0.1', 28502, {})
+        wsEndpoint1 = new WsEndpoint(wss1, {})
+        wsEndpoint2 = new WsEndpoint(wss2, {})
+    })
+
+    afterAll(async () => {
+        await wsEndpoint1.stop()
+        await wsEndpoint2.stop()
+    })
+
+    test('if two endpoints open a connection (socket) to each other concurrently, one of them should be closed', async () => {
+        let connectionsOpened = 0
+        const connectionsClosedReasons = []
+
+        wss1.on('connection', (ws) => {
+            connectionsOpened += 1
+            ws.on('close', (code, reason) => {
+                connectionsClosedReasons.push(reason)
+            })
+        })
+        wss2.on('connection', (ws) => {
+            connectionsOpened += 1
+            ws.on('close', (code, reason) => {
+                connectionsClosedReasons.push(reason)
+            })
+        })
+
+        await Promise.all([
+            wsEndpoint1.connect('ws://127.0.0.1:28502'),
+            wsEndpoint2.connect('ws://127.0.0.1:28501'),
+        ])
+        await wait(500)
+
+        expect(connectionsOpened).toEqual(2) // sanity check
+        expect(connectionsClosedReasons).toEqual(['streamr:endpoint:duplicate-connection']) // length === 1
+    })
+})


### PR DESCRIPTION
If two peers attempt to connect to each other at the same time, two sockets could be opened. Maintaining two sockets between two peers is inefficient (and not supported by the current code, which assumes at most one connection between any two peers). Added code to handle the situation by closing the 2nd socket if such a situation where to happen.

I would image this to be a very rare occurrence in reality, but it is something that pops up in our test suite because everything is run locally in the same node.js process.