### PR TITLE
Remove rate limiting from tracker

### DIFF
--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -203,7 +203,7 @@ class WsEndpoint extends EventEmitter {
         // thereby leaving no connection behind.
         if (this.isConnected(address) && this.getAddress().localeCompare(address) === 1) {
             debug('dropped new connection with %s because an existing connection already exists', address)
-            this.close(address, disconnectionReasons.DUPLICATE_SOCKET)
+            ws.close(1000, disconnectionReasons.DUPLICATE_SOCKET)
             return
         }
 

--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -5,6 +5,12 @@ const WebSocket = require('ws')
 const { disconnectionReasons } = require('../messages/messageTypes')
 const Endpoint = require('./Endpoint')
 
+class ReadyStateError extends Error {
+    constructor(readyState) {
+        super(`cannot send because socket.readyState=${readyState}`)
+    }
+}
+
 class CustomHeaders {
     constructor(headers) {
         this.headers = this._transformToObjectWithLowerCaseKeys(headers)
@@ -87,7 +93,7 @@ class WsEndpoint extends EventEmitter {
                         })
                     } else {
                         debug('sent failed because readyState of socket is %d', ws.readyState)
-                        resolve()
+                        reject(new ReadyStateError(ws.readyState))
                     }
                 } catch (e) {
                     console.error('sending to %s failed because of %s', recipientAddress, e)

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -44,7 +44,10 @@ class Node extends EventEmitter {
         this.protocols.nodeToNode.on(NodeToNode.events.SUBSCRIBE_REQUEST, (subscribeMessage) => this.onSubscribeRequest(subscribeMessage))
         this.protocols.nodeToNode.on(NodeToNode.events.UNSUBSCRIBE_REQUEST, (unsubscribeMessage) => this.onUnsubscribeRequest(unsubscribeMessage))
         this.protocols.nodeToNode.on(NodeToNode.events.NODE_DISCONNECTED, (node) => this.onNodeDisconnected(node))
-        this.on(events.NODE_SUBSCRIBED, () => this._sendStatusToAllTrackers())
+        this.on(events.NODE_SUBSCRIBED, ({ streamId }) => {
+            this._handleBufferedMessages(streamId)
+            this._sendStatusToAllTrackers()
+        })
 
         this.debug = createDebug(`streamr:logic:node:${this.id}`)
         this.debug('started %s', this.id)
@@ -152,7 +155,6 @@ class Node extends EventEmitter {
             this.streams.addInboundNode(streamId, source)
         }
 
-        this._handleBufferedMessages(streamId)
         this.debug('node %s subscribed to stream %s', source, streamId)
         this.emit(events.NODE_SUBSCRIBED, {
             streamId,
@@ -210,7 +212,6 @@ class Node extends EventEmitter {
 
             this.streams.addInboundNode(streamId, node)
             this.streams.addOutboundNode(streamId, node)
-            this._handleBufferedMessages(streamId)
 
             // TODO get prove message from node that we successfully subscribed
             this.emit(events.NODE_SUBSCRIBED, {

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -83,13 +83,20 @@ class Node extends EventEmitter {
         this.debug('received instructions for %s', streamId)
 
         await Promise.all(nodeAddresses.map(async (nodeAddress) => {
-            const node = await this.protocols.nodeToNode.connectToNode(nodeAddress)
+            let node
+            try {
+                node = await this.protocols.nodeToNode.connectToNode(nodeAddress)
+            } catch (e) {
+                this.debug('failed to connect to node at %s (%s)', nodeAddress, e)
+                return
+            }
             try {
                 await this._subscribeToStreamOnNode(node, streamId)
-                nodeIds.push(node)
             } catch (e) {
-                this.debug('failed to subscribe to %s (%s)', node, e)
+                this.debug('failed to subscribe to node %s (%s)', node, e)
+                return
             }
+            nodeIds.push(node)
         }))
 
         this.debug('connected and subscribed to %j for stream %s', nodeIds, streamId)

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -10,7 +10,6 @@ module.exports = class Tracker extends EventEmitter {
     constructor(id, trackerServer) {
         super()
         this.overlayPerStream = {} // streamKey => overlayTopology
-        this.lastTimestampPerNode = {}
 
         this.id = id
         this.protocols = {
@@ -59,12 +58,9 @@ module.exports = class Tracker extends EventEmitter {
     _formAndSendInstructions(node, streams) {
         Object.keys(streams).forEach((streamKey) => {
             const instructions = this.overlayPerStream[streamKey].formInstructions(node)
-            this.debug('sending stream %s instructions %j', streamKey, instructions)
+            this.debug('sending instructions %j for stream %s', instructions, streamKey)
             Object.entries(instructions).forEach(([nodeId, newNeighbors]) => {
-                if (this.lastTimestampPerNode[nodeId] == null || Date.now() - this.lastTimestampPerNode[nodeId] > 250) {
-                    this.lastTimestampPerNode[nodeId] = Date.now()
-                    this.protocols.trackerServer.sendInstruction(nodeId, StreamID.fromKey(streamKey), newNeighbors)
-                }
+                this.protocols.trackerServer.sendInstruction(nodeId, StreamID.fromKey(streamKey), newNeighbors)
             })
         })
     }

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -28,19 +28,13 @@ class NodeToNode extends EventEmitter {
     }
 
     sendData(receiverNodeId, messageId, previousMessageReference, payload) {
-        try {
-            const receiverNodeAddress = this.peerBook.getAddress(receiverNodeId)
-            return this.endpoint.send(receiverNodeAddress, encoder.dataMessage(messageId, previousMessageReference, payload))
-        } catch (err) {
-            return new Promise((resolve, reject) => {
-                reject(err)
-            })
-        }
+        const receiverNodeAddress = this.peerBook.getAddress(receiverNodeId)
+        return this.endpoint.send(receiverNodeAddress, encoder.dataMessage(messageId, previousMessageReference, payload))
     }
 
     sendSubscribe(receiverNodeId, streamId, leechOnly) {
         const receiverNodeAddress = this.peerBook.getAddress(receiverNodeId)
-        this.endpoint.send(receiverNodeAddress, encoder.subscribeMessage(streamId, leechOnly))
+        return this.endpoint.send(receiverNodeAddress, encoder.subscribeMessage(streamId, leechOnly))
     }
 
     sendUnsubscribe(receiverNodeId, streamId) {
@@ -50,7 +44,7 @@ class NodeToNode extends EventEmitter {
 
     disconnectFromNode(receiverNodeId, reason) {
         const receiverNodeAddress = this.peerBook.getAddress(receiverNodeId)
-        this.endpoint.close(receiverNodeAddress, reason).catch((err) => {
+        return this.endpoint.close(receiverNodeAddress, reason).catch((err) => {
             console.info(`Could not close connection ${receiverNodeAddress} because '${err}'`)
         })
     }

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -23,9 +23,7 @@ class TrackerNode extends EventEmitter {
 
     async sendStatus(trackerId, status) {
         const trackerAddress = this.peerBook.getAddress(trackerId)
-        await this.endpoint.send(trackerAddress, encoder.statusMessage(status)).catch((err) => {
-            console.error(`Could not send status to tracker ${trackerAddress} because '${err}'`)
-        })
+        return this.endpoint.send(trackerAddress, encoder.statusMessage(status))
     }
 
     onMessageReceived(message) {

--- a/test/integration/tracker-node-reconnect-instructions.test.js
+++ b/test/integration/tracker-node-reconnect-instructions.test.js
@@ -36,7 +36,7 @@ describe('Check tracker instructions to node', () => {
         await callbackToPromise(tracker.stop.bind(tracker))
     })
 
-    it('tracker should receive statuses from both nodes', async (done) => {
+    it('tracker should receive statuses from both nodes', (done) => {
         let receivedTotal = 0
         tracker.protocols.trackerServer.on(TrackerServer.events.NODE_STATUS_RECEIVED, () => {
             receivedTotal += 1

--- a/test/integration/tracker-node-reconnect-instructions.test.js
+++ b/test/integration/tracker-node-reconnect-instructions.test.js
@@ -18,7 +18,7 @@ describe('Check tracker instructions to node', () => {
     let otherNodes
     const streamId = 'stream-1'
 
-    it('init tracker and nodes, tracker receives stream info', async () => {
+    beforeAll(async () => {
         tracker = await startTracker(LOCALHOST, 30950, 'tracker')
 
         otherNodes = await Promise.all([
@@ -36,7 +36,7 @@ describe('Check tracker instructions to node', () => {
         await callbackToPromise(tracker.stop.bind(tracker))
     })
 
-    it('tracker should receive statuses from both', async (done) => {
+    it('tracker should receive statuses from both nodes', async (done) => {
         let receivedTotal = 0
         tracker.protocols.trackerServer.on(TrackerServer.events.NODE_STATUS_RECEIVED, () => {
             receivedTotal += 1
@@ -47,9 +47,16 @@ describe('Check tracker instructions to node', () => {
         })
     })
 
-    it('tracker sends empty list of nodes, so node-one will disconnect from node two', (done) => {
+    it('tracker sends empty list of nodes, so node-one will disconnect from node two', async (done) => {
+        let firstCheck = false
+        let secondCheck = false
+
         otherNodes[1].protocols.nodeToNode.endpoint.once(endpointEvents.PEER_DISCONNECTED, ({ _, reason }) => {
             expect(reason).toBe(disconnectionReasons.TRACKER_INSTRUCTION)
+            firstCheck = true
+            if (firstCheck && secondCheck) {
+                done()
+            }
         })
 
         let receivedTotal = 0
@@ -66,11 +73,17 @@ describe('Check tracker instructions to node', () => {
 
             receivedTotal += 1
             if (receivedTotal === otherNodes.length) {
-                done()
+                secondCheck = true
+                if (firstCheck && secondCheck) {
+                    done()
+                }
             }
         })
 
         // send empty list
-        tracker.protocols.trackerServer.endpoint.send(otherNodes[0].protocols.nodeToNode.getAddress(), encoder.instructionMessage(new StreamID(streamId, 0), []))
+        await tracker.protocols.trackerServer.endpoint.send(
+            otherNodes[0].protocols.nodeToNode.getAddress(),
+            encoder.instructionMessage(new StreamID(streamId, 0), [])
+        )
     })
 })


### PR DESCRIPTION
Removed "rate limiting" from tracker that limited amount of instructions sent to nodes. Ultimately problem was due to duplicate socket disconnection logic.

Added in some error handling and debug messages. Improved accuracy of existing debug messages by `await`(ing) for promises to finish before sending debug messages.