### PR TITLE
Allow previous number to be null (in any state) of DuplicateMessageDetector

### DIFF
--- a/src/logic/DuplicateMessageDetector.js
+++ b/src/logic/DuplicateMessageDetector.js
@@ -99,7 +99,7 @@ class DuplicateMessageDetector {
         for (let i = this.gaps.length - 1; i >= 0; --i) {
             const [lowerBound, upperBound] = this.gaps[i] // invariant: upperBound > lowerBound
 
-            // implies nextNumber > upperBound (would've been handled in previous iteration if gap exists)
+            // implies number > upperBound (would've been handled in previous iteration if gap exists)
             if (previousNumber.greaterThanOrEqual(upperBound)) {
                 return false
             }

--- a/src/logic/DuplicateMessageDetector.js
+++ b/src/logic/DuplicateMessageDetector.js
@@ -42,8 +42,6 @@ class NumberPair {
     }
 }
 
-const NULL_NUMBER_PAIR = new NumberPair(-Infinity, -Infinity)
-
 class GapMisMatchError extends Error {
     constructor(...args) {
         super(...args)
@@ -84,16 +82,24 @@ class DuplicateMessageDetector {
      * returns true if number has not yet been seen (i.e. is not a duplicate)
      */
     markAndCheck(previousNumber, number) {
-        if (previousNumber === null) {
-            previousNumber = NULL_NUMBER_PAIR // eslint-disable-line no-param-reassign
-        }
-        if (previousNumber.greaterThanOrEqual(number)) {
+        if (previousNumber && previousNumber.greaterThanOrEqual(number)) {
             throw new Error('pre-condition: previousNumber < number')
         }
 
         if (this.gaps.length === 0) {
             this.gaps.push([number, new NumberPair(Infinity, Infinity)])
             return true
+        }
+
+        // Handle special case where previousNumber is not provided. Only
+        // minimal duplicate detection is provided (comparing against latest
+        // known message number).
+        if (previousNumber === null) {
+            if (number.greaterThan(this.gaps[this.gaps.length - 1][0])) {
+                this.gaps[this.gaps.length - 1][0] = number
+                return true
+            }
+            return false
         }
 
         for (let i = this.gaps.length - 1; i >= 0; --i) {

--- a/test/unit/DuplicateMessageDetector.test.js
+++ b/test/unit/DuplicateMessageDetector.test.js
@@ -20,9 +20,10 @@ test('checking numbers in order introduces no new gaps', () => {
     detector.markAndCheck(null, new NumberPair(10, 0))
     expect(detector.markAndCheck(new NumberPair(10, 0), new NumberPair(20, 0))).toEqual(true)
     expect(detector.markAndCheck(new NumberPair(20, 0), new NumberPair(30, 0))).toEqual(true)
-    expect(detector.markAndCheck(new NumberPair(30, 0), new NumberPair(30, 1))).toEqual(true)
+    expect(detector.markAndCheck(null, new NumberPair(30, 1))).toEqual(true)
+    expect(detector.markAndCheck(new NumberPair(30, 1), new NumberPair(30, 5))).toEqual(true)
     const state = detector.toString()
-    expect(state).toEqual('(30|1, Infinity|Infinity]')
+    expect(state).toEqual('(30|5, Infinity|Infinity]')
 })
 
 test('skipping next expected messages creates gaps', () => {
@@ -37,6 +38,17 @@ test('skipping next expected messages creates gaps', () => {
 
     expect(detector.markAndCheck(new NumberPair(40, 10), new NumberPair(80, 20))).toEqual(true)
     expect(detector.toString()).toEqual('(10|0, 15|0], (20|0, 30|0], (40|0, 40|10], (80|20, Infinity|Infinity]')
+})
+
+test('only last gap is checked if no previous number given', () => {
+    const detector = new DuplicateMessageDetector()
+    detector.markAndCheck(null, new NumberPair(10, 0))
+    detector.markAndCheck(new NumberPair(10, 0), new NumberPair(20, 0))
+
+    expect(detector.markAndCheck(null, new NumberPair(15, 0))).toEqual(false)
+    expect(detector.markAndCheck(null, new NumberPair(30, 5))).toEqual(true)
+    const state = detector.toString()
+    expect(state).toEqual('(30|5, Infinity|Infinity]')
 })
 
 describe('gap handling', () => {
@@ -116,6 +128,16 @@ describe('duplicates return false and do not change state', () => {
 
     it('previous number touches upper bound of 2nd gap', () => {
         expect(detector.markAndCheck(new NumberPair(80, 10), new NumberPair(90, 0))).toEqual(false)
+        expect(detector.toString()).toEqual(expectedState)
+    })
+
+    it('previous number not provided, number is below last gap', () => {
+        expect(detector.markAndCheck(null, new NumberPair(80, 10))).toEqual(false)
+        expect(detector.toString()).toEqual(expectedState)
+    })
+
+    it('previous number not provided, number touches lower bound of last gap', () => {
+        expect(detector.markAndCheck(null, new NumberPair(100, 0))).toEqual(false)
         expect(detector.toString()).toEqual(expectedState)
     })
 })


### PR DESCRIPTION
Method `DuplicateMessageDetector#markAndCheck(previousNumber, number)` is used to mark a message as seen and to check whether the message has been seen before.

The assumption before was that only the first message in a streamId-producerId session would have `previousNumber = null`, the messages thereafter having it always set to refer to the previous message. This assumption was too strict, we should now assume that `previousNumber = null` at any point in time.

I updated `DuplicateMessageDetector` to work with this assumption. It provides primitive duplicate detection (based on last messageId seen) when checking a message that does not have previous number set.