### PR TITLE
OverlayTopology: discard unknown nodes

### DIFF
--- a/src/logic/OverlayTopology.js
+++ b/src/logic/OverlayTopology.js
@@ -18,8 +18,10 @@ class OverlayTopology {
     }
 
     update(nodeId, neighbors) {
-        this.nodes[nodeId] = new Set(neighbors)
-        neighbors.forEach((neighbor) => this.nodes[neighbor].add(nodeId)) // assumption: neighbor already initialized in tracker
+        const knownNeighbors = [...neighbors].filter((n) => n in this.nodes)
+
+        this.nodes[nodeId] = new Set(knownNeighbors)
+        knownNeighbors.forEach((neighbor) => this.nodes[neighbor].add(nodeId))
         Object.keys(this.nodes)
             .filter((n) => !this.nodes[nodeId].has(n))
             .forEach((n) => this.nodes[n].delete(nodeId))
@@ -27,7 +29,7 @@ class OverlayTopology {
 
     leave(nodeId) {
         if (this.nodes[nodeId] != null) {
-            this.nodes[nodeId].forEach((neighbor) => this.nodes[neighbor].delete(nodeId)) // assumption: neighbor already initialized in tracker
+            this.nodes[nodeId].forEach((neighbor) => this.nodes[neighbor].delete(nodeId))
             delete this.nodes[nodeId]
         }
     }

--- a/test/unit/OverlayTopology.test.js
+++ b/test/unit/OverlayTopology.test.js
@@ -221,3 +221,25 @@ test('forming overlay topology', () => {
         ]
     })
 })
+
+test('unknown nodes are discarded', () => {
+    const topology = new OverlayTopology(3)
+
+    topology.update('node-1', [])
+    topology.update('node-2', [])
+    topology.update('node-3', [])
+
+    topology.update('node-1', ['node-2', 'node-3', 'node-4'])
+    expect(topology.state()).toEqual({
+        'node-1': [
+            'node-2',
+            'node-3'
+        ],
+        'node-2': [
+            'node-1'
+        ],
+        'node-3': [
+            'node-1'
+        ]
+    })
+})


### PR DESCRIPTION
@mirpo discovered in emulator that in certain situations tracker will receive information about nodes that haven't yet sent their status to it. This could happen, for example, if two nodes `N1`, `N2` connect to tracker `T` and subscribe to a common stream. Then the tracker `T` goes down for a moment and comes up. In this scenario tracker `T` will receive status of either `N1` or `N2` first with the other node being unknown to tracker. 

Wrote handling for this into `OverlayTopology`. Unknown nodes will simply be discard from neighbors list.