### PR TITLE
Duplicate detection per publisherId-msgChainId

### DIFF
--- a/test/unit/StreamManager.test.js
+++ b/test/unit/StreamManager.test.js
@@ -66,20 +66,30 @@ describe('StreamManager', () => {
         }).toThrowError('Stream stream-id::0 is not set up')
     })
 
-    test('duplicate detection is per publisher', () => {
+    test('duplicate detection is per publisher, msgChainId', () => {
         manager.setUpStream(new StreamID('stream-id', 0))
         manager.markNumbersAndCheckThatIsNotDuplicate(
-            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-1', 'session-id'),
+            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-1', 'session-1'),
             new MessageReference(5, 0)
         )
 
         expect(manager.markNumbersAndCheckThatIsNotDuplicate(
-            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-1', 'session-id'),
+            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-1', 'session-1'),
             new MessageReference(5, 0)
         )).toEqual(false)
 
         expect(manager.markNumbersAndCheckThatIsNotDuplicate(
-            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-2', 'session-id'),
+            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-2', 'session-1'),
+            new MessageReference(5, 0)
+        )).toEqual(true)
+
+        expect(manager.markNumbersAndCheckThatIsNotDuplicate(
+            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-1', 'session-2'),
+            new MessageReference(5, 0)
+        )).toEqual(true)
+
+        expect(manager.markNumbersAndCheckThatIsNotDuplicate(
+            new MessageID(new StreamID('stream-id', 0), 10, 0, 'publisher-2', 'session-2'),
             new MessageReference(5, 0)
         )).toEqual(true)
     })


### PR DESCRIPTION
Fixes #195 

Perform duplicate detection per `(streamId, publisherId, msgChainId)`. This takes into account the newly added msgChainId field in https://github.com/streamr-dev/network/commit/c6c03710a6788c0f00a2f6f7ac6e35d470589407.

The effect is that if two publishers publish messages under the same stream and the same publisherId we can distinguish between them (for gap & duplicate detection) by msgChainId, which is a randomly generated sort-of "session" id. 