### PR TITLE
Unsubscribe from stream

### DIFF
--- a/src/logic/StreamManager.js
+++ b/src/logic/StreamManager.js
@@ -65,6 +65,13 @@ module.exports = class StreamManager {
         })
     }
 
+    removeStream(streamId) {
+        this._verifyThatIsSetUp(streamId)
+        const { inboundNodes, outboundNodes } = this.streams.get(streamId.key())
+        this.streams.delete(streamId.key())
+        return [...new Set([...inboundNodes, ...outboundNodes])]
+    }
+
     isSetUp(streamId) {
         return this.streams.has(streamId.key())
     }

--- a/test/integration/unsubscribe-from-stream.test.js
+++ b/test/integration/unsubscribe-from-stream.test.js
@@ -18,10 +18,8 @@ describe('node unsubscribing from a stream', () => {
         nodeA = await startNetworkNode(LOCALHOST, 30451, 'a')
         nodeB = await startNetworkNode(LOCALHOST, 30452, 'b')
 
-        await Promise.all([
-            nodeA.addBootstrapTracker(tracker.getAddress()),
-            nodeB.addBootstrapTracker(tracker.getAddress())
-        ])
+        nodeA.addBootstrapTracker(tracker.getAddress())
+        nodeB.addBootstrapTracker(tracker.getAddress())
 
         nodeA.subscribeToStreamIfHaveNotYet(s1)
         nodeB.subscribeToStreamIfHaveNotYet(s1)

--- a/test/integration/unsubscribe-from-stream.test.js
+++ b/test/integration/unsubscribe-from-stream.test.js
@@ -1,0 +1,57 @@
+const { startNetworkNode, startTracker } = require('../../src/composition')
+const { callbackToPromise } = require('../../src/util')
+const Node = require('../../src/logic/Node')
+const { wait, waitForEvent, LOCALHOST, DEFAULT_TIMEOUT } = require('../util')
+const { StreamID } = require('../../src/identifiers')
+
+jest.setTimeout(DEFAULT_TIMEOUT)
+
+describe('node unsubscribing from a stream', () => {
+    let tracker
+    let nodeA
+    let nodeB
+    const s1 = new StreamID('s', 1)
+    const s2 = new StreamID('s', 2)
+
+    beforeAll(async () => {
+        tracker = await startTracker(LOCALHOST, 30450, 'tracker')
+        nodeA = await startNetworkNode(LOCALHOST, 30451, 'a')
+        nodeB = await startNetworkNode(LOCALHOST, 30452, 'b')
+
+        await Promise.all([
+            nodeA.addBootstrapTracker(tracker.getAddress()),
+            nodeB.addBootstrapTracker(tracker.getAddress())
+        ])
+
+        nodeA.subscribeToStreamIfHaveNotYet(s1)
+        nodeB.subscribeToStreamIfHaveNotYet(s1)
+        nodeA.subscribeToStreamIfHaveNotYet(s2)
+        nodeB.subscribeToStreamIfHaveNotYet(s2)
+
+        await waitForEvent(nodeB, Node.events.NODE_SUBSCRIBED)
+        await waitForEvent(nodeA, Node.events.NODE_SUBSCRIBED)
+    })
+
+    afterAll(async () => {
+        await callbackToPromise(nodeA.stop.bind(nodeA))
+        await callbackToPromise(nodeB.stop.bind(nodeB))
+        await callbackToPromise(tracker.stop.bind(tracker))
+    })
+
+    test('node still receives data for subscribed streams thru existing connections', async () => {
+        const actual = []
+        nodeB.addMessageListener((streamId, streamPartition) => {
+            actual.push(`${streamId}::${streamPartition}`)
+        })
+
+        nodeB.unsubscribeFromStream(s2)
+        await waitForEvent(nodeA, Node.events.NODE_UNSUBSCRIBED)
+
+        nodeA.publish('s', 2, 0, 0, '', '', null, null, {}, '', 0) // s::2
+        nodeA.publish('s', 1, 0, 0, '', '', null, null, {}, '', 0) // s::1
+
+        await wait(150)
+
+        expect(actual).toEqual(['s::1'])
+    })
+})

--- a/test/unit/StreamManager.test.js
+++ b/test/unit/StreamManager.test.js
@@ -188,4 +188,30 @@ describe('StreamManager', () => {
         expect(manager.hasInboundNode(new StreamID('stream-1', 0), 'node')).toEqual(false)
         expect(manager.hasOutboundNode(new StreamID('stream-2', 0), 'node')).toEqual(false)
     })
+
+    test('remove stream', () => {
+        manager.setUpStream(new StreamID('stream-1', 0))
+        manager.setUpStream(new StreamID('stream-2', 0))
+
+        manager.addInboundNode(new StreamID('stream-1', 0), 'n1')
+        manager.addOutboundNode(new StreamID('stream-1', 0), 'n1')
+
+        manager.addInboundNode(new StreamID('stream-2', 0), 'n1')
+        manager.addOutboundNode(new StreamID('stream-2', 0), 'n1')
+
+        manager.removeStream(new StreamID('stream-1', 0))
+
+        expect(manager.isSetUp(new StreamID('stream-1', 0))).toEqual(false)
+
+        expect(manager.getStreams()).toEqual([
+            new StreamID('stream-2', 0)
+        ])
+
+        expect(manager.getStreamsWithConnections()).toEqual({
+            'stream-2::0': {
+                inboundNodes: ['n1'],
+                outboundNodes: ['n1']
+            }
+        })
+    })
 })


### PR DESCRIPTION
- Add method `unsubscribeFromStream(stream)` to Node for unsubscribing from a stream. 
- Add event `NODE_UNSUBSCRIBED` that is emitted when an unsubscribe message is received.
- Write simple test to verify that unsubscribe works (get only messages for subscribed streams, not for one that was just unsubscribed from)