### PR TITLE
Node: unsubscribe instead of disconnect based on tracker instructions

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -111,11 +111,11 @@ class Node extends EventEmitter {
         this.debug('connected and subscribed to %j for stream %s', nodeIds, streamId)
 
         const currentNodes = this.streams.getAllNodes()
-        const nodesToDisconnect = currentNodes.filter((node) => !nodeIds.includes(node))
+        const nodesToUnsubscribeFrom = currentNodes.filter((node) => !nodeIds.includes(node))
 
-        nodesToDisconnect.forEach(async (node) => {
-            await this.protocols.nodeToNode.disconnectFromNode(node, disconnectionReasons.TRACKER_INSTRUCTION)
-            this.debug('disconnected from node %s (tracker instruction)', node)
+        nodesToUnsubscribeFrom.forEach(async (node) => {
+            await this.protocols.nodeToNode.sendUnsubscribe(node, streamId)
+            this.debug('unsubscribed from node %s (tracker instruction)', node)
         })
     }
 

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -114,6 +114,7 @@ class Node extends EventEmitter {
         const nodesToUnsubscribeFrom = currentNodes.filter((node) => !nodeIds.includes(node))
 
         nodesToUnsubscribeFrom.forEach(async (node) => {
+            this.streams.removeNodeFromStream(streamId, node)
             await this.protocols.nodeToNode.sendUnsubscribe(node, streamId)
             this.debug('unsubscribed from node %s (tracker instruction)', node)
         })

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -113,10 +113,8 @@ class Node extends EventEmitter {
         const currentNodes = this.streams.getAllNodes()
         const nodesToUnsubscribeFrom = currentNodes.filter((node) => !nodeIds.includes(node))
 
-        nodesToUnsubscribeFrom.forEach(async (node) => {
-            this.streams.removeNodeFromStream(streamId, node)
-            await this.protocols.nodeToNode.sendUnsubscribe(node, streamId)
-            this.debug('unsubscribed from node %s (tracker instruction)', node)
+        nodesToUnsubscribeFrom.forEach((node) => {
+            this._unsubscribeFromStreamOnNode(node, streamId)
         })
     }
 
@@ -265,6 +263,12 @@ class Node extends EventEmitter {
                 node
             })
         }
+    }
+
+    async _unsubscribeFromStreamOnNode(node, streamId) {
+        this.streams.removeNodeFromStream(streamId, node)
+        await this.protocols.nodeToNode.sendUnsubscribe(node, streamId)
+        this.debug('unsubscribed from node %s (tracker instruction)', node)
     }
 
     onNodeDisconnected(node) {

--- a/src/messages/messageTypes.js
+++ b/src/messages/messageTypes.js
@@ -10,7 +10,6 @@ const msgTypes = {
 }
 
 const disconnectionReasons = Object.freeze({
-    TRACKER_INSTRUCTION: 'streamr:node:tracker-instruction',
     GRACEFUL_SHUTDOWN: 'streamr:node:graceful-shutdown',
     DUPLICATE_SOCKET: 'streamr:endpoint:duplicate-connection',
     NO_SHARED_STREAMS: 'streamr:node:no-shared-streams'

--- a/test/integration/tracker-node-reconnect-instructions.test.js
+++ b/test/integration/tracker-node-reconnect-instructions.test.js
@@ -52,7 +52,7 @@ describe('Check tracker instructions to node', () => {
         let secondCheck = false
 
         otherNodes[1].protocols.nodeToNode.endpoint.once(endpointEvents.PEER_DISCONNECTED, ({ _, reason }) => {
-            expect(reason).toBe(disconnectionReasons.TRACKER_INSTRUCTION)
+            expect(reason).toBe(disconnectionReasons.NO_SHARED_STREAMS)
             firstCheck = true
             if (firstCheck && secondCheck) {
                 done()


### PR DESCRIPTION
Upon receiving tracker instructions for a stream, a node will now unsubscribe instead of immediately disconnect from neighbor nodes that were not included in the instructions. This is because two nodes may be still neighbors in other shared streams.

Only when no streams are shared, will the node that receives the final unsubscribe message initiate the disconnection in `Node#onUnsubscribeRequest`. 