### PR TITLE
Node: handle failing sends in propagation

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -61,6 +61,8 @@ class Node extends EventEmitter {
                 duplicates: 0
             }
         }
+
+        this.seenButNotPropagated = new Set()
     }
 
     onConnectedToTracker(tracker) {
@@ -129,7 +131,7 @@ class Node extends EventEmitter {
 
         if (this._isReadyToPropagate(streamId)) {
             const isUnseen = this.streams.markNumbersAndCheckThatIsNotDuplicate(messageId, previousMessageReference)
-            if (isUnseen) {
+            if (isUnseen || this.seenButNotPropagated.has(messageId)) {
                 this.debug('received from %s data %s', dataMessage.getSource(), messageId)
                 this._propagateMessage(dataMessage)
             } else {
@@ -165,8 +167,18 @@ class Node extends EventEmitter {
                 this.debug('failed to propagate data %s to node %s (%s)', messageId, subscriber, e)
             }
         }))
-        this.debug('propagated data %s to %j', messageId, successfulSends)
-        this.emit(events.MESSAGE_PROPAGATED, dataMessage)
+        if (successfulSends.length >= MIN_NUM_OF_OUTBOUND_NODES_FOR_PROPAGATION) {
+            this.debug('propagated data %s to %j', messageId, successfulSends)
+            this.seenButNotPropagated.delete(messageId)
+            this.emit(events.MESSAGE_PROPAGATED, dataMessage)
+        } else {
+            // Handle scenario in which we were unable to propagate message to enough nodes. This often happens when
+            // socket.readyState=2 (closing)
+            this.debug('put %s back to buffer because could not propagated %d nodes or more',
+                messageId, MIN_NUM_OF_OUTBOUND_NODES_FOR_PROPAGATION)
+            this.seenButNotPropagated.add(messageId)
+            this.messageBuffer.put(streamId.key(), dataMessage)
+        }
     }
 
     onSubscribeRequest(subscribeMessage) {

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -167,7 +167,7 @@ class Node extends EventEmitter {
                 this.debug('failed to propagate data %s to node %s (%s)', messageId, subscriber, e)
             }
         }))
-        if (successfulSends.length >= MIN_NUM_OF_OUTBOUND_NODES_FOR_PROPAGATION) {
+        if (successfulSends.length >= Math.min(MIN_NUM_OF_OUTBOUND_NODES_FOR_PROPAGATION, subscribers.length)) {
             this.debug('propagated data %s to %j', messageId, successfulSends)
             this.seenButNotPropagated.delete(messageId)
             this.emit(events.MESSAGE_PROPAGATED, dataMessage)

--- a/test/integration/message-duplication.test.js
+++ b/test/integration/message-duplication.test.js
@@ -1,6 +1,7 @@
 const { startNetworkNode, startTracker } = require('../../src/composition')
 const { callbackToPromise } = require('../../src/util')
 const { wait, waitForEvent, LOCALHOST, DEFAULT_TIMEOUT } = require('../util')
+const Node = require('../../src/logic/Node')
 const TrackerNode = require('../../src/protocol/TrackerNode')
 
 jest.setTimeout(DEFAULT_TIMEOUT)
@@ -53,6 +54,8 @@ describe('duplicate message detection and avoidance', () => {
         contactNode.publish('stream-id', 0, 120, 0, 'publisher-id', 'session-id', 100, 0, {
             foo: 'bar'
         })
+
+        await waitForEvent(contactNode, Node.events.MESSAGE_PROPAGATED)
         await wait(2000)
     })
 


### PR DESCRIPTION
This is a quick fix. More thought or at least refactoring is necessary.

Node may fail to propagate data to other nodes if for example sockets are in closing state. Worst case scenario (that comes up in tests but not not necessarily that often in reality) is that we fail to forward message to any node.

Added logic that puts message back to buffer if it was not propagated to enough nodes. Later on another propagation of the message will be re-tried.

Partly fixes #224 but #222 is also needed. 