### PR TITLE
NetworkNode: implement unsubscribe

### DIFF
--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -52,9 +52,6 @@ module.exports = class NetworkNode extends Node {
     }
 
     unsubscribe(streamId, streamPartition) {
-        if (streamPartition !== 0) {
-            throw new Error('Stream partitions not yet supported.')
-        }
-        // TODO: do it
+        this.unsubscribeFromStream(new StreamID(streamId, streamPartition))
     }
 }


### PR DESCRIPTION
Now that `unsubscribeFromStream` was added in #209 the `unsubscribe` method of NetworkNode could finally be implemented.