### PR TITLE
L1 Resend Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@streamr/streamr-p2p-network",
-  "version": "3.0.16",
+  "version": "3.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1970,6 +1970,16 @@
         "map-cache": "^0.2.2"
       }
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2304,6 +2314,16 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "into-stream": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.0.tgz",
+      "integrity": "sha512-cbDhb8qlxKMxPBk/QxTtYg1DQ4CwXmadu7quG3B7nrJsgSncEreF2kwWKZFdnjc/lSNNIkFPsjI7SM0Cx/QXPw==",
+      "dev": true,
+      "requires": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "invariant": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-import-order": "2.1.4",
+    "into-stream": "^5.1.0",
     "jest": "^24.5.0",
     "p-event": "^4.0.0"
   }

--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -1,4 +1,7 @@
 const DataMessage = require('./messages/DataMessage')
+const ResendLastRequest = require('./messages/ResendLastRequest')
+const ResendFromRequest = require('./messages/ResendFromRequest')
+const ResendRangeRequest = require('./messages/ResendRangeRequest')
 const Node = require('./logic/Node')
 const { StreamID, MessageID, MessageReference } = require('./identifiers')
 
@@ -53,5 +56,37 @@ module.exports = class NetworkNode extends Node {
 
     unsubscribe(streamId, streamPartition) {
         this.unsubscribeFromStream(new StreamID(streamId, streamPartition))
+    }
+
+    requestResendLast(streamId, streamPartition, subId, number) {
+        this.requestResend(new ResendLastRequest(new StreamID(streamId, streamPartition), subId, number, null))
+    }
+
+    requestResendFrom(streamId, streamPartition, subId, fromTimestamp, fromSequenceNo, publisherId) {
+        this.requestResend(new ResendFromRequest(
+            new StreamID(streamId, streamPartition),
+            subId,
+            new MessageReference(fromTimestamp, fromSequenceNo),
+            publisherId,
+            null
+        ))
+    }
+
+    requestResendRange(streamId,
+        streamPartition,
+        subId,
+        fromTimestamp,
+        fromSequenceNo,
+        toTimestamp,
+        toSequenceNo,
+        publisherId) {
+        this.requestResend(new ResendRangeRequest(
+            new StreamID(streamId, streamPartition),
+            subId,
+            new MessageReference(fromTimestamp, fromSequenceNo),
+            new MessageReference(toTimestamp, toSequenceNo),
+            publisherId,
+            null
+        ))
     }
 }

--- a/src/NoOpStorage.js
+++ b/src/NoOpStorage.js
@@ -1,0 +1,27 @@
+const { Readable } = require('stream')
+
+module.exports = class NoOpStorage {
+    requestLast() {
+        const stream = new Readable({
+            objectMode: true
+        })
+        stream.push(null)
+        return stream
+    }
+
+    requestFrom() {
+        const stream = new Readable({
+            objectMode: true
+        })
+        stream.push(null)
+        return stream
+    }
+
+    requestRange() {
+        const stream = new Readable({
+            objectMode: true
+        })
+        stream.push(null)
+        return stream
+    }
+}

--- a/src/composition.js
+++ b/src/composition.js
@@ -5,6 +5,7 @@ const NodeToNode = require('./protocol/NodeToNode')
 const Tracker = require('./logic/Tracker')
 const Node = require('./logic/Node')
 const NetworkNode = require('./NetworkNode')
+const NoOpStorage = require('./NoOpStorage')
 const { startEndpoint } = require('./connection/WsEndpoint')
 const { MessageID, MessageReference, StreamID } = require('./identifiers')
 
@@ -20,25 +21,25 @@ async function startTracker(host, port, id = uuidv4()) {
     })
 }
 
-async function startNode(host, port, id = uuidv4()) {
+async function startNode(host, port, id = uuidv4(), storage = new NoOpStorage()) {
     const identity = {
         'streamr-peer-id': id,
         'streamr-peer-type': 'node'
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
+        return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint), storage)
     }).catch((err) => {
         throw err
     })
 }
 
-async function startNetworkNode(host, port, id = uuidv4()) {
+async function startNetworkNode(host, port, id = uuidv4(), storage = new NoOpStorage()) {
     const identity = {
         'streamr-peer-id': id,
         'streamr-peer-type': 'node'
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new NetworkNode(id, new TrackerNode(endpoint), new NodeToNode(endpoint))
+        return new NetworkNode(id, new TrackerNode(endpoint), new NodeToNode(endpoint), storage)
     }).catch((err) => {
         throw err
     })

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -14,7 +14,12 @@ const events = Object.freeze({
     NODE_UNSUBSCRIBED: 'streamr:node:node-unsubscribed',
     NODE_DISCONNECTED: 'streamr:node:node-disconnected',
     SUBSCRIPTION_REQUEST: 'streamr:node:subscription-received',
-    MESSAGE_DELIVERY_FAILED: 'streamr:node:message-delivery-failed'
+    MESSAGE_DELIVERY_FAILED: 'streamr:node:message-delivery-failed',
+    UNICAST_RECEIVED: 'streamr:node:unicast-received',
+    RESPONSE_NO_RESEND: 'streamr:node:resend-response-no-resend',
+    RESPONSE_RESENDING: 'streamr:node:resend-response-resending',
+    RESPONSE_RESENT: 'streamr:node:resend-response-resent'
+
 })
 
 const MIN_NUM_OF_OUTBOUND_NODES_FOR_PROPAGATION = 1
@@ -33,6 +38,7 @@ class Node extends EventEmitter {
             this.emit(events.MESSAGE_DELIVERY_FAILED, streamId)
         })
         this.resendHandler = new ResendHandler(storage)
+        this._bindResendHandlerEventsToNodeEvents()
 
         this.id = id
         this.trackers = new Set()
@@ -327,6 +333,44 @@ class Node extends EventEmitter {
             clearInterval(this.connectToBoostrapTrackersInterval)
             this.connectToBoostrapTrackersInterval = null
         }
+    }
+
+    _bindResendHandlerEventsToNodeEvents() {
+        this.resendHandler.on(ResendHandler.events.NO_RESEND, (args) => {
+            const { source, ...restOfArgs } = args
+            if (source === null) {
+                this.emit(events.RESPONSE_NO_RESEND, restOfArgs)
+            } else {
+                throw new Error('L2 resend not yet implemented.')
+            }
+        })
+        this.resendHandler.on(ResendHandler.events.RESENDING, (args) => {
+            const { source, ...restOfArgs } = args
+            if (source === null) {
+                this.emit(events.RESPONSE_RESENDING, restOfArgs)
+            } else {
+                throw new Error('L2 resend not yet implemented.')
+            }
+        })
+        this.resendHandler.on(ResendHandler.events.RESENT, (args) => {
+            const { source, ...restOfArgs } = args
+            if (source === null) {
+                this.emit(events.RESPONSE_RESENT, restOfArgs)
+            } else {
+                throw new Error('L2 resend not yet implemented.')
+            }
+        })
+        this.resendHandler.on(ResendHandler.events.UNICAST, (args) => {
+            const { source, ...restOfArgs } = args
+            if (source === null) {
+                this.emit(events.UNICAST_RECEIVED, restOfArgs)
+            } else {
+                throw new Error('L2 resend not yet implemented.')
+            }
+        })
+        this.resendHandler.on(ResendHandler.events.ERROR, (args) => {
+            console.error(args)
+        })
     }
 }
 

--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -1,0 +1,127 @@
+const { EventEmitter } = require('events')
+const ResendLastRequest = require('../messages/ResendLastRequest')
+const ResendFromRequest = require('../messages/ResendFromRequest')
+const ResendRangeRequest = require('../messages/ResendRangeRequest')
+const { MessageID, MessageReference } = require('../identifiers')
+
+const events = Object.freeze({
+    NO_RESEND: 'streamr:resendHandler:no-resend',
+    RESENDING: 'streamr:resendHandler:resending',
+    RESENT: 'streamr:resendHandler:resent',
+    UNICAST: 'streamr:resendHandler:unicast',
+    ERROR: 'streamr:resendHandler:error'
+})
+
+class ResendHandler extends EventEmitter {
+    constructor(storage) {
+        super()
+        if (storage == null) {
+            throw new Error('storage not given')
+        }
+        this.storage = storage
+    }
+
+    handleRequest(request) {
+        const storageStream = this._getStorageStream(request)
+        this._attachEventEmittingListeners(storageStream, request)
+    }
+
+    _getStorageStream(request) {
+        const { id, partition } = request.getStreamId()
+
+        if (request instanceof ResendLastRequest) {
+            return this.storage.requestLast(
+                id,
+                partition,
+                request.getNumberLast()
+            )
+        }
+        if (request instanceof ResendFromRequest) {
+            const fromMsgRef = request.getFromMsgRef()
+            return this.storage.requestFrom(
+                id,
+                partition,
+                fromMsgRef.timestamp,
+                fromMsgRef.sequenceNo,
+                request.getPublisherId()
+            )
+        }
+        if (request instanceof ResendRangeRequest) {
+            const fromMsgRef = request.getFromMsgRef()
+            const toMsgRef = request.getToMsgRef()
+            return this.storage.requestRange(
+                id,
+                partition,
+                fromMsgRef.timestamp,
+                fromMsgRef.sequenceNo,
+                toMsgRef.timestamp,
+                toMsgRef.sequenceNo,
+                request.getPublisherId()
+            )
+        }
+        throw new Error(`unknown resend request ${request}`)
+    }
+
+    _attachEventEmittingListeners(storageStream, request) {
+        const streamId = request.getStreamId()
+        const subId = request.getSubId()
+        const source = request.getSource()
+
+        let numOfMessages = 0
+
+        storageStream.once('data', () => {
+            this.emit(events.RESENDING, {
+                streamId,
+                subId,
+                source
+            })
+        })
+
+        storageStream.on('data', () => {
+            numOfMessages += 1
+        })
+
+        storageStream.on('data', ({
+            timestamp,
+            sequenceNo,
+            publisherId,
+            msgChainId,
+            previousTimestamp,
+            previousSequenceNo,
+            data,
+            signature,
+            signatureType
+        }) => {
+            this.emit(events.UNICAST, {
+                messageId: new MessageID(streamId, timestamp, sequenceNo, publisherId, msgChainId),
+                previousMessageReference: previousTimestamp != null ? new MessageReference(previousTimestamp, previousSequenceNo) : null,
+                data,
+                signature,
+                signatureType,
+                subId,
+                source
+            })
+        })
+
+        storageStream.on('end', () => {
+            this.emit(numOfMessages === 0 ? events.NO_RESEND : events.RESENT, {
+                streamId,
+                subId,
+                source
+            })
+        })
+
+        storageStream.on('error', (error) => {
+            this.emit(events.ERROR, {
+                streamId,
+                subId,
+                error,
+                source
+            })
+        })
+    }
+}
+
+ResendHandler.events = events
+
+module.exports = ResendHandler

--- a/test/integration/l1-resend-requests.test.js
+++ b/test/integration/l1-resend-requests.test.js
@@ -1,0 +1,105 @@
+const intoStream = require('into-stream')
+const { startNetworkNode, startTracker } = require('../../src/composition')
+const { callbackToPromise } = require('../../src/util')
+const { eventsToArray, waitForEvent, LOCALHOST } = require('../util')
+const Node = require('../../src/logic/Node')
+
+jest.setTimeout(5000)
+
+/**
+ * This test verifies that a node can fulfill resend requests at L1. This means
+ * that the node
+ *      a) understands and handles resend requests,
+ *      b) can respond with resend responses, and finally,
+ *      c) uses its local storage to find messages.
+ */
+describe('resend requests are fulfilled at L1', () => {
+    let tracker
+    let contactNode
+
+    beforeAll(async () => {
+        tracker = await startTracker(LOCALHOST, 28600, 'tracker')
+        contactNode = await startNetworkNode(LOCALHOST, 28601, 'contactNode', {
+            requestLast: () => intoStream.object([
+                {
+                    timestamp: 666,
+                    sequenceNo: 50,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+                {
+                    timestamp: 756,
+                    sequenceNo: 0,
+                    previousTimestamp: 666,
+                    previousSequenceNo: 50,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+                {
+                    timestamp: 800,
+                    sequenceNo: 0,
+                    previousTimestamp: 756,
+                    previousSequenceNo: 0,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                }
+            ]),
+            requestFrom: () => intoStream.object([
+                {
+                    timestamp: 666,
+                    sequenceNo: 50,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+            ]),
+            requestRange: () => intoStream.object([]),
+        })
+        contactNode.addBootstrapTracker(tracker.getAddress())
+        contactNode.subscribe('streamId', 0)
+    })
+
+    afterAll(async () => {
+        await callbackToPromise(contactNode.stop.bind(contactNode))
+        await callbackToPromise(tracker.stop.bind(tracker))
+    })
+
+    test('requestResendLast', async () => {
+        const actualEvents = eventsToArray(contactNode, Object.values(Node.events))
+        contactNode.requestResendLast('streamId', 0, 'subId', 10)
+
+        await waitForEvent(contactNode, Node.events.RESPONSE_RESENT)
+        expect(actualEvents.map(([e]) => e)).toEqual([
+            Node.events.RESPONSE_RESENDING,
+            Node.events.UNICAST_RECEIVED,
+            Node.events.UNICAST_RECEIVED,
+            Node.events.UNICAST_RECEIVED,
+            Node.events.RESPONSE_RESENT,
+        ])
+    })
+
+    test('requestResendFrom', async () => {
+        const actualEvents = eventsToArray(contactNode, Object.values(Node.events))
+        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId')
+
+        await waitForEvent(contactNode, Node.events.RESPONSE_RESENT)
+        expect(actualEvents.map(([e]) => e)).toEqual([
+            Node.events.RESPONSE_RESENDING,
+            Node.events.UNICAST_RECEIVED,
+            Node.events.RESPONSE_RESENT,
+        ])
+    })
+
+    test('requestResendRange', async () => {
+        const actualEvents = eventsToArray(contactNode, Object.values(Node.events))
+        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId')
+
+        await waitForEvent(contactNode, Node.events.RESPONSE_NO_RESEND)
+        expect(actualEvents.map(([e]) => e)).toEqual([
+            Node.events.RESPONSE_NO_RESEND
+        ])
+    })
+})

--- a/test/unit/ResendHandler.test.js
+++ b/test/unit/ResendHandler.test.js
@@ -1,18 +1,10 @@
 const intoStream = require('into-stream')
 const ResendHandler = require('../../src/logic/ResendHandler')
-const { wait } = require('../util')
+const { eventsToArray, wait } = require('../util')
 const ResendLastRequest = require('../../src/messages/ResendLastRequest')
 const ResendFromRequest = require('../../src/messages/ResendFromRequest')
 const ResendRangeRequest = require('../../src/messages/ResendRangeRequest')
 const { MessageID, MessageReference, StreamID } = require('../../src/identifiers')
-
-function eventsToArray(emitter, events) {
-    const array = []
-    events.forEach((e) => {
-        emitter.on(e, (...args) => array.push([e, ...args]))
-    })
-    return array
-}
 
 describe('ResendHandler', () => {
     let storage

--- a/test/unit/ResendHandler.test.js
+++ b/test/unit/ResendHandler.test.js
@@ -1,0 +1,210 @@
+const intoStream = require('into-stream')
+const ResendHandler = require('../../src/logic/ResendHandler')
+const { wait } = require('../util')
+const ResendLastRequest = require('../../src/messages/ResendLastRequest')
+const ResendFromRequest = require('../../src/messages/ResendFromRequest')
+const ResendRangeRequest = require('../../src/messages/ResendRangeRequest')
+const { MessageID, MessageReference, StreamID } = require('../../src/identifiers')
+
+function eventsToArray(emitter, events) {
+    const array = []
+    events.forEach((e) => {
+        emitter.on(e, (...args) => array.push([e, ...args]))
+    })
+    return array
+}
+
+describe('ResendHandler', () => {
+    let storage
+    let resendHandler
+
+    beforeEach(async () => {
+        storage = {}
+        resendHandler = new ResendHandler(storage)
+    })
+
+    test('on receiving ResendLastRequest, storage#requestLast is invoked', async () => {
+        storage.requestLast = jest.fn()
+            .mockReturnValueOnce(intoStream.object([]))
+
+        resendHandler.handleRequest(new ResendLastRequest(new StreamID('streamId', 0), 'subId', 10))
+
+        expect(storage.requestLast.mock.calls).toEqual([
+            ['streamId', 0, 10]
+        ])
+    })
+
+    test('on receiving ResendFromRequest, storage#requestFrom is invoked', async () => {
+        storage.requestFrom = jest.fn()
+            .mockReturnValueOnce(intoStream.object([]))
+
+        resendHandler.handleRequest(new ResendFromRequest(
+            new StreamID('streamId', 0),
+            'subId',
+            new MessageReference(1555555555555, 0),
+            'publisherId'
+        ))
+
+        expect(storage.requestFrom.mock.calls).toEqual([
+            ['streamId', 0, 1555555555555, 0, 'publisherId']
+        ])
+    })
+
+    test('on receiving ResendRangeRequest, storage#requestRange is invoked', async () => {
+        storage.requestRange = jest.fn()
+            .mockReturnValueOnce(intoStream.object([]))
+
+        resendHandler.handleRequest(new ResendRangeRequest(
+            new StreamID('streamId', 0),
+            'subId',
+            new MessageReference(1555555555555, 0),
+            new MessageReference(1555555555555, 1000),
+            'publisherId'
+        ))
+
+        expect(storage.requestRange.mock.calls).toEqual([
+            ['streamId', 0, 1555555555555, 0, 1555555555555, 1000, 'publisherId']
+        ])
+    })
+
+    // All three resend request types share the same response logic so we only test for one of them (ResendLastRequest).
+    describe('after receiving resend request', () => {
+        let events
+        let doRequest
+
+        beforeEach(() => {
+            events = eventsToArray(resendHandler, Object.values(ResendHandler.events))
+            doRequest = async () => {
+                resendHandler.handleRequest(new ResendLastRequest(new StreamID('streamId', 0), 'subId', 10, 'source'))
+
+                // Wait for 5 events
+                for (let i = 0; i < 5; ++i) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await wait(0)
+                }
+            }
+        })
+
+        test('if storage data is empty, emits NO_RESEND', async () => {
+            storage.requestLast = jest.fn()
+                .mockReturnValueOnce(intoStream.object([]))
+
+            await doRequest()
+
+            expect(events).toEqual([
+                [
+                    ResendHandler.events.NO_RESEND,
+                    {
+                        source: 'source',
+                        streamId: new StreamID('streamId', 0),
+                        subId: 'subId'
+                    }
+                ]
+            ])
+        })
+
+        test('if storage data has data, emits RESENDING, UNICAST(s), and finally RESENT', async () => {
+            storage.requestLast = jest.fn()
+                .mockReturnValueOnce(intoStream.object([
+                    {
+                        timestamp: 2,
+                        sequenceNo: 0,
+                        publisherId: 'publisher1',
+                        msgChainId: 'msgChainId',
+                        previousTimestamp: 1,
+                        previousSequenceNo: 999,
+                        data: {
+                            hello: 'world'
+                        },
+                        signature: 'signature',
+                        signatureType: 1
+                    },
+                    {
+                        timestamp: 515,
+                        sequenceNo: 0,
+                        publisherId: 'publisher2',
+                        msgChainId: 'msgChainId',
+                        data: {
+                            hi: 'world'
+                        },
+                        signature: 'signature',
+                        signatureType: 1
+                    },
+                    {
+                        timestamp: 5005,
+                        sequenceNo: 0,
+                        publisherId: 'publisher3',
+                        msgChainId: 'msgChainId',
+                        data: {
+                            yo: 'world'
+                        },
+                        signature: '',
+                        signatureType: 2
+                    },
+                ]))
+
+            await doRequest()
+
+            expect(events).toEqual([
+                [
+                    ResendHandler.events.RESENDING,
+                    {
+                        source: 'source',
+                        streamId: new StreamID('streamId', 0),
+                        subId: 'subId'
+                    }
+                ],
+                [
+                    ResendHandler.events.UNICAST,
+                    {
+                        messageId: new MessageID(new StreamID('streamId', 0), 2, 0, 'publisher1', 'msgChainId'),
+                        previousMessageReference: new MessageReference(1, 999),
+                        data: {
+                            hello: 'world'
+                        },
+                        signature: 'signature',
+                        signatureType: 1,
+                        subId: 'subId',
+                        source: 'source'
+                    }
+                ],
+                [
+                    ResendHandler.events.UNICAST,
+                    {
+                        messageId: new MessageID(new StreamID('streamId', 0), 515, 0, 'publisher2', 'msgChainId'),
+                        previousMessageReference: null,
+                        data: {
+                            hi: 'world'
+                        },
+                        signature: 'signature',
+                        signatureType: 1,
+                        subId: 'subId',
+                        source: 'source'
+                    }
+                ],
+                [
+                    ResendHandler.events.UNICAST,
+                    {
+                        messageId: new MessageID(new StreamID('streamId', 0), 5005, 0, 'publisher3', 'msgChainId'),
+                        previousMessageReference: null,
+                        data: {
+                            yo: 'world'
+                        },
+                        signature: '',
+                        signatureType: 2,
+                        subId: 'subId',
+                        source: 'source'
+                    }
+                ],
+                [
+                    ResendHandler.events.RESENT,
+                    {
+                        source: 'source',
+                        streamId: new StreamID('streamId', 0),
+                        subId: 'subId'
+                    }
+                ],
+            ])
+        })
+    })
+})

--- a/test/util.js
+++ b/test/util.js
@@ -12,14 +12,19 @@ const waitForEvent = (emitter, event, timeout = 20 * 1000) => pEvent(emitter, ev
 
 const getPeers = (max) => Array.from(Array(max), (d, i) => 'address-' + i)
 
-// eslint-disable-next-line max-len
-const PRIVATE_KEY = 'CAASpgkwggSiAgEAAoIBAQC2SKo/HMFZeBml1AF3XijzrxrfQXdJzjePBZAbdxqKR1Mc6juRHXij6HXYPjlAk01BhF1S3Ll4Lwi0cAHhggf457sMg55UWyeGKeUv0ucgvCpBwlR5cQ020i0MgzjPWOLWq1rtvSbNcAi2ZEVn6+Q2EcHo3wUvWRtLeKz+DZSZfw2PEDC+DGPJPl7f8g7zl56YymmmzH9liZLNrzg/qidokUv5u1pdGrcpLuPNeTODk0cqKB+OUbuKj9GShYECCEjaybJDl9276oalL9ghBtSeEv20kugatTvYy590wFlJkkvyl+nPxIH0EEYMKK9XRWlu9XYnoSfboiwcv8M3SlsjAgMBAAECggEAZtju/bcKvKFPz0mkHiaJcpycy9STKphorpCT83srBVQi59CdFU6Mj+aL/xt0kCPMVigJw8P3/YCEJ9J+rS8BsoWE+xWUEsJvtXoT7vzPHaAtM3ci1HZd302Mz1+GgS8Epdx+7F5p80XAFLDUnELzOzKftvWGZmWfSeDnslwVONkL/1VAzwKy7Ce6hk4SxRE7l2NE2OklSHOzCGU1f78ZzVYKSnS5Ag9YrGjOAmTOXDbKNKN/qIorAQ1bovzGoCwx3iGIatQKFOxyVCyO1PsJYT7JO+kZbhBWRRE+L7l+ppPER9bdLFxs1t5CrKc078h+wuUr05S1P1JjXk68pk3+kQKBgQDeK8AR11373Mzib6uzpjGzgNRMzdYNuExWjxyxAzz53NAR7zrPHvXvfIqjDScLJ4NcRO2TddhXAfZoOPVH5k4PJHKLBPKuXZpWlookCAyENY7+Pd55S8r+a+MusrMagYNljb5WbVTgN8cgdpim9lbbIFlpN6SZaVjLQL3J8TWH6wKBgQDSChzItkqWX11CNstJ9zJyUE20I7LrpyBJNgG1gtvz3ZMUQCn3PxxHtQzN9n1P0mSSYs+jBKPuoSyYLt1wwe10/lpgL4rkKWU3/m1Myt0tveJ9WcqHh6tzcAbb/fXpUFT/o4SWDimWkPkuCb+8j//2yiXk0a/T2f36zKMuZvujqQKBgC6B7BAQDG2H2B/ijofp12ejJU36nL98gAZyqOfpLJ+FeMz4TlBDQ+phIMhnHXA5UkdDapQ+zA3SrFk+6yGk9Vw4Hf46B+82SvOrSbmnMa+PYqKYIvUzR4gg34rL/7AhwnbEyD5hXq4dHwMNsIDq+l2elPjwm/U9V0gdAl2+r50HAoGALtsKqMvhv8HucAMBPrLikhXP/8um8mMKFMrzfqZ+otxfHzlhI0L08Bo3jQrb0Z7ByNY6M8epOmbCKADsbWcVre/AAY0ZkuSZK/CaOXNX/AhMKmKJh8qAOPRY02LIJRBCpfS4czEdnfUhYV/TYiFNnKRj57PPYZdTzUsxa/yVTmECgYBr7slQEjb5Onn5mZnGDh+72BxLNdgwBkhO0OCdpdISqk0F0Pxby22DFOKXZEpiyI9XYP1C8wPiJsShGm2yEwBPWXnrrZNWczaVuCbXHrZkWQogBDG3HGXNdU4MAWCyiYlyinIBpPpoAJZSzpGLmWbMWh28+RJS6AQX6KHrK1o2uw=='
+const eventsToArray = (emitter, events) => {
+    const array = []
+    events.forEach((e) => {
+        emitter.on(e, (...args) => array.push([e, ...args]))
+    })
+    return array
+}
 
 module.exports = {
+    eventsToArray,
     getPeers,
     wait,
     waitForEvent,
     DEFAULT_TIMEOUT,
     LOCALHOST,
-    PRIVATE_KEY
 }


### PR DESCRIPTION
Network now supports resend at L1, which means serving clients directly from a network node's local storage. Proxying resend requests to other nodes (L2) and to storage nodes (L3) are the next steps and come later.

## Summary of changes

- Class `ResendHandler` handles resend requests and interactions between `Node` and `Storage`.
- Object implementing `Storage` "interface" is now passed to `Node` via constructor.
- Object implementing `Storage` "interface" can be passed to `startNode` and `startNetworkNode` in composition.js. 
- `NoOpStorage` is the default (and currently only) class implementing `Storage`. As its name implies, it doesn't store anything and always returns empty streams.
- Add convenience methods to `NetworkNode` for requesting resends. Will be used by [broker](https://github.com/streamr-dev/broker) on behalf of clients.
- Made integration test `l1-resend-requests.test.js` to check that resend requests works at L1 level, end-to-end. 
