### PR TITLE
Add store method to storage

### DIFF
--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -2,13 +2,18 @@ const DataMessage = require('./messages/DataMessage')
 const ResendLastRequest = require('./messages/ResendLastRequest')
 const ResendFromRequest = require('./messages/ResendFromRequest')
 const ResendRangeRequest = require('./messages/ResendRangeRequest')
+const ResendHandler = require('./logic/ResendHandler')
 const Node = require('./logic/Node')
 const { StreamID, MessageID, MessageReference } = require('./identifiers')
 
 /*
-Convenience wrapper for broker/data-api. We can replace this with something else later.
+Convenience wrapper for building client-facing functionality. Used by broker.
  */
 module.exports = class NetworkNode extends Node {
+    constructor(id, trackerNode, nodeToNode, storage) {
+        super(id, trackerNode, nodeToNode, new ResendHandler(storage))
+    }
+
     publish(streamId,
         streamPartition,
         timestamp,

--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -12,6 +12,7 @@ Convenience wrapper for building client-facing functionality. Used by broker.
 module.exports = class NetworkNode extends Node {
     constructor(id, trackerNode, nodeToNode, storage) {
         super(id, trackerNode, nodeToNode, new ResendHandler(storage))
+        this.addMessageListener(storage.store)
     }
 
     publish(streamId,

--- a/src/NoOpStorage.js
+++ b/src/NoOpStorage.js
@@ -1,6 +1,8 @@
 const { Readable } = require('stream')
 
 module.exports = class NoOpStorage {
+    store() {}
+
     requestLast() {
         const stream = new Readable({
             objectMode: true

--- a/src/composition.js
+++ b/src/composition.js
@@ -5,6 +5,7 @@ const NodeToNode = require('./protocol/NodeToNode')
 const { peerTypes } = require('./protocol/PeerBook')
 const Tracker = require('./logic/Tracker')
 const Node = require('./logic/Node')
+const ResendHandler = require('./logic/ResendHandler')
 const NetworkNode = require('./NetworkNode')
 const NoOpStorage = require('./NoOpStorage')
 const { startEndpoint } = require('./connection/WsEndpoint')
@@ -22,13 +23,13 @@ async function startTracker(host, port, id = uuidv4(), maxNeighborsPerNode = 4) 
     })
 }
 
-async function startNode(host, port, id = uuidv4(), storage = new NoOpStorage()) {
+async function startNode(host, port, id = uuidv4(), resendHandler = new ResendHandler(new NoOpStorage())) {
     const identity = {
         'streamr-peer-id': id,
         'streamr-peer-type': peerTypes.NODE
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint), storage)
+        return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint), resendHandler)
     }).catch((err) => {
         throw err
     })

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -25,7 +25,7 @@ const events = Object.freeze({
 const MIN_NUM_OF_OUTBOUND_NODES_FOR_PROPAGATION = 1
 
 class Node extends EventEmitter {
-    constructor(id, trackerNode, nodeToNode, storage) {
+    constructor(id, trackerNode, nodeToNode, resendHandler) {
         super()
 
         this.connectToBoostrapTrackersInterval = setInterval(this._connectToBootstrapTrackers.bind(this), 5000)
@@ -37,7 +37,7 @@ class Node extends EventEmitter {
             this.debug('failed to deliver buffered messages of stream %s', streamId)
             this.emit(events.MESSAGE_DELIVERY_FAILED, streamId)
         })
-        this.resendHandler = new ResendHandler(storage)
+        this.resendHandler = resendHandler
         this._bindResendHandlerEventsToNodeEvents()
 
         this.id = id


### PR DESCRIPTION
- Add `storage#store` method to Storage interface.
- Invoke `storage#store` from NetworkNode when message has been propagated.
- Have `resendHandler` as last argument of Node constructor instead of `storage` since `storage` is not directly used by node.

Fixes #239