### PR TITLE
Speed up and fix tests

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -318,6 +318,7 @@ class Node extends EventEmitter {
 
     addBootstrapTracker(trackerAddress) {
         this.bootstrapTrackerAddresses.push(trackerAddress)
+        this._connectToBootstrapTrackers()
     }
 
     _connectToBootstrapTrackers() {

--- a/test/integration/message-duplication.test.js
+++ b/test/integration/message-duplication.test.js
@@ -1,7 +1,6 @@
 const { startNetworkNode, startTracker } = require('../../src/composition')
 const { callbackToPromise } = require('../../src/util')
-const { wait, waitForEvent, LOCALHOST, DEFAULT_TIMEOUT } = require('../util')
-const Node = require('../../src/logic/Node')
+const { waitForCondition, waitForEvent, LOCALHOST, DEFAULT_TIMEOUT } = require('../util')
 const TrackerNode = require('../../src/protocol/TrackerNode')
 
 jest.setTimeout(DEFAULT_TIMEOUT)
@@ -39,8 +38,10 @@ describe('duplicate message detection and avoidance', () => {
         otherNodes[4].subscribe('stream-id', 0)
 
         // Set up 1st test case
+        let totalMessages = 0
         numOfReceivedMessages = [0, 0, 0, 0, 0]
         const updater = (i) => () => {
+            totalMessages += 1
             numOfReceivedMessages[i] += 1
         }
         for (let i = 0; i < otherNodes.length; ++i) {
@@ -55,8 +56,7 @@ describe('duplicate message detection and avoidance', () => {
             foo: 'bar'
         })
 
-        await waitForEvent(contactNode, Node.events.MESSAGE_PROPAGATED)
-        await wait(2000)
+        await waitForCondition(() => totalMessages > 9)
     })
 
     afterAll(async () => {

--- a/test/util.js
+++ b/test/util.js
@@ -10,8 +10,8 @@ const waitForEvent = (emitter, event, timeout = 20 * 1000) => pEvent(emitter, ev
     multiArgs: true
 })
 
-const waitForCondition = (fn, timeout = 10 * 1000, retryInterval = 100) => {
-    if (fn()) {
+const waitForCondition = (conditionFn, timeout = 10 * 1000, retryInterval = 100) => {
+    if (conditionFn()) {
         return Promise.resolve()
     }
     return new Promise((resolve, reject) => {
@@ -23,7 +23,7 @@ const waitForCondition = (fn, timeout = 10 * 1000, retryInterval = 100) => {
         }, timeout)
 
         refs.interval = setInterval(() => {
-            if (fn()) {
+            if (conditionFn()) {
                 clearTimeout(refs.timeOut)
                 clearInterval(refs.interval)
                 resolve()

--- a/test/util.js
+++ b/test/util.js
@@ -10,6 +10,28 @@ const waitForEvent = (emitter, event, timeout = 20 * 1000) => pEvent(emitter, ev
     multiArgs: true
 })
 
+const waitForCondition = (fn, timeout = 10 * 1000, retryInterval = 100) => {
+    if (fn()) {
+        return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => {
+        const refs = {}
+
+        refs.timeOut = setTimeout(() => {
+            clearInterval(refs.interval)
+            reject(new Error('waitForCondition: timed out before condition became true'))
+        }, timeout)
+
+        refs.interval = setInterval(() => {
+            if (fn()) {
+                clearTimeout(refs.timeOut)
+                clearInterval(refs.interval)
+                resolve()
+            }
+        }, retryInterval)
+    })
+}
+
 const getPeers = (max) => Array.from(Array(max), (d, i) => 'address-' + i)
 
 const eventsToArray = (emitter, events) => {
@@ -25,6 +47,7 @@ module.exports = {
     getPeers,
     wait,
     waitForEvent,
+    waitForCondition,
     DEFAULT_TIMEOUT,
     LOCALHOST,
 }


### PR DESCRIPTION
- Connect to tracker immediately after adding to Node. Every integration test is taking at least 5 seconds more to run because we were waiting for the 5-second interval bootstrap connection interval to execute.
- Add test utility `waitForCondition(conditionFn, timeout, retryInterval) => Promise` to wait for a condition to become true. It will re-try every `retryInterval` until the return value of `fn()` is true or a timeout occurs. If a timeout occurs it rejects. This is good for situations where there is no good event to `await waitForEvent(...)` for but you want to avoid `await wait(..)`.
- Speed up and reduce flakiness of message-propagation.test.js and message-duplication.test.js