### PR TITLE
L2 resend requests

### DIFF
--- a/src/logic/resendStrategies.js
+++ b/src/logic/resendStrategies.js
@@ -107,10 +107,10 @@ class AskNeighborsResendStrategy {
                     this.pending[subId].responseStream.push(unicastMessage)
                     this._reSetTimeout(subId)
                 } else {
-                    throw new Error(`received unicast from non-current neighbor ${source}`)
+                    console.error(`received unicast from non-current neighbor ${source}`)
                 }
             } else {
-                throw new Error(`received unicast for unknown subId ${subId}`)
+                console.error(`received unicast for unknown subId ${subId}`)
             }
         })
         this.nodeToNode.on(NodeToNode.events.RESEND_RESPONSE, (response) => {
@@ -128,10 +128,10 @@ class AskNeighborsResendStrategy {
                         throw new Error(`unexpected response type ${response}`)
                     }
                 } else {
-                    throw new Error(`received resend response from non-current neighbor ${source}`)
+                    console.error(`received resend response from non-current neighbor ${source}`)
                 }
             } else {
-                throw new Error(`received resend response for unknown subId ${subId}`)
+                console.error(`received resend response for unknown subId ${subId}`)
             }
         })
         this.nodeToNode.on(NodeToNode.events.NODE_DISCONNECTED, (nodeId) => {

--- a/src/logic/resendStrategies.js
+++ b/src/logic/resendStrategies.js
@@ -1,8 +1,12 @@
-const { Transform } = require('stream')
+const { Readable, Transform } = require('stream')
 const ResendLastRequest = require('../messages/ResendLastRequest')
 const ResendFromRequest = require('../messages/ResendFromRequest')
 const ResendRangeRequest = require('../messages/ResendRangeRequest')
+const ResendResponseResent = require('../../src/messages/ResendResponseResent')
+const ResendResponseResending = require('../../src/messages/ResendResponseResending')
+const ResendResponseNoResend = require('../../src/messages/ResendResponseNoResend')
 const UnicastMessage = require('../../src/messages/UnicastMessage')
+const NodeToNode = require('../protocol/NodeToNode')
 const { MessageID, MessageReference } = require('../../src/identifiers')
 
 function toUnicastMessage(request) {
@@ -81,6 +85,158 @@ class StorageResendStrategy {
     }
 }
 
+/**
+ * Resend strategy that forwards resend request to neighbor nodes and then acts
+ * as a proxy in between.
+ * Often used at L2.
+ */
+class AskNeighborsResendStrategy {
+    constructor(nodeToNode, getNeighbors, maxTries = 3) {
+        this.nodeToNode = nodeToNode
+        this.getNeighbors = getNeighbors
+        this.maxTries = maxTries
+        this.pending = {}
+
+        this.nodeToNode.on(NodeToNode.events.UNICAST_RECEIVED, (unicastMessage) => {
+            const subId = unicastMessage.getSubId()
+            const source = unicastMessage.getSource()
+
+            if (this.pending[subId]) {
+                if (this.pending[subId].currentNeighbor === source) {
+                    this.pending[subId].responseStream.push(unicastMessage)
+                    this._reSetTimeout(subId)
+                } else {
+                    throw new Error(`received unicast from non-current neighbor ${source}`)
+                }
+            } else {
+                throw new Error(`received unicast for unknown subId ${subId}`)
+            }
+        })
+        this.nodeToNode.on(NodeToNode.events.RESEND_RESPONSE, (response) => {
+            const subId = response.getSubId()
+            const source = response.getSource()
+            if (this.pending[subId]) {
+                if (this.pending[subId].currentNeighbor === source) {
+                    if (response instanceof ResendResponseResent) {
+                        this._endStream(subId)
+                    } else if (response instanceof ResendResponseNoResend) {
+                        this._askNextNeighbor(subId)
+                    } else if (response instanceof ResendResponseResending) {
+                        this._reSetTimeout(subId)
+                    } else {
+                        throw new Error(`unexpected response type ${response}`)
+                    }
+                } else {
+                    throw new Error(`received resend response from non-current neighbor ${source}`)
+                }
+            } else {
+                throw new Error(`received resend response for unknown subId ${subId}`)
+            }
+        })
+        this.nodeToNode.on(NodeToNode.events.NODE_DISCONNECTED, (nodeId) => {
+            Object.entries(this.pending).forEach(([subId, { currentNeighbor }]) => {
+                if (currentNeighbor === nodeId) {
+                    this._askNextNeighbor(subId)
+                }
+            })
+        })
+    }
+
+    getResendResponseStream(request) {
+        const responseStream = new Readable({
+            objectMode: true,
+            read() {}
+        })
+
+        // L2 only works on local requests
+        if (request.getSource() === null) {
+            this.pending[request.getSubId()] = {
+                responseStream,
+                request,
+                neighborsAsked: new Set(),
+                currentNeighbor: null,
+                timeoutRef: null
+            }
+            this._askNextNeighbor(request.getSubId())
+        } else {
+            responseStream.push(null)
+        }
+
+        return responseStream
+    }
+
+    _askNextNeighbor(subId) {
+        const { request, neighborsAsked, timeoutRef } = this.pending[subId]
+
+        clearTimeout(timeoutRef)
+
+        if (neighborsAsked.size >= this.maxTries) {
+            this._endStream(subId)
+            return
+        }
+
+        const candidates = this.getNeighbors(request.getStreamId()).filter((x) => !neighborsAsked.has(x))
+        if (candidates.length === 0) {
+            this._endStream(subId)
+            return
+        }
+
+        const neighborId = candidates[0]
+
+        this._forwardRequestToNeighbor(neighborId, request)
+            .catch(() => this._askNextNeighbor(subId))
+            .then(() => {
+                neighborsAsked.add(neighborId)
+                this.pending[subId].currentNeighbor = neighborId
+                this._reSetTimeout(subId)
+            })
+    }
+
+    _endStream(subId) {
+        const { responseStream, timeoutRef } = this.pending[subId]
+        clearTimeout(timeoutRef)
+        responseStream.push(null)
+        delete this.pending[subId]
+    }
+
+    _reSetTimeout(subId) {
+        clearTimeout(this.pending[subId].timeoutRef)
+        this.pending[subId].timeoutRef = setTimeout(() => this._askNextNeighbor(subId), 10 * 1000)
+    }
+
+    _forwardRequestToNeighbor(neighborId, request) {
+        if (request instanceof ResendLastRequest) {
+            return this.nodeToNode.requestResendLast(
+                neighborId,
+                request.getStreamId(),
+                request.getSubId(),
+                request.getNumberLast()
+            )
+        }
+        if (request instanceof ResendFromRequest) {
+            return this.nodeToNode.requestResendFrom(
+                neighborId,
+                request.getStreamId(),
+                request.getSubId(),
+                request.getFromMsgRef(),
+                request.getPublisherId()
+            )
+        }
+        if (request instanceof ResendRangeRequest) {
+            return this.nodeToNode.requestResendRange(
+                neighborId,
+                request.getStreamId(),
+                request.getSubId(),
+                request.getFromMsgRef(),
+                request.getToMsgRef(),
+                request.getPublisherId()
+            )
+        }
+        throw new Error(`unknown resend request ${request}`)
+    }
+}
+
 module.exports = {
+    AskNeighborsResendStrategy,
     StorageResendStrategy
 }

--- a/src/logic/resendStrategies.js
+++ b/src/logic/resendStrategies.js
@@ -183,7 +183,7 @@ class AskNeighborsResendStrategy {
 
         const neighborId = candidates[0]
 
-        this._forwardRequestToNeighbor(neighborId, request)
+        this.nodeToNode.send(neighborId, request)
             .catch(() => this._askNextNeighbor(subId))
             .then(() => {
                 neighborsAsked.add(neighborId)
@@ -202,37 +202,6 @@ class AskNeighborsResendStrategy {
     _reSetTimeout(subId) {
         clearTimeout(this.pending[subId].timeoutRef)
         this.pending[subId].timeoutRef = setTimeout(() => this._askNextNeighbor(subId), 10 * 1000)
-    }
-
-    _forwardRequestToNeighbor(neighborId, request) {
-        if (request instanceof ResendLastRequest) {
-            return this.nodeToNode.requestResendLast(
-                neighborId,
-                request.getStreamId(),
-                request.getSubId(),
-                request.getNumberLast()
-            )
-        }
-        if (request instanceof ResendFromRequest) {
-            return this.nodeToNode.requestResendFrom(
-                neighborId,
-                request.getStreamId(),
-                request.getSubId(),
-                request.getFromMsgRef(),
-                request.getPublisherId()
-            )
-        }
-        if (request instanceof ResendRangeRequest) {
-            return this.nodeToNode.requestResendRange(
-                neighborId,
-                request.getStreamId(),
-                request.getSubId(),
-                request.getFromMsgRef(),
-                request.getToMsgRef(),
-                request.getPublisherId()
-            )
-        }
-        throw new Error(`unknown resend request ${request}`)
     }
 }
 

--- a/test/integration/l2-resend-requests.test.js
+++ b/test/integration/l2-resend-requests.test.js
@@ -1,0 +1,145 @@
+const intoStream = require('into-stream')
+const { startNetworkNode, startTracker } = require('../../src/composition')
+const { callbackToPromise } = require('../../src/util')
+const { eventsToArray, waitForEvent, wait, LOCALHOST } = require('../util')
+const Node = require('../../src/logic/Node')
+const NetworkNode = require('../../src/NetworkNode')
+
+const collectNetworkNodeEvents = (node) => eventsToArray(node, Object.values(NetworkNode.events))
+
+/**
+ * This test verifies that a node can fulfill resend requests at L2. A resend
+ * request will be sent to contactNode. Being unable to fulfill the request,
+ * it will forward it to its neighbors of which one or zero will be able to
+ * fulfill it. Meanwhile contactNode will act as a proxy in between the
+ * requesting client and neighbor nodes.
+ */
+describe('resend requests are fulfilled at L2', () => {
+    let tracker
+    let contactNode
+    let n1
+    let n2
+
+    beforeAll(async () => {
+        tracker = await startTracker(LOCALHOST, 28610, 'tracker')
+        contactNode = await startNetworkNode(LOCALHOST, 28611, 'contactNode', [{
+            store: () => {},
+            requestLast: () => intoStream.object([]),
+            requestFrom: () => intoStream.object([]),
+            requestRange: () => intoStream.object([]),
+        }])
+        n1 = await startNetworkNode(LOCALHOST, 28612, 'n1', [{
+            store: () => {},
+            requestLast: () => intoStream.object([
+                {
+                    timestamp: 666,
+                    sequenceNo: 50,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+            ]),
+            requestFrom: () => intoStream.object([]),
+            requestRange: () => intoStream.object([]),
+        }])
+        n2 = await startNetworkNode(LOCALHOST, 28613, 'n2', [{
+            store: () => {},
+            requestLast: () => intoStream.object([]),
+            requestFrom: () => intoStream.object([
+                {
+                    timestamp: 756,
+                    sequenceNo: 0,
+                    previousTimestamp: 666,
+                    previousSequenceNo: 50,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+                {
+                    timestamp: 800,
+                    sequenceNo: 0,
+                    previousTimestamp: 756,
+                    previousSequenceNo: 0,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+                {
+                    timestamp: 900,
+                    sequenceNo: 0,
+                    previousTimestamp: 800,
+                    previousSequenceNo: 0,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+                {
+                    timestamp: 512012,
+                    sequenceNo: 0,
+                    publisherId: 'publisherId2',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                }
+            ]),
+            requestRange: () => intoStream.object([]),
+        }])
+
+        contactNode.subscribe('streamId', 0)
+        n1.subscribe('streamId', 0)
+        n2.subscribe('streamId', 0)
+
+        contactNode.addBootstrapTracker(tracker.getAddress())
+        n1.addBootstrapTracker(tracker.getAddress())
+        n2.addBootstrapTracker(tracker.getAddress())
+
+        await Promise.all([
+            waitForEvent(contactNode, Node.events.NODE_SUBSCRIBED),
+            waitForEvent(n2, Node.events.NODE_SUBSCRIBED),
+            waitForEvent(n1, Node.events.NODE_SUBSCRIBED)
+        ])
+    })
+
+    afterAll(async () => {
+        await callbackToPromise(contactNode.stop.bind(contactNode))
+        await callbackToPromise(n1.stop.bind(n1))
+        await callbackToPromise(n2.stop.bind(n2))
+        await callbackToPromise(tracker.stop.bind(tracker))
+    })
+
+    test('requestResendLast', async () => {
+        const events = collectNetworkNodeEvents(contactNode)
+        contactNode.requestResendLast('streamId', 0, 'subId', 10)
+
+        await waitForEvent(contactNode, NetworkNode.events.RESENT)
+        expect(events).toEqual([
+            NetworkNode.events.RESENDING,
+            NetworkNode.events.UNICAST,
+            NetworkNode.events.RESENT,
+        ])
+    })
+
+    test('requestResendFrom', async () => {
+        const events = collectNetworkNodeEvents(contactNode)
+        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId')
+
+        await waitForEvent(contactNode, NetworkNode.events.RESENT)
+        expect(events).toEqual([
+            NetworkNode.events.RESENDING,
+            NetworkNode.events.UNICAST,
+            NetworkNode.events.UNICAST,
+            NetworkNode.events.UNICAST,
+            NetworkNode.events.UNICAST,
+            NetworkNode.events.RESENT,
+        ])
+    })
+
+    test('requestResendRange', async () => {
+        const events = collectNetworkNodeEvents(contactNode)
+        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId')
+
+        await waitForEvent(contactNode, NetworkNode.events.NO_RESEND)
+        expect(events).toEqual([
+            NetworkNode.events.NO_RESEND
+        ])
+    })
+})

--- a/test/unit/resendStrategies.test.js
+++ b/test/unit/resendStrategies.test.js
@@ -1,11 +1,18 @@
+const { EventEmitter } = require('events')
 const intoStream = require('into-stream')
-const { StorageResendStrategy } = require('../../src/logic/resendStrategies')
+const { AskNeighborsResendStrategy, StorageResendStrategy } = require('../../src/logic/resendStrategies')
 const ResendLastRequest = require('../../src/messages/ResendLastRequest')
 const ResendFromRequest = require('../../src/messages/ResendFromRequest')
 const ResendRangeRequest = require('../../src/messages/ResendRangeRequest')
-const { MessageReference, StreamID } = require('../../src/identifiers')
+const ResendResponseNoResend = require('../../src/messages/ResendResponseNoResend')
+const ResendResponseResending = require('../../src/messages/ResendResponseResending')
+const ResendResponseResent = require('../../src/messages/ResendResponseResent')
+const UnicastMessage = require('../../src/messages/UnicastMessage')
+const { wait } = require('../util')
+const { MessageID, MessageReference, StreamID } = require('../../src/identifiers')
+const NodeToNode = require('../../src/protocol/NodeToNode')
 
-describe('StorageResendStrategy', () => {
+describe('StorageResendStrategy#getResendResponseStream', () => {
     let storage
     let resendStrategy
 
@@ -53,5 +60,192 @@ describe('StorageResendStrategy', () => {
         expect(storage.requestRange.mock.calls).toEqual([
             ['streamId', 0, 1555555555555, 0, 1555555555555, 1000, 'publisherId']
         ])
+    })
+})
+
+async function streamToArray(stream) {
+    const arr = []
+    return new Promise((resolve, reject) => {
+        stream
+            .on('data', arr.push.bind(arr))
+            .on('error', reject)
+            .on('end', () => resolve(arr))
+    })
+}
+
+describe('AskNeighborsResendStrategy#getResendResponseStream', () => {
+    const TIMEOUT = 50
+    let nodeToNode
+    let getNeighbors
+    let resendStrategy
+    let request
+
+    beforeEach(async () => {
+        nodeToNode = new EventEmitter()
+        getNeighbors = jest.fn()
+        resendStrategy = new AskNeighborsResendStrategy(nodeToNode, getNeighbors, 2, TIMEOUT)
+        request = new ResendLastRequest(new StreamID('streamId', 0), 'subId', 10)
+    })
+
+    test('if given non-local request returns empty stream', async () => {
+        request = new ResendLastRequest(new StreamID('streamId', 0), 'subId', 10, 'non-local')
+        const responseStream = resendStrategy.getResendResponseStream(request)
+        const streamAsArray = await streamToArray(responseStream)
+        expect(streamAsArray).toEqual([])
+    })
+
+    test('if no neighbors available returns empty stream', async () => {
+        getNeighbors.mockReturnValueOnce([])
+        const responseStream = resendStrategy.getResendResponseStream(request)
+        const streamAsArray = await streamToArray(responseStream)
+        expect(streamAsArray).toEqual([])
+    })
+
+    describe('if neighbors available', () => {
+        beforeEach(() => {
+            getNeighbors.mockReturnValue(['neighbor-1', 'neighbor-2', 'neighbor-3'])
+        })
+
+        afterEach(() => {
+            resendStrategy.stop()
+        })
+
+        test('forwards request to first neighbor', async () => {
+            nodeToNode.send = jest.fn().mockReturnValueOnce(Promise.resolve())
+
+            resendStrategy.getResendResponseStream(request)
+
+            expect(nodeToNode.send).toBeCalledTimes(1)
+            expect(nodeToNode.send).toBeCalledWith('neighbor-1', request)
+        })
+
+        test('if forwarding request to first neighbor fails, forwards to 2nd', async () => {
+            nodeToNode.send = jest.fn()
+                .mockReturnValueOnce(Promise.reject())
+                .mockReturnValueOnce(Promise.resolve())
+
+            resendStrategy.getResendResponseStream(request)
+            await wait(0)
+
+            expect(nodeToNode.send).toBeCalledTimes(2)
+            expect(nodeToNode.send).toBeCalledWith('neighbor-1', request)
+            expect(nodeToNode.send).toBeCalledWith('neighbor-2', request)
+        })
+
+        test('if forwarding request to both neighbors fails (maxTries=2) returns empty stream', async () => {
+            nodeToNode.send = jest.fn()
+                .mockReturnValueOnce(Promise.reject())
+                .mockReturnValueOnce(Promise.reject())
+
+            const responseStream = resendStrategy.getResendResponseStream(request)
+            const streamAsArray = await streamToArray(responseStream)
+            expect(streamAsArray).toEqual([])
+        })
+
+        test('avoids forwarding request to same neighbor again', () => {
+            getNeighbors.mockClear()
+            getNeighbors.mockReturnValue(['neighbor-1', 'neighbor-1', 'neighbor-1'])
+            nodeToNode.send = jest.fn().mockReturnValue(Promise.reject())
+
+            resendStrategy.getResendResponseStream(request)
+
+            expect(nodeToNode.send).toBeCalledTimes(1)
+        })
+    })
+
+    describe('after successfully forwarding request to neighbor', () => {
+        let responseStream
+
+        beforeEach(() => {
+            getNeighbors.mockReturnValue(['neighbor-1', 'neighbor-2'])
+            nodeToNode.send = jest.fn().mockReturnValue(Promise.resolve())
+            responseStream = resendStrategy.getResendResponseStream(request)
+            expect(nodeToNode.send).toBeCalledTimes(1) // sanity check
+        })
+
+        test('if no response within timeout, move to next neighbor', (done) => {
+            setTimeout(() => {
+                expect(nodeToNode.send).toBeCalledTimes(2)
+                done()
+            }, TIMEOUT)
+        })
+
+        test('if neighbor disconnects, move to next neighbor', () => {
+            nodeToNode.emit(NodeToNode.events.NODE_DISCONNECTED, 'neighbor-1')
+            expect(nodeToNode.send).toBeCalledTimes(2)
+        })
+
+        test('if neighbor responds with ResendResponseResending, extend timeout', (done) => {
+            setTimeout(() => {
+                expect(nodeToNode.send).toBeCalledTimes(1)
+                done()
+            }, TIMEOUT)
+
+            nodeToNode.emit(NodeToNode.events.RESEND_RESPONSE,
+                new ResendResponseResending(new StreamID('streamId', 0), 'subId', 'neighbor-1'))
+        })
+
+        test('if neighbor responds with UnicastMessage, extend timeout', (done) => {
+            setTimeout(() => {
+                expect(nodeToNode.send).toBeCalledTimes(1)
+                done()
+            }, TIMEOUT)
+
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, new UnicastMessage(
+                new MessageID(new StreamID('streamId', 0), 0, 0, '', ''),
+                null,
+                {},
+                '',
+                0,
+                'subId',
+                'neighbor-1'
+            ))
+        })
+
+        test('if neighbor responds with ResendResponseNoResend, move to next neighbor', () => {
+            nodeToNode.emit(NodeToNode.events.RESEND_RESPONSE,
+                new ResendResponseNoResend(new StreamID('streamId', 0), 'subId', 'neighbor-1'))
+            expect(nodeToNode.send).toBeCalledTimes(2)
+        })
+
+        test('if neighbor responds with ResendResponseResent, returned stream is closed', async () => {
+            nodeToNode.emit(NodeToNode.events.RESEND_RESPONSE,
+                new ResendResponseResent(new StreamID('streamId', 0), 'subId', 'neighbor-1'))
+
+            await streamToArray(responseStream)
+
+            expect(nodeToNode.send).toBeCalledTimes(1) // ensure next neighbor wasn't asked
+        })
+
+        test('all UnicastMessages received from neighbor are pushed to returned stream', async () => {
+            const createUnicastMessage = (timestamp) => new UnicastMessage(
+                new MessageID(new StreamID('streamId', 0), timestamp, 0, '', ''),
+                null,
+                {},
+                '',
+                0,
+                'subId',
+                'neighbor-1'
+            )
+
+            const u1 = createUnicastMessage(0)
+            const u2 = createUnicastMessage(1000)
+            const u3 = createUnicastMessage(11000)
+            const u4 = createUnicastMessage(21000)
+            const u5 = createUnicastMessage(22000)
+
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u1)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u2)
+            await wait(10)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u3)
+            await wait(10)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u4)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u5)
+            nodeToNode.emit(NodeToNode.events.RESEND_RESPONSE,
+                new ResendResponseResent(new StreamID('streamId', 0), 'subId', 'neighbor-1'))
+
+            const streamAsArray = await streamToArray(responseStream)
+            expect(streamAsArray).toEqual([u1, u2, u3, u4, u5])
+        })
     })
 })


### PR DESCRIPTION
If a network node is unable to fulfill a resend request from its own local storages, it will use strategy `AskNeighborsResendStrategy` (L2) to forward the request to neighbor nodes and act as a proxy in between.

## Summary of changes
- New class `AskNeighborsResendStrategy` provides a resend strategy in which the resend request is forwarded to neighbors, one neighbor at a time, until the request is fulfilled by one of them or all neighbors have been exhausted or `maxTries` limit has been hit. Results from neighbor are forwarded to the requester by the asking node. Timeouts are in place in case of unresponsiveness of neighbor(s).
- `NetworkNode` is initialized with `AskNeighborsResendStrategy` as second strategy (hence the name L2)
- In class `Node`
    - resendHandler callback function for sending unicast messages extracted into private method `_unicast`
    -  in `Node#respondResend` implement sending of response messages to other nodes
-  Add method `NodeToNode#send(receiverNodeId, message)` for sending arbitrary message
- Unit test for  `AskNeighborsResendStrategy`
- Integration test for L2 resend request behavior