### PR TITLE
Add msg chain id to resend requests

### DIFF
--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -78,12 +78,13 @@ class NetworkNode extends Node {
         this.requestResend(new ResendLastRequest(new StreamID(streamId, streamPartition), subId, number, null))
     }
 
-    requestResendFrom(streamId, streamPartition, subId, fromTimestamp, fromSequenceNo, publisherId) {
+    requestResendFrom(streamId, streamPartition, subId, fromTimestamp, fromSequenceNo, publisherId, msgChainId) {
         this.requestResend(new ResendFromRequest(
             new StreamID(streamId, streamPartition),
             subId,
             new MessageReference(fromTimestamp, fromSequenceNo),
             publisherId,
+            msgChainId,
             null
         ))
     }
@@ -95,13 +96,15 @@ class NetworkNode extends Node {
         fromSequenceNo,
         toTimestamp,
         toSequenceNo,
-        publisherId) {
+        publisherId,
+        msgChainId) {
         this.requestResend(new ResendRangeRequest(
             new StreamID(streamId, streamPartition),
             subId,
             new MessageReference(fromTimestamp, fromSequenceNo),
             new MessageReference(toTimestamp, toSequenceNo),
             publisherId,
+            msgChainId,
             null
         ))
     }

--- a/src/helpers/MessageEncoder.js
+++ b/src/helpers/MessageEncoder.js
@@ -93,6 +93,7 @@ const decode = (source, message) => {
                 payload.subId,
                 MessageReference.fromObject(payload.fromMsgRef),
                 payload.publisherId,
+                payload.msgChainId,
                 source
             )
 
@@ -103,6 +104,7 @@ const decode = (source, message) => {
                 MessageReference.fromObject(payload.fromMsgRef),
                 MessageReference.fromObject(payload.toMsgRef),
                 payload.publisherId,
+                payload.msgChainId,
                 source
             )
 
@@ -183,20 +185,22 @@ module.exports = {
         subId,
         numberLast
     }),
-    resendFromRequest: (streamId, subId, fromMsgRef, publisherId) => encode(msgTypes.RESEND_FROM, {
+    resendFromRequest: (streamId, subId, fromMsgRef, publisherId, msgChainId) => encode(msgTypes.RESEND_FROM, {
         streamId: streamId.id,
         streamPartition: streamId.partition,
         subId,
         fromMsgRef,
-        publisherId
+        publisherId,
+        msgChainId
     }),
-    resendRangeRequest: (streamId, subId, fromMsgRef, toMsgRef, publisherId) => encode(msgTypes.RESEND_RANGE, {
+    resendRangeRequest: (streamId, subId, fromMsgRef, toMsgRef, publisherId, msgChainId) => encode(msgTypes.RESEND_RANGE, {
         streamId: streamId.id,
         streamPartition: streamId.partition,
         subId,
         fromMsgRef,
         toMsgRef,
-        publisherId
+        publisherId,
+        msgChainId
     }),
     resendResponseResending: (streamId, subId) => encode(msgTypes.RESEND_RESPONSE_RESENDING, {
         streamId: streamId.id,

--- a/src/logic/resendStrategies.js
+++ b/src/logic/resendStrategies.js
@@ -66,7 +66,8 @@ class StorageResendStrategy {
                 partition,
                 fromMsgRef.timestamp,
                 fromMsgRef.sequenceNo,
-                request.getPublisherId()
+                request.getPublisherId(),
+                request.getMsgChainId()
             ).pipe(toUnicastMessage(request))
         }
         if (request instanceof ResendRangeRequest) {
@@ -79,7 +80,8 @@ class StorageResendStrategy {
                 fromMsgRef.sequenceNo,
                 toMsgRef.timestamp,
                 toMsgRef.sequenceNo,
-                request.getPublisherId()
+                request.getPublisherId(),
+                request.getMsgChainId()
             ).pipe(toUnicastMessage(request))
         }
         throw new Error(`unknown resend request ${request}`)

--- a/src/messages/ResendFromRequest.js
+++ b/src/messages/ResendFromRequest.js
@@ -2,7 +2,7 @@ const { StreamID, MessageReference } = require('../identifiers')
 const { msgTypes, CURRENT_VERSION } = require('./messageTypes')
 
 module.exports = class ResendFromRequest {
-    constructor(streamId, subId, fromMsgRef, publisherId, source = null) {
+    constructor(streamId, subId, fromMsgRef, publisherId, msgChainId, source = null) {
         if (!(streamId instanceof StreamID)) {
             throw new Error(`invalid streamId: ${streamId}`)
         }
@@ -20,6 +20,7 @@ module.exports = class ResendFromRequest {
         this.subId = subId
         this.fromMsgRef = fromMsgRef
         this.publisherId = publisherId
+        this.msgChainId = msgChainId
     }
 
     getVersion() {
@@ -48,5 +49,9 @@ module.exports = class ResendFromRequest {
 
     getPublisherId() {
         return this.publisherId
+    }
+
+    getMsgChainId() {
+        return this.msgChainId
     }
 }

--- a/src/messages/ResendRangeRequest.js
+++ b/src/messages/ResendRangeRequest.js
@@ -2,7 +2,7 @@ const { StreamID, MessageReference } = require('../identifiers')
 const { msgTypes, CURRENT_VERSION } = require('./messageTypes')
 
 module.exports = class ResendRangeRequest {
-    constructor(streamId, subId, fromMsgRef, toMsgRef, publisherId, source = null) {
+    constructor(streamId, subId, fromMsgRef, toMsgRef, publisherId, msgChainId, source = null) {
         if (!(streamId instanceof StreamID)) {
             throw new Error(`invalid streamId: ${streamId}`)
         }
@@ -24,6 +24,7 @@ module.exports = class ResendRangeRequest {
         this.fromMsgRef = fromMsgRef
         this.toMsgRef = toMsgRef
         this.publisherId = publisherId
+        this.msgChainId = msgChainId
     }
 
     getVersion() {
@@ -56,5 +57,9 @@ module.exports = class ResendRangeRequest {
 
     getPublisherId() {
         return this.publisherId
+    }
+
+    getMsgChainId() {
+        return this.msgChainId
     }
 }

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -121,7 +121,8 @@ class NodeToNode extends EventEmitter {
                 message.getStreamId(),
                 message.getSubId(),
                 message.getFromMsgRef(),
-                message.getPublisherId()
+                message.getPublisherId(),
+                message.getMsgChainId()
             )
         }
         if (message instanceof ResendRangeRequest) {
@@ -131,7 +132,8 @@ class NodeToNode extends EventEmitter {
                 message.getSubId(),
                 message.getFromMsgRef(),
                 message.getToMsgRef(),
-                message.getPublisherId()
+                message.getPublisherId(),
+                message.getMsgChainId()
             )
         }
         if (message instanceof ResendResponseNoResend) {

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -68,16 +68,19 @@ class NodeToNode extends EventEmitter {
         return this.endpoint.send(receiverNodeAddress, encoder.resendLastRequest(streamId, subId, numberLast))
     }
 
-    requestResendFrom(receiverNodeId, streamId, subId, fromMsgRef, publisherId) {
-        const receiverNodeAddress = this.peerBook.getAddress(receiverNodeId)
-        return this.endpoint.send(receiverNodeAddress, encoder.resendFromRequest(streamId, subId, fromMsgRef, publisherId))
-    }
-
-    requestResendRange(receiverNodeId, streamId, subId, fromMsgRef, toMsgRef, publisherId) {
+    requestResendFrom(receiverNodeId, streamId, subId, fromMsgRef, publisherId, msgChainId) {
         const receiverNodeAddress = this.peerBook.getAddress(receiverNodeId)
         return this.endpoint.send(
             receiverNodeAddress,
-            encoder.resendRangeRequest(streamId, subId, fromMsgRef, toMsgRef, publisherId)
+            encoder.resendFromRequest(streamId, subId, fromMsgRef, publisherId, msgChainId)
+        )
+    }
+
+    requestResendRange(receiverNodeId, streamId, subId, fromMsgRef, toMsgRef, publisherId, msgChainId) {
+        const receiverNodeAddress = this.peerBook.getAddress(receiverNodeId)
+        return this.endpoint.send(
+            receiverNodeAddress,
+            encoder.resendRangeRequest(streamId, subId, fromMsgRef, toMsgRef, publisherId, msgChainId)
         )
     }
 

--- a/src/storage/MemoryStorage.js
+++ b/src/storage/MemoryStorage.js
@@ -7,7 +7,17 @@ module.exports = class MemoryStorage {
     }
 
     store({
-        streamId, streamPartition, timestamp, sequenceNo, publisherId, msgChainId, previousTimestamp, previousSequenceNo, data, signature, signatureType
+        streamId,
+        streamPartition,
+        timestamp,
+        sequenceNo,
+        publisherId,
+        msgChainId,
+        previousTimestamp,
+        previousSequenceNo,
+        data,
+        signature,
+        signatureType
     }) {
         const streamKey = this._getStreamKey(streamId, streamPartition)
 
@@ -16,7 +26,17 @@ module.exports = class MemoryStorage {
         }
 
         this.storage.get(streamKey).push({
-            streamId, streamPartition, timestamp, sequenceNo, publisherId, previousTimestamp, msgChainId, previousSequenceNo, data, signature, signatureType
+            streamId,
+            streamPartition,
+            timestamp,
+            sequenceNo,
+            publisherId,
+            previousTimestamp,
+            msgChainId,
+            previousSequenceNo,
+            data,
+            signature,
+            signatureType
         })
 
         if (this.storage.get(streamKey).length > this.maxNumberOfMessages) {
@@ -73,7 +93,7 @@ module.exports = class MemoryStorage {
         return this._createStream(filterFunc, streamId, streamPartition)
     }
 
-    requestFrom(streamId, streamPartition, fromTimestamp, fromSequenceNo = 0, publisherId = null) {
+    requestFrom(streamId, streamPartition, fromTimestamp, fromSequenceNo = 0, publisherId = null, msgChainId = null) {
         if (!Number.isInteger(fromTimestamp) || fromTimestamp <= 0) {
             throw new TypeError('fromTimestamp is not an positive integer')
         }
@@ -86,12 +106,22 @@ module.exports = class MemoryStorage {
         const filterFunc = () => Object.values(this.storage.get(streamKey)).filter((record) => {
             return (record.timestamp > fromTimestamp || (record.timestamp === fromTimestamp && record.sequenceNo >= fromSequenceNo))
                 && (record.publisherId === publisherId || publisherId === null)
+                && (record.msgChainId === msgChainId || msgChainId === null)
         })
 
         return this._createStream(filterFunc, streamId, streamPartition)
     }
 
-    requestRange(streamId, streamPartition, fromTimestamp, toTimestamp, fromSequenceNo, toSequenceNo, publisherId = null) {
+    requestRange(
+        streamId,
+        streamPartition,
+        fromTimestamp,
+        toTimestamp,
+        fromSequenceNo,
+        toSequenceNo,
+        publisherId = null,
+        msgChainId = null
+    ) {
         if (!Number.isInteger(fromTimestamp) || fromTimestamp <= 0) {
             throw new TypeError('fromTimestamp is not an positive integer')
         }
@@ -114,9 +144,10 @@ module.exports = class MemoryStorage {
 
         const streamKey = this._getStreamKey(streamId, streamPartition)
         const filterFunc = () => Object.values(this.storage.get(streamKey)).filter((record) => {
-            return ((record.timestamp > fromTimestamp || (record.timestamp === fromTimestamp && record.sequenceNo >= fromSequenceNo))
+            return (record.timestamp > fromTimestamp || (record.timestamp === fromTimestamp && record.sequenceNo >= fromSequenceNo))
                 && (record.timestamp < toTimestamp || (record.timestamp === toTimestamp && record.sequenceNo <= toSequenceNo))
-                && (record.publisherId === publisherId || publisherId === null))
+                && (record.publisherId === publisherId || publisherId === null)
+                && (record.msgChainId === msgChainId || msgChainId === null)
         })
 
         return this._createStream(filterFunc, streamId, streamPartition)

--- a/test/integration/delivery-of-messages-protocol-layer.test.js
+++ b/test/integration/delivery-of-messages-protocol-layer.test.js
@@ -143,7 +143,7 @@ describe('delivery of messages in protocol layer', () => {
 
     test('requestResendFrom is delivered', async () => {
         nodeToNode2.requestResendFrom('nodeToNode1', new StreamID('stream', 10), 'subId',
-            new MessageReference(1, 1), 'publisherId')
+            new MessageReference(1, 1), 'publisherId', 'msgChainId')
         const [msg] = await waitForEvent(nodeToNode1, NodeToNode.events.RESEND_REQUEST)
 
         expect(msg).toBeInstanceOf(ResendFromRequest)
@@ -152,11 +152,12 @@ describe('delivery of messages in protocol layer', () => {
         expect(msg.getSubId()).toEqual('subId')
         expect(msg.getFromMsgRef()).toEqual(new MessageReference(1, 1))
         expect(msg.getPublisherId()).toEqual('publisherId')
+        expect(msg.getMsgChainId()).toEqual('msgChainId')
     })
 
     test('requestResendRange is delivered', async () => {
         nodeToNode2.requestResendRange('nodeToNode1', new StreamID('stream', 10), 'subId',
-            new MessageReference(1, 1), new MessageReference(2, 2), 'publisherId')
+            new MessageReference(1, 1), new MessageReference(2, 2), 'publisherId', 'msgChainId')
         const [msg] = await waitForEvent(nodeToNode1, NodeToNode.events.RESEND_REQUEST)
 
         expect(msg).toBeInstanceOf(ResendRangeRequest)
@@ -166,6 +167,7 @@ describe('delivery of messages in protocol layer', () => {
         expect(msg.getFromMsgRef()).toEqual(new MessageReference(1, 1))
         expect(msg.getToMsgRef()).toEqual(new MessageReference(2, 2))
         expect(msg.getPublisherId()).toEqual('publisherId')
+        expect(msg.getMsgChainId()).toEqual('msgChainId')
     })
 
     test('respondResending is delivered', async () => {

--- a/test/integration/l1-resend-requests.test.js
+++ b/test/integration/l1-resend-requests.test.js
@@ -81,7 +81,7 @@ describe('resend requests are fulfilled at L1', () => {
 
     test('requestResendFrom', async () => {
         const actualEvents = eventsToArray(contactNode, Object.values(NetworkNode.events))
-        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId')
+        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId', 'msgChainId')
 
         await waitForEvent(contactNode, NetworkNode.events.RESENT)
         expect(actualEvents).toEqual([
@@ -93,7 +93,7 @@ describe('resend requests are fulfilled at L1', () => {
 
     test('requestResendRange', async () => {
         const actualEvents = eventsToArray(contactNode, Object.values(NetworkNode.events))
-        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId')
+        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId', 'msgChainId')
 
         await waitForEvent(contactNode, NetworkNode.events.NO_RESEND)
         expect(actualEvents).toEqual([

--- a/test/integration/l2-resend-requests.test.js
+++ b/test/integration/l2-resend-requests.test.js
@@ -119,7 +119,7 @@ describe('resend requests are fulfilled at L2', () => {
 
     test('requestResendFrom', async () => {
         const events = collectNetworkNodeEvents(contactNode)
-        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId')
+        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId', 'msgChainId')
 
         await waitForEvent(contactNode, NetworkNode.events.RESENT)
         expect(events).toEqual([
@@ -134,7 +134,7 @@ describe('resend requests are fulfilled at L2', () => {
 
     test('requestResendRange', async () => {
         const events = collectNetworkNodeEvents(contactNode)
-        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId')
+        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId', 'msgChainId')
 
         await waitForEvent(contactNode, NetworkNode.events.NO_RESEND)
         expect(events).toEqual([

--- a/test/integration/l3-resend-requests.test.js
+++ b/test/integration/l3-resend-requests.test.js
@@ -130,7 +130,7 @@ describe('resend requests are fulfilled at L3', () => {
 
     test('requestResendFrom', async () => {
         const events = collectNetworkNodeEvents(contactNode)
-        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId')
+        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId', 'msgChainId')
 
         await waitForEvent(contactNode, NetworkNode.events.RESENT)
         expect(events).toEqual([
@@ -142,7 +142,7 @@ describe('resend requests are fulfilled at L3', () => {
 
     test('requestResendRange', async () => {
         const events = collectNetworkNodeEvents(contactNode)
-        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId')
+        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId', 'msgChainId')
 
         await waitForEvent(contactNode, NetworkNode.events.NO_RESEND)
         expect(events).toEqual([

--- a/test/unit/MemoryStorage.test.js
+++ b/test/unit/MemoryStorage.test.js
@@ -121,7 +121,7 @@ describe('test mem storage', () => {
 
     test('test requestFrom', (done) => {
         const FROM_TIME = 8
-        const fromStream = memoryStorage.requestFrom(id, partition, FROM_TIME, 0, 'publisher-id')
+        const fromStream = memoryStorage.requestFrom(id, partition, FROM_TIME, 0, 'publisher-id', 'sessionId')
 
         const arr = []
         fromStream.on('data', (object) => arr.push(object))
@@ -168,7 +168,7 @@ describe('test mem storage', () => {
     test('test requestRange', (done) => {
         const FROM_TIME = 3
         const TO_TIME = 5
-        const rangeStream = memoryStorage.requestRange(id, partition, FROM_TIME, TO_TIME, 0, 0, 'publisher-id')
+        const rangeStream = memoryStorage.requestRange(id, partition, FROM_TIME, TO_TIME, 0, 0, 'publisher-id', 'sessionId')
 
         const arr = []
         rangeStream.on('data', (object) => arr.push(object))
@@ -225,4 +225,9 @@ describe('test mem storage', () => {
             done()
         })
     })
+
+    // TODO: write tests to verify that
+    //  (1) publisherId and msgChainId actually filters out undesired message with requestRange and requestFrom
+    //  (2) publisherId = null does not filter by publisher
+    //  (3) msgChainId = null does not filter by msgChainId
 })

--- a/test/unit/encoder.test.js
+++ b/test/unit/encoder.test.js
@@ -225,7 +225,8 @@ describe('encoder', () => {
             new StreamID('stream', 6),
             'subId',
             new MessageReference(6666, 0),
-            'publisherId'
+            'publisherId',
+            'msgChainId'
         )
         expect(JSON.parse(actual)).toEqual({
             version,
@@ -238,7 +239,8 @@ describe('encoder', () => {
                     timestamp: 6666,
                     sequenceNo: 0
                 },
-                publisherId: 'publisherId'
+                publisherId: 'publisherId',
+                msgChainId: 'msgChainId'
             }
         })
     })
@@ -255,7 +257,8 @@ describe('encoder', () => {
                     timestamp: 6666,
                     sequenceNo: 0
                 },
-                publisherId: 'publisherId'
+                publisherId: 'publisherId',
+                msgChainId: 'msgChainId'
             }
         }))
 
@@ -267,6 +270,8 @@ describe('encoder', () => {
         expect(resendFromRequest.getStreamId()).toEqual(new StreamID('stream', 6))
         expect(resendFromRequest.getSubId()).toEqual('subId')
         expect(resendFromRequest.getFromMsgRef()).toEqual(new MessageReference(6666, 0))
+        expect(resendFromRequest.getPublisherId()).toEqual('publisherId')
+        expect(resendFromRequest.getMsgChainId()).toEqual('msgChainId')
     })
 
     it('check encoding RESEND_RANGE', () => {
@@ -275,7 +280,8 @@ describe('encoder', () => {
             'subId',
             new MessageReference(6666, 0),
             new MessageReference(7000, 100),
-            'publisherId'
+            'publisherId',
+            'msgChainId'
         )
         expect(JSON.parse(actual)).toEqual({
             version,
@@ -292,7 +298,8 @@ describe('encoder', () => {
                     timestamp: 7000,
                     sequenceNo: 100
                 },
-                publisherId: 'publisherId'
+                publisherId: 'publisherId',
+                msgChainId: 'msgChainId'
             }
         })
     })
@@ -313,7 +320,8 @@ describe('encoder', () => {
                     timestamp: 7000,
                     sequenceNo: 100
                 },
-                publisherId: 'publisherId'
+                publisherId: 'publisherId',
+                msgChainId: 'msgChainId'
             }
         }))
 
@@ -326,6 +334,8 @@ describe('encoder', () => {
         expect(resendRangeRequest.getSubId()).toEqual('subId')
         expect(resendRangeRequest.getFromMsgRef()).toEqual(new MessageReference(6666, 0))
         expect(resendRangeRequest.getToMsgRef()).toEqual(new MessageReference(7000, 100))
+        expect(resendRangeRequest.getPublisherId()).toEqual('publisherId')
+        expect(resendRangeRequest.getMsgChainId()).toEqual('msgChainId')
     })
 
     it('check encoding RESEND_RESPONSE_RESENDING', () => {

--- a/test/unit/resendStrategies.test.js
+++ b/test/unit/resendStrategies.test.js
@@ -60,11 +60,12 @@ describe('StorageResendStrategy#getResendResponseStream', () => {
             new StreamID('streamId', 0),
             'subId',
             new MessageReference(1555555555555, 0),
-            'publisherId'
+            'publisherId',
+            'msgChainId'
         ))
 
         expect(storage.requestFrom.mock.calls).toEqual([
-            ['streamId', 0, 1555555555555, 0, 'publisherId']
+            ['streamId', 0, 1555555555555, 0, 'publisherId', 'msgChainId']
         ])
     })
 
@@ -76,11 +77,12 @@ describe('StorageResendStrategy#getResendResponseStream', () => {
             'subId',
             new MessageReference(1555555555555, 0),
             new MessageReference(1555555555555, 1000),
-            'publisherId'
+            'publisherId',
+            'msgChainId'
         ))
 
         expect(storage.requestRange.mock.calls).toEqual([
-            ['streamId', 0, 1555555555555, 0, 1555555555555, 1000, 'publisherId']
+            ['streamId', 0, 1555555555555, 0, 1555555555555, 1000, 'publisherId', 'msgChainId']
         ])
     })
 


### PR DESCRIPTION
While working on broker I noticed that we are missing field `msgChainId` in resendFrom and resendRange requests. Added the field to both `ResendFromRequest` and `ResendRangeRequest`, and then made necessary changes to all three layers. Also added filtering support to `MemoryStorage` for `msgChainId`.

### Public API change
Added new parameter `msgChainId` to the end of methods `NetworkNode#requestResendFrom` and `NetworkNode#requestResendRange`. This change should be backwards compatible as the parameter is optional.