### PR TITLE
Parameters in constructors

### DIFF
--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -53,20 +53,23 @@ function toObjectTransform() {
 Convenience wrapper for building client-facing functionality. Used by broker.
  */
 class NetworkNode extends Node {
-    constructor(id, trackerNode, nodeToNode, storages) {
-        const opts = {
-            id
+    constructor(opts) {
+        let networkOpts = {
+            resendStrategies: [
+                ...opts.storages.map((storage) => new StorageResendStrategy(storage)),
+                new AskNeighborsResendStrategy(opts.protocols.nodeToNode, (streamId) => {
+                    return this.streams.getOutboundNodesForStream(streamId)
+                }),
+                new StorageNodeResendStrategy(opts.protocols.trackerNode, opts.protocols.nodeToNode,
+                    () => [...this.trackers][0],
+                    (node) => this.streams.isNodePresent(node))
+            ]
         }
-        super(trackerNode, nodeToNode, [
-            ...storages.map((storage) => new StorageResendStrategy(storage)),
-            new AskNeighborsResendStrategy(nodeToNode, (streamId) => {
-                return this.streams.getOutboundNodesForStream(streamId)
-            }),
-            new StorageNodeResendStrategy(trackerNode, nodeToNode,
-                () => [...this.trackers][0],
-                (node) => this.streams.isNodePresent(node))
-        ], opts)
-        storages.forEach((storage) => this.on(events.MESSAGE, storage.store.bind(storage)))
+
+        networkOpts = Object.assign({}, opts, networkOpts)
+
+        super(networkOpts)
+        this.opts.storages.forEach((storage) => this.on(events.MESSAGE, storage.store.bind(storage)))
 
         this.on(Node.events.MESSAGE_PROPAGATED, this._emitMessage.bind(this))
         this.on(Node.events.UNICAST_RECEIVED, this._emitUnicast.bind(this))

--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -54,7 +54,10 @@ Convenience wrapper for building client-facing functionality. Used by broker.
  */
 class NetworkNode extends Node {
     constructor(id, trackerNode, nodeToNode, storages) {
-        super(id, trackerNode, nodeToNode, [
+        const opts = {
+            id
+        }
+        super(trackerNode, nodeToNode, [
             ...storages.map((storage) => new StorageResendStrategy(storage)),
             new AskNeighborsResendStrategy(nodeToNode, (streamId) => {
                 return this.streams.getOutboundNodesForStream(streamId)
@@ -62,7 +65,7 @@ class NetworkNode extends Node {
             new StorageNodeResendStrategy(trackerNode, nodeToNode,
                 () => [...this.trackers][0],
                 (node) => this.streams.isNodePresent(node))
-        ])
+        ], opts)
         storages.forEach((storage) => this.on(events.MESSAGE, storage.store.bind(storage)))
 
         this.on(Node.events.MESSAGE_PROPAGATED, this._emitMessage.bind(this))

--- a/src/composition.js
+++ b/src/composition.js
@@ -26,9 +26,14 @@ function startNode(host, port, id = uuidv4(), resendStrategies = []) {
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
         const opts = {
-            id
+            id,
+            protocols: {
+                trackerNode: new TrackerNode(endpoint),
+                nodeToNode: new NodeToNode(endpoint)
+            },
+            resendStrategies
         }
-        return new Node(new TrackerNode(endpoint), new NodeToNode(endpoint), resendStrategies, opts)
+        return new Node(opts)
     })
 }
 
@@ -38,7 +43,15 @@ function startNetworkNode(host, port, id = uuidv4(), storages = []) {
         'streamr-peer-type': peerTypes.NODE
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new NetworkNode(id, new TrackerNode(endpoint), new NodeToNode(endpoint), storages)
+        const opts = {
+            id,
+            protocols: {
+                trackerNode: new TrackerNode(endpoint),
+                nodeToNode: new NodeToNode(endpoint)
+            },
+            storages
+        }
+        return new NetworkNode(opts)
     })
 }
 
@@ -48,7 +61,15 @@ function startStorageNode(host, port, id = uuidv4(), storages = []) {
         'streamr-peer-type': peerTypes.STORAGE
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new NetworkNode(id, new TrackerNode(endpoint), new NodeToNode(endpoint), storages)
+        const opts = {
+            id,
+            protocols: {
+                trackerNode: new TrackerNode(endpoint),
+                nodeToNode: new NodeToNode(endpoint)
+            },
+            storages
+        }
+        return new NetworkNode(opts)
     })
 }
 

--- a/src/composition.js
+++ b/src/composition.js
@@ -15,7 +15,14 @@ function startTracker(host, port, id = uuidv4(), maxNeighborsPerNode = 4) {
         'streamr-peer-type': peerTypes.TRACKER
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new Tracker(id, new TrackerServer(endpoint), maxNeighborsPerNode)
+        const opts = {
+            id,
+            protocols: {
+                trackerServer: new TrackerServer(endpoint)
+            },
+            maxNeighborsPerNode
+        }
+        return new Tracker(opts)
     })
 }
 

--- a/src/composition.js
+++ b/src/composition.js
@@ -25,7 +25,10 @@ function startNode(host, port, id = uuidv4(), resendStrategies = []) {
         'streamr-peer-type': peerTypes.NODE
     }
     return startEndpoint(host, port, identity).then((endpoint) => {
-        return new Node(id, new TrackerNode(endpoint), new NodeToNode(endpoint), resendStrategies)
+        const opts = {
+            id
+        }
+        return new Node(new TrackerNode(endpoint), new NodeToNode(endpoint), resendStrategies, opts)
     })
 }
 

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -37,6 +37,11 @@ class Node extends EventEmitter {
         }
 
         this.opts = Object.assign({}, defaultOptions, opts)
+
+        if (!(this.opts.protocols.trackerNode instanceof TrackerNode) || !(this.opts.protocols.nodeToNode instanceof NodeToNode)) {
+            throw new Error('Provided protocols are not correct')
+        }
+
         this.connectToBoostrapTrackersInterval = setInterval(this._connectToBootstrapTrackers.bind(this), this.opts.connectToBootstrapTrackersInterval)
         this.sendStatusTimeout = null
         this.bootstrapTrackerAddresses = []

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -6,22 +6,26 @@ const { StreamID } = require('../identifiers')
 const { peerTypes } = require('../protocol/PeerBook')
 
 module.exports = class Tracker extends EventEmitter {
-    constructor(id, trackerServer, maxNeighborsPerNode) {
+    constructor(opts) {
         super()
+
+        if (!Number.isInteger(opts.maxNeighborsPerNode)) {
+            throw new Error('maxNeighborsPerNode is not an integer')
+        }
+
+        // set default options
+        const defaultOptions = {
+            id: 'tracker',
+            protocols: []
+        }
+
+        this.opts = Object.assign({}, defaultOptions, opts)
 
         this.overlayPerStream = {} // streamKey => overlayTopology
         this.storageNodes = new Map()
 
-        this.id = id
-        this.protocols = {
-            trackerServer
-        }
-
-        if (!Number.isInteger(maxNeighborsPerNode)) {
-            throw new Error('maxNeighborsPerNode is not an integer')
-        }
-
-        this.maxNeighborsPerNode = maxNeighborsPerNode
+        // this.id = id
+        this.protocols = opts.protocols
 
         this.protocols.trackerServer.on(TrackerServer.events.NODE_DISCONNECTED, ({ peerId, nodeType }) => this.onNodeDisconnected(peerId, nodeType))
         this.protocols.trackerServer.on(TrackerServer.events.NODE_STATUS_RECEIVED, ({ statusMessage, nodeType }) => this.processNodeStatus(statusMessage, nodeType))
@@ -79,7 +83,7 @@ module.exports = class Tracker extends EventEmitter {
         // Add or update
         Object.entries(streams).forEach(([streamKey, { inboundNodes, outboundNodes }]) => {
             if (this.overlayPerStream[streamKey] == null) {
-                this.overlayPerStream[streamKey] = new OverlayTopology(this.maxNeighborsPerNode)
+                this.overlayPerStream[streamKey] = new OverlayTopology(this.opts.maxNeighborsPerNode)
             }
 
             newNode = this.overlayPerStream[streamKey].hasNode(node)

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -21,6 +21,10 @@ module.exports = class Tracker extends EventEmitter {
 
         this.opts = Object.assign({}, defaultOptions, opts)
 
+        if (!(this.opts.protocols.trackerServer instanceof TrackerServer)) {
+            throw new Error('Provided protocols are not correct')
+        }
+
         this.overlayPerStream = {} // streamKey => overlayTopology
         this.storageNodes = new Map()
 

--- a/test/integration/tracker-node-status.test.js
+++ b/test/integration/tracker-node-status.test.js
@@ -20,7 +20,7 @@ describe('check status message flow between tracker and two nodes', () => {
 
     it('tracker should receive status message from node', async (done) => {
         tracker.protocols.trackerServer.once(TrackerServer.events.NODE_STATUS_RECEIVED, ({ statusMessage, nodeType }) => {
-            expect(statusMessage.getSource()).toEqual(nodeOne.id)
+            expect(statusMessage.getSource()).toEqual(nodeOne.opts.id)
             // eslint-disable-next-line no-underscore-dangle
             expect(statusMessage.getStatus()).toEqual(nodeOne._getStatus())
             done()
@@ -31,7 +31,7 @@ describe('check status message flow between tracker and two nodes', () => {
 
     it('tracker should receive status from second node', async (done) => {
         tracker.protocols.trackerServer.once(TrackerServer.events.NODE_STATUS_RECEIVED, ({ statusMessage, nodeType }) => {
-            expect(statusMessage.getSource()).toEqual(nodeTwo.id)
+            expect(statusMessage.getSource()).toEqual(nodeTwo.opts.id)
             // eslint-disable-next-line no-underscore-dangle
             expect(statusMessage.getStatus()).toEqual(nodeTwo._getStatus())
             done()
@@ -53,12 +53,12 @@ describe('check status message flow between tracker and two nodes', () => {
 
             let receivedTotal = 0
             tracker.protocols.trackerServer.on(TrackerServer.events.NODE_STATUS_RECEIVED, ({ statusMessage, nodeType }) => {
-                if (statusMessage.getSource() === nodeOne.id) {
+                if (statusMessage.getSource() === nodeOne.opts.id) {
                     // eslint-disable-next-line no-underscore-dangle
                     expect(statusMessage.getStatus()).toEqual(nodeOne._getStatus())
                 }
 
-                if (statusMessage.getSource() === nodeTwo.id) {
+                if (statusMessage.getSource() === nodeTwo.opts.id) {
                     // eslint-disable-next-line no-underscore-dangle
                     expect(statusMessage.getStatus()).toEqual(nodeTwo._getStatus())
                 }


### PR DESCRIPTION
I moved all possible parameters/intervals to some options object inside classes (#261)
I decided to keep `this.protocols = this.opts.protocols` to be short in out listeners `this.protocols.trackerNode.on`