### PR TITLE
Stop resend strategies on Node#stop

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -265,6 +265,7 @@ class Node extends EventEmitter {
 
     stop(cb) {
         this.debug('stopping')
+        this.resendHandler.stop()
         this._clearConnectToBootstrapTrackersInterval()
         this._disconnectFromAllNodes()
         this._disconnectFromTrackers()

--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -45,6 +45,14 @@ class ResendHandler {
         return requestStream
     }
 
+    stop() {
+        this.resendStrategies.forEach((resendStrategy) => {
+            if (resendStrategy.stop) {
+                resendStrategy.stop()
+            }
+        })
+    }
+
     async _loopThruResendStrategies(request, requestStream) {
         let isRequestFulfilled = false
 


### PR DESCRIPTION
Properly clean up and stop resend strategies on Node#stop. I suspect this causes Broker tests to hang.