### PR TITLE
add metrics: messageBuffer size & open handles

### DIFF
--- a/src/helpers/MessageBuffer.js
+++ b/src/helpers/MessageBuffer.js
@@ -34,6 +34,14 @@ module.exports = class MessageBuffer {
         Object.keys(this.buffer).forEach((id) => this.popAll(id))
     }
 
+    size() {
+        let total = 0
+        Object.values(this.buffer).forEach((messages) => {
+            total += messages.length
+        })
+        return total
+    }
+
     _hasBufferFor(id) {
         return this.buffer[id]
     }

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -393,6 +393,9 @@ class Node extends EventEmitter {
         metrics.msg += ' messages/second'
         metrics.inSpeed = pretty(metrics.inSpeed)
         metrics.outSpeed = pretty(metrics.outSpeed)
+        // eslint-disable-next-line no-underscore-dangle
+        metrics.openHandles = process._getActiveRequests().length + process._getActiveHandles().length
+        metrics.messageBufferSize = this.messageBuffer.size()
 
         return metrics
     }

--- a/test/unit/MessageBuffer.test.js
+++ b/test/unit/MessageBuffer.test.js
@@ -98,6 +98,35 @@ test('clear() removes all messages and timeout callbacks', () => {
     expect(timeoutCb).not.toHaveBeenCalled()
 })
 
+test('size() gives correct size of buffer across streams', () => {
+    const buffer = new MessageBuffer(999999999)
+
+    buffer.put('stream-1', {
+        id: 'stream-1',
+        data: 'hello'
+    })
+    buffer.put('stream-1', {
+        id: 'stream-1',
+        data: 'world'
+    })
+    buffer.put('stream-2', {
+        id: 'stream-2',
+        data: 'not!'
+    })
+    buffer.put('stream-1', {
+        id: 'stream-1',
+        data: '!'
+    })
+
+    expect(buffer.size()).toEqual(4)
+
+    buffer.popAll('stream-1')
+    expect(buffer.size()).toEqual(1)
+
+    buffer.clear()
+    expect(buffer.size()).toEqual(0)
+})
+
 test('clearing and pushing to ids do not affect other ids', () => {
     const buffer = new MessageBuffer(100)
 


### PR DESCRIPTION
Added two metrics that are useful as signals for node not being able to keep up with amount of publishing.