### PR TITLE
simplify resend response stream

### DIFF
--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -81,8 +81,8 @@ class ResendHandler {
                 .on('data', () => {
                     numOfMessages += 1
                 })
-                .on('data', ([unicastMessage, unicastMessageSource]) => {
-                    this._emitUnicast(source, unicastMessage, unicastMessageSource)
+                .on('data', (unicastMessage) => {
+                    this._emitUnicast(source, unicastMessage)
                 })
                 .on('error', (error) => {
                     this._emitError(request, error)
@@ -100,8 +100,8 @@ class ResendHandler {
         this.sendResponse(source, ControlLayer.ResendResponseResending.create(request.streamId, request.streamPartition, request.subId))
     }
 
-    _emitUnicast(requestSource, unicastMessage, unicastMessageSource) {
-        this.sendUnicast(requestSource, unicastMessage, unicastMessageSource)
+    _emitUnicast(requestSource, unicastMessage) {
+        this.sendUnicast(requestSource, unicastMessage)
     }
 
     _emitResent(request, source) {

--- a/src/logic/resendStrategies.js
+++ b/src/logic/resendStrategies.js
@@ -21,11 +21,11 @@ function toUnicastMessage(request) {
                 signature,
                 signatureType,
             } = streamData
-            done(null, [ControlLayer.UnicastMessage.create(request.subId, StreamMessage.create(
+            done(null, ControlLayer.UnicastMessage.create(request.subId, StreamMessage.create(
                 [request.streamId, request.streamPartition, timestamp, sequenceNo, publisherId, msgChainId],
                 previousTimestamp != null ? [previousTimestamp, previousSequenceNo] : null,
                 StreamMessage.CONTENT_TYPES.JSON, data, signatureType, signature
-            )), null])
+            )))
         }
     })
 }
@@ -134,7 +134,7 @@ class ProxiedResend {
     _onUnicast(unicastMessage, source) {
         const { subId } = unicastMessage
         if (this.request.subId === subId && this.currentNeighbor === source) {
-            this.responseStream.push([unicastMessage, source])
+            this.responseStream.push(unicastMessage)
             this._resetTimeout()
         }
     }

--- a/test/unit/ResendHandler.test.js
+++ b/test/unit/ResendHandler.test.js
@@ -103,18 +103,18 @@ describe('ResendHandler', () => {
         beforeEach(() => {
             resendHandler = new ResendHandler([{
                 getResendResponseStream: () => intoStream.object([
-                    [ControlLayer.UnicastMessage.create(
+                    ControlLayer.UnicastMessage.create(
                         'subId', StreamMessage.create(
                             ['streamId', 0, 1000, 0, 'publisherId', 'msgChainId'], null, StreamMessage.CONTENT_TYPES.JSON,
                             {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                         )
-                    ), null],
-                    [ControlLayer.UnicastMessage.create(
+                    ),
+                    ControlLayer.UnicastMessage.create(
                         'subId', StreamMessage.create(
                             ['streamId', 0, 2000, 0, 'publisherId', 'msgChainId'], null, StreamMessage.CONTENT_TYPES.JSON,
                             {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                         )
-                    ), null],
+                    ),
                 ])
             }], sendResponse, sendUnicast, notifyError)
         })
@@ -151,20 +151,20 @@ describe('ResendHandler', () => {
                     })
 
                     setImmediate(() => stream.push(
-                        [ControlLayer.UnicastMessage.create(
+                        ControlLayer.UnicastMessage.create(
                             'subId', StreamMessage.create(
                                 ['streamId', 0, 1000, 0, 'publisherId', 'msgChainId'], null, StreamMessage.CONTENT_TYPES.JSON,
                                 {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                             )
-                        ), null]
+                        ),
                     ))
                     setImmediate(() => stream.push(
-                        [ControlLayer.UnicastMessage.create(
+                        ControlLayer.UnicastMessage.create(
                             'subId', StreamMessage.create(
                                 ['streamId', 0, 2000, 0, 'publisherId', 'msgChainId'], null, StreamMessage.CONTENT_TYPES.JSON,
                                 {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                             )
-                        ), null]
+                        )
                     ))
                     setImmediate(() => {
                         stream.emit('error', new Error('yikes'))
@@ -211,12 +211,12 @@ describe('ResendHandler', () => {
                         read() {}
                     })
                     setImmediate(() => stream.push(
-                        [ControlLayer.UnicastMessage.create(
+                        ControlLayer.UnicastMessage.create(
                             'subId', StreamMessage.create(
                                 ['streamId', 0, 2000, 0, 'publisherId', 'msgChainId'], null, StreamMessage.CONTENT_TYPES.JSON,
                                 {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                             )
-                        ), null]
+                        )
                     ))
                     setImmediate(() => {
                         stream.emit('error', new Error('yikes'))
@@ -227,18 +227,18 @@ describe('ResendHandler', () => {
 
             const thirdStrategy = {
                 getResendResponseStream: () => intoStream.object([
-                    [ControlLayer.UnicastMessage.create(
+                    ControlLayer.UnicastMessage.create(
                         'subId', StreamMessage.create(
                             ['streamId', 0, 1000, 0, 'publisherId', 'msgChainId'], null, StreamMessage.CONTENT_TYPES.JSON,
                             {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                         )
-                    ), null],
-                    [ControlLayer.UnicastMessage.create(
+                    ),
+                    ControlLayer.UnicastMessage.create(
                         'subId', StreamMessage.create(
                             ['streamId', 0, 1000, 0, 'publisherId', 'msgChainId'], null, StreamMessage.CONTENT_TYPES.JSON,
                             {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                         )
-                    ), null],
+                    ),
                 ])
             }
 
@@ -272,12 +272,12 @@ describe('ResendHandler', () => {
 
             const firstStrategy = {
                 getResendResponseStream: () => intoStream.object([
-                    [ControlLayer.UnicastMessage.create(
+                    ControlLayer.UnicastMessage.create(
                         'subId', StreamMessage.create(
                             ['streamId', 0, 1000, 0, 'publisher', 'msgChain'], null, StreamMessage.CONTENT_TYPES.JSON,
                             {}, StreamMessage.SIGNATURE_TYPES.NONE, null
                         )
-                    ), null]
+                    )
                 ])
             }
 
@@ -328,14 +328,14 @@ describe('ResendHandler', () => {
             beforeEach(() => {
                 resendHandler = new ResendHandler([{
                     getResendResponseStream: () => intoStream.object([
-                        [ControlLayer.UnicastMessage.create(
+                        ControlLayer.UnicastMessage.create(
                             'subId', StreamMessage.create(
                                 ['streamId', 0, 756, 0, 'publisherId', 'msgChainId'], [666, 50],
                                 StreamMessage.CONTENT_TYPES.JSON, {
                                     hello: 'world'
                                 }, StreamMessage.SIGNATURE_TYPES.ETH, 'signature'
                             )
-                        ), null]
+                        )
                     ])
                 }], sendResponse, sendUnicast, notifyError)
             })
@@ -364,7 +364,7 @@ describe('ResendHandler', () => {
                             hello: 'world'
                         }, StreamMessage.SIGNATURE_TYPES.ETH, 'signature'
                     )
-                ), null)
+                ))
             })
         })
     })

--- a/test/unit/resendStrategies.test.js
+++ b/test/unit/resendStrategies.test.js
@@ -90,16 +90,16 @@ describe('StorageResendStrategy#getResendResponseStream', () => {
         )
         const streamAsArray = await waitForStreamToEnd(responseStream)
         expect(streamAsArray).toEqual([
-            [ControlLayer.UnicastMessage.create(
+            ControlLayer.UnicastMessage.create(
                 'subId', StreamMessage.create(['streamId', 0, 0, 0, 'publisherId', 'msgChainId'],
                     null, StreamMessage.CONTENT_TYPES.JSON, {
                         hello: 'world'
                     }, StreamMessage.SIGNATURE_TYPES.ETH, 'signature'),
-            ), null],
-            [ControlLayer.UnicastMessage.create(
+            ),
+            ControlLayer.UnicastMessage.create(
                 'subId', StreamMessage.create(['streamId', 0, 10, 10, 'publisherId', 'msgChainId'], [0, 0],
                     StreamMessage.CONTENT_TYPES.JSON, {}, StreamMessage.SIGNATURE_TYPES.ETH, 'signature')
-            ), null],
+            ),
         ])
     })
 })
@@ -251,25 +251,25 @@ describe('AskNeighborsResendStrategy#getResendResponseStream', () => {
         })
 
         test('all UnicastMessages received from neighbor are pushed to returned stream', async () => {
-            const createUnicastMessageAndSource = (timestamp) => {
+            const createUnicastMessage = (timestamp) => {
                 const streamMessage = MessageLayer.StreamMessage.create(['streamId', 0, timestamp, 0, '', ''], null,
                     MessageLayer.StreamMessage.CONTENT_TYPES.JSON, {}, MessageLayer.StreamMessage.SIGNATURE_TYPES.NONE, null)
-                return [ControlLayer.UnicastMessage.create('subId', streamMessage), 'neighbor-1']
+                return ControlLayer.UnicastMessage.create('subId', streamMessage)
             }
 
-            const u1 = createUnicastMessageAndSource(0)
-            const u2 = createUnicastMessageAndSource(1000)
-            const u3 = createUnicastMessageAndSource(11000)
-            const u4 = createUnicastMessageAndSource(21000)
-            const u5 = createUnicastMessageAndSource(22000)
+            const u1 = createUnicastMessage(0)
+            const u2 = createUnicastMessage(1000)
+            const u3 = createUnicastMessage(11000)
+            const u4 = createUnicastMessage(21000)
+            const u5 = createUnicastMessage(22000)
 
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u1)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u2)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u1, 'neighbor-1')
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u2, 'neighbor-1')
             jest.advanceTimersByTime(TIMEOUT / 10)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u3)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u3, 'neighbor-1')
             jest.advanceTimersByTime(TIMEOUT / 10)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u4)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u5)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u4, 'neighbor-1')
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u5, 'neighbor-1')
             nodeToNode.emit(NodeToNode.events.RESEND_RESPONSE,
                 ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'), 'neighbor-1')
 
@@ -521,25 +521,25 @@ describe('StorageNodeResendStrategy#getResendResponseStream', () => {
         })
 
         test('all UnicastMessages received from storage node are pushed to returned stream', async () => {
-            const createUnicastMessageAndSource = (timestamp) => {
+            const createUnicastMessage = (timestamp) => {
                 const streamMessage = MessageLayer.StreamMessage.create(['streamId', 0, timestamp, 0, '', ''], null,
                     MessageLayer.StreamMessage.CONTENT_TYPES.JSON, {}, MessageLayer.StreamMessage.SIGNATURE_TYPES.NONE, null)
-                return [ControlLayer.UnicastMessage.create('subId', streamMessage), 'storageNode']
+                return ControlLayer.UnicastMessage.create('subId', streamMessage)
             }
 
-            const u1 = createUnicastMessageAndSource(0)
-            const u2 = createUnicastMessageAndSource(1000)
-            const u3 = createUnicastMessageAndSource(11000)
-            const u4 = createUnicastMessageAndSource(21000)
-            const u5 = createUnicastMessageAndSource(22000)
+            const u1 = createUnicastMessage(0)
+            const u2 = createUnicastMessage(1000)
+            const u3 = createUnicastMessage(11000)
+            const u4 = createUnicastMessage(21000)
+            const u5 = createUnicastMessage(22000)
 
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u1)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u2)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u1, 'storageNode')
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u2, 'storageNode')
             jest.advanceTimersByTime(TIMEOUT / 10)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u3)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u3, 'storageNode')
             jest.advanceTimersByTime(TIMEOUT / 10)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u4)
-            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, ...u5)
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u4, 'storageNode')
+            nodeToNode.emit(NodeToNode.events.UNICAST_RECEIVED, u5, 'storageNode')
             nodeToNode.emit(NodeToNode.events.RESEND_RESPONSE,
                 ControlLayer.ResendResponseResent.create('streamId', 0, 'subId'), 'storageNode')
 


### PR DESCRIPTION
Remove `unicastMessageSource` from resend response stream since the user of this library (i.e. broker) has no need for this information.

Simplifies items of response stream to be `UnicastMessage` instead of `[UnicastMessage, source]`.