### PR TITLE
advertistedWsUrl: allow manual setting of public WebSocket URL

### DIFF
--- a/src/composition.js
+++ b/src/composition.js
@@ -10,12 +10,12 @@ const NetworkNode = require('./NetworkNode')
 const { startEndpoint } = require('./connection/WsEndpoint')
 const { StreamIdAndPartition } = require('./identifiers')
 
-function startTracker(host, port, id = uuidv4(), maxNeighborsPerNode = 4) {
+function startTracker(host, port, id = uuidv4(), maxNeighborsPerNode = 4, advertisedWsUrl = null) {
     const identity = {
         'streamr-peer-id': id,
         'streamr-peer-type': peerTypes.TRACKER
     }
-    return startEndpoint(host, port, identity).then((endpoint) => {
+    return startEndpoint(host, port, identity, advertisedWsUrl).then((endpoint) => {
         const opts = {
             id,
             protocols: {
@@ -27,12 +27,12 @@ function startTracker(host, port, id = uuidv4(), maxNeighborsPerNode = 4) {
     })
 }
 
-function startNode(host, port, id = uuidv4(), resendStrategies = []) {
+function startNode(host, port, id = uuidv4(), resendStrategies = [], advertisedWsUrl = null) {
     const identity = {
         'streamr-peer-id': id,
         'streamr-peer-type': peerTypes.NODE
     }
-    return startEndpoint(host, port, identity).then((endpoint) => {
+    return startEndpoint(host, port, identity, advertisedWsUrl).then((endpoint) => {
         const opts = {
             id,
             protocols: {
@@ -45,12 +45,12 @@ function startNode(host, port, id = uuidv4(), resendStrategies = []) {
     })
 }
 
-function startNetworkNode(host, port, id = uuidv4(), storages = []) {
+function startNetworkNode(host, port, id = uuidv4(), storages = [], advertisedWsUrl = null) {
     const identity = {
         'streamr-peer-id': id,
         'streamr-peer-type': peerTypes.NODE
     }
-    return startEndpoint(host, port, identity).then((endpoint) => {
+    return startEndpoint(host, port, identity, advertisedWsUrl).then((endpoint) => {
         const opts = {
             id,
             protocols: {
@@ -63,12 +63,12 @@ function startNetworkNode(host, port, id = uuidv4(), storages = []) {
     })
 }
 
-function startStorageNode(host, port, id = uuidv4(), storages = []) {
+function startStorageNode(host, port, id = uuidv4(), storages = [], advertisedWsUrl = null) {
     const identity = {
         'streamr-peer-id': id,
         'streamr-peer-type': peerTypes.STORAGE
     }
-    return startEndpoint(host, port, identity).then((endpoint) => {
+    return startEndpoint(host, port, identity, advertisedWsUrl).then((endpoint) => {
         const opts = {
             id,
             protocols: {

--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -50,7 +50,7 @@ class CustomHeaders {
 }
 
 class WsEndpoint extends EventEmitter {
-    constructor(wss, customHeaders) {
+    constructor(wss, customHeaders, advertisedWsUrl) {
         super()
 
         if (!wss) {
@@ -59,9 +59,13 @@ class WsEndpoint extends EventEmitter {
         if (!customHeaders) {
             throw new Error('customHeaders not given')
         }
+        if (advertisedWsUrl === undefined) {
+            throw new Error('advertisedWsUrl not given')
+        }
 
         this.wss = wss
         this.customHeaders = new CustomHeaders(customHeaders)
+        this.advertisedWsUrl = advertisedWsUrl
 
         this.endpoint = new Endpoint()
         this.endpoint.implement(this)
@@ -242,6 +246,9 @@ class WsEndpoint extends EventEmitter {
     }
 
     getAddress() {
+        if (this.advertisedWsUrl) {
+            return this.advertisedWsUrl
+        }
         const socketAddress = this.wss.address()
         return `ws://${socketAddress.address}:${socketAddress.port}`
     }
@@ -337,8 +344,8 @@ async function startWebSocketServer(host, port) {
     })
 }
 
-async function startEndpoint(host, port, customHeaders) {
-    return startWebSocketServer(host, port).then((wss) => new WsEndpoint(wss, customHeaders))
+async function startEndpoint(host, port, customHeaders, advertisedWsUrl) {
+    return startWebSocketServer(host, port).then((wss) => new WsEndpoint(wss, customHeaders, advertisedWsUrl))
 }
 
 module.exports = {

--- a/test/integration/delivery-of-messages-protocol-layer.test.js
+++ b/test/integration/delivery-of-messages-protocol-layer.test.js
@@ -29,22 +29,22 @@ describe('delivery of messages in protocol layer', () => {
         nodeToNode1 = new NodeToNode(new WsEndpoint(wss1, {
             'streamr-peer-id': 'nodeToNode1',
             'streamr-peer-type': peerTypes.NODE
-        }))
+        }, null))
 
         nodeToNode2 = new NodeToNode(new WsEndpoint(wss2, {
             'streamr-peer-id': 'nodeToNode2',
             'streamr-peer-type': peerTypes.NODE
-        }))
+        }, null))
 
         trackerNode = new TrackerNode(new WsEndpoint(wss3, {
             'streamr-peer-id': 'trackerNode',
             'streamr-peer-type': peerTypes.NODE
-        }))
+        }, null))
 
         trackerServer = new TrackerServer(new WsEndpoint(wss4, {
             'streamr-peer-id': 'trackerServer',
             'streamr-peer-type': peerTypes.NODE
-        }))
+        }, null))
 
         // Connect nodeToNode1 <-> nodeToNode2
         nodeToNode1.connectToNode(nodeToNode2.getAddress())

--- a/test/integration/duplicate-connections-are-closed.test.js
+++ b/test/integration/duplicate-connections-are-closed.test.js
@@ -12,8 +12,8 @@ describe('duplicate connections are closed', () => {
     beforeEach(async () => {
         wss1 = await startWebSocketServer('127.0.0.1', 28501, {})
         wss2 = await startWebSocketServer('127.0.0.1', 28502, {})
-        wsEndpoint1 = new WsEndpoint(wss1, {})
-        wsEndpoint2 = new WsEndpoint(wss2, {})
+        wsEndpoint1 = new WsEndpoint(wss1, {}, null)
+        wsEndpoint2 = new WsEndpoint(wss2, {}, null)
     })
 
     afterAll(async () => {

--- a/test/integration/passing-address-between-ws-endpoints.test.js
+++ b/test/integration/passing-address-between-ws-endpoints.test.js
@@ -1,0 +1,31 @@
+const { startEndpoint } = require('../../src/connection/WsEndpoint')
+const Endpoint = require('../../src/connection/Endpoint')
+const { LOCALHOST, waitForEvent } = require('../util')
+
+describe('passing address between WsEndpoints', () => {
+    let wsEndpoint1
+    let wsEndpoint2
+
+    beforeEach(async () => {
+        wsEndpoint1 = await startEndpoint(LOCALHOST, 31960, {}, null)
+    })
+
+    afterEach(async () => {
+        await wsEndpoint1.stop()
+        await wsEndpoint2.stop()
+    })
+
+    it('bound address is passed to other WsEndpoint if advertisedWsUrl not set', async () => {
+        wsEndpoint2 = await startEndpoint(LOCALHOST, 31961, {}, null)
+        wsEndpoint2.connect(`ws://${LOCALHOST}:31960`)
+        const [address] = await waitForEvent(wsEndpoint1, Endpoint.events.PEER_CONNECTED)
+        expect(address).toEqual('ws://127.0.0.1:31961')
+    })
+
+    it('advertised address is passed to other WsEndpoint if advertisedWsUrl set', async () => {
+        wsEndpoint2 = await startEndpoint(LOCALHOST, 31961, {}, 'ws://advertised-ws-url:666')
+        wsEndpoint2.connect(`ws://${LOCALHOST}:31960`)
+        const [address] = await waitForEvent(wsEndpoint1, Endpoint.events.PEER_CONNECTED)
+        expect(address).toEqual('ws://advertised-ws-url:666')
+    })
+})

--- a/test/integration/ws-endpoint.test.js
+++ b/test/integration/ws-endpoint.test.js
@@ -9,7 +9,7 @@ describe('create five endpoints and init connection between them', () => {
     it('should be able to start and stop successfully', async () => {
         for (let i = 0; i < MAX; i++) {
             // eslint-disable-next-line no-await-in-loop
-            const endpoint = await startEndpoint(LOCALHOST, 30690 + i, {}).catch((err) => { throw err })
+            const endpoint = await startEndpoint(LOCALHOST, 30690 + i, {}, null).catch((err) => { throw err })
             endpoints.push(endpoint)
         }
 
@@ -43,10 +43,10 @@ describe('create five endpoints and init connection between them', () => {
     it('address and custom headers are exchanged between connecting endpoints', async () => {
         const endpointOne = await startEndpoint(LOCALHOST, 30695, {
             'my-identity': 'endpoint-1'
-        })
+        }, null)
         const endpointTwo = await startEndpoint(LOCALHOST, 30696, {
             'my-identity': 'endpoint-2'
-        })
+        }, null)
 
         const e1 = waitForEvent(endpointOne, endpointEvents.PEER_CONNECTED)
         const e2 = waitForEvent(endpointTwo, endpointEvents.PEER_CONNECTED)


### PR DESCRIPTION
It is not possible to bind the WebSocket server to a public IP address in certain environments (EC2 or behind a NAT) because no network interface is assigned to that address. On other hand, we don't want to advertise an unreachable internal IP address to the tracker and other nodes.

Therefore, in this PR, separated these two concepts in code. A user of this library (e.g. Broker) can now explicitly set an advertised WebSocket URL when necessary. If none is set, default to previous behavior which consists of forming the WebSocket URL based on the bound IP address and port.

fixes #290 