### PR TITLE
NET-31: fix bug with resends on uninvolved nodes

### DIFF
--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -25,7 +25,7 @@ class NetworkNode extends Node {
             resendStrategies: [
                 ...opts.storages.map((storage) => new StorageResendStrategy(storage)),
                 new AskNeighborsResendStrategy(opts.protocols.nodeToNode, (streamId) => {
-                    return this.streams.getOutboundNodesForStream(streamId)
+                    return this.streams.isSetUp(streamId) ? this.streams.getOutboundNodesForStream(streamId) : []
                 }),
                 new StorageNodeResendStrategy(opts.protocols.trackerNode, opts.protocols.nodeToNode,
                     () => [...this.trackers][0],

--- a/test/integration/request-resend-from-uninvolved-node.test.js
+++ b/test/integration/request-resend-from-uninvolved-node.test.js
@@ -1,0 +1,89 @@
+const intoStream = require('into-stream')
+
+const { startNetworkNode, startStorageNode, startTracker } = require('../../src/composition')
+const { eventsToArray, waitForEvent, LOCALHOST } = require('../util')
+const Node = require('../../src/logic/Node')
+const NetworkNode = require('../../src/NetworkNode')
+
+const collectNetworkNodeEvents = (node) => eventsToArray(node, Object.values(NetworkNode.events))
+
+/**
+ * This test verifies that requesting a resend of stream S from a node that is
+ * not subscribed to S (is uninvolved) works as expected. That is, the resend
+ * request will be fulfilled via L3 by delegating & proxying through a storage
+ * node.
+ */
+describe('request resend from uninvolved node', () => {
+    let tracker
+    let uninvolvedNode
+    let involvedNode
+    let storageNode
+
+    beforeAll(async () => {
+        tracker = await startTracker(LOCALHOST, 28640, 'tracker')
+        uninvolvedNode = await startNetworkNode(LOCALHOST, 28641, 'uninvolvedNode', [{
+            store: () => {},
+            requestLast: () => intoStream.object([]),
+        }])
+        involvedNode = await startNetworkNode(LOCALHOST, 28642, 'involvedNode', [{
+            store: () => {},
+            requestLast: () => intoStream.object([]),
+        }])
+        storageNode = await startStorageNode(LOCALHOST, 28643, 'storageNode', [{
+            store: () => {},
+            requestLast: () => intoStream.object([
+                {
+                    timestamp: 756,
+                    sequenceNo: 0,
+                    previousTimestamp: 666,
+                    previousSequenceNo: 50,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+                {
+                    timestamp: 800,
+                    sequenceNo: 0,
+                    previousTimestamp: 756,
+                    previousSequenceNo: 0,
+                    publisherId: 'publisherId',
+                    msgChainId: 'msgChainId',
+                    data: {}
+                },
+            ])
+        }])
+
+        involvedNode.subscribe('streamId', 0)
+        // storageNode automatically assigned (subscribed) by tracker
+
+        uninvolvedNode.addBootstrapTracker(tracker.getAddress())
+        involvedNode.addBootstrapTracker(tracker.getAddress())
+        storageNode.addBootstrapTracker(tracker.getAddress())
+
+        await Promise.all([
+            waitForEvent(involvedNode, Node.events.NODE_SUBSCRIBED),
+            waitForEvent(storageNode, Node.events.NODE_SUBSCRIBED)
+        ])
+    })
+
+    afterAll(async () => {
+        await uninvolvedNode.stop()
+        await involvedNode.stop()
+        await storageNode.stop()
+        await tracker.stop()
+    })
+
+    test('requesting resend from uninvolved node is fulfilled using l3', async () => {
+        const events = collectNetworkNodeEvents(uninvolvedNode)
+        uninvolvedNode.requestResendLast('streamId', 0, 'subId', 10)
+
+        await waitForEvent(uninvolvedNode, NetworkNode.events.RESENT)
+        expect(events).toEqual([
+            NetworkNode.events.RESENDING,
+            NetworkNode.events.UNICAST,
+            NetworkNode.events.UNICAST,
+            NetworkNode.events.RESENT,
+        ])
+        expect(uninvolvedNode.streams.getStreamsAsKeys()).toEqual([]) // sanity check
+    })
+})


### PR DESCRIPTION
Fix bug where a node would crash if it was requested a resend for a stream it was not subscribed to. The new behavior is to use L3 (delegate & proxy to storage node) to fulfill resend requests for streams a node is not subscribed to.

Also added test to verify behavior.