### PR TITLE
Remove resend events

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -50,20 +50,20 @@ class Node extends EventEmitter {
         )
         this.sendStatusTimeout = null
         this.bootstrapTrackerAddresses = []
+        this.protocols = this.opts.protocols
 
         this.streams = new StreamManager()
         this.messageBuffer = new MessageBuffer(this.opts.messageBufferSize, (streamId) => {
             this.debug('failed to deliver buffered messages of stream %s', streamId)
             this.emit(events.MESSAGE_DELIVERY_FAILED, streamId)
         })
-        this.resendHandler = new ResendHandler(this.opts.resendStrategies,
-            (...args) => this.protocols.nodeToNode.send(...args),
-            (...args) => this.protocols.nodeToNode.send(...args),
-            console.error.bind(console))
+        this.resendHandler = new ResendHandler(
+            this.opts.resendStrategies,
+            this.protocols.nodeToNode.send.bind(this.protocols.nodeToNode),
+            console.error.bind(console)
+        )
 
         this.trackers = new Set()
-
-        this.protocols = this.opts.protocols
 
         this.protocols.trackerNode.on(TrackerNode.events.CONNECTED_TO_TRACKER, (tracker) => this.onConnectedToTracker(tracker))
         this.protocols.trackerNode.on(TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED, (streamMessage) => this.onTrackerInstructionReceived(streamMessage))

--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -64,9 +64,9 @@ class ResendHandler {
         }
 
         if (isRequestFulfilled) {
-            this._emitResent(request, source)
+            this._sendResent(request, source)
         } else {
-            this._emitNoResend(request, source)
+            this._sendNoResend(request, source)
         }
 
         requestStream.done(isRequestFulfilled)
@@ -77,13 +77,13 @@ class ResendHandler {
         return new Promise((resolve) => {
             responseStream
                 .once('data', () => {
-                    this._emitResending(request, source)
+                    this._sendResending(request, source)
                 })
                 .on('data', () => {
                     numOfMessages += 1
                 })
                 .on('data', (unicastMessage) => {
-                    this._emitUnicast(source, unicastMessage)
+                    this._sendUnicast(unicastMessage, source)
                 })
                 .on('error', (error) => {
                     this._emitError(request, error)
@@ -97,20 +97,40 @@ class ResendHandler {
         })
     }
 
-    _emitResending(request, source) {
-        this.sendResponse(source, ControlLayer.ResendResponseResending.create(request.streamId, request.streamPartition, request.subId))
+    _sendResending(request, source) {
+        if (source != null) {
+            this.sendResponse(source, ControlLayer.ResendResponseResending.create(
+                request.streamId,
+                request.streamPartition,
+                request.subId
+            ))
+        }
     }
 
-    _emitUnicast(requestSource, unicastMessage) {
-        this.sendUnicast(requestSource, unicastMessage)
+    _sendUnicast(unicastMessage, source) {
+        if (source != null) {
+            this.sendUnicast(source, unicastMessage)
+        }
     }
 
-    _emitResent(request, source) {
-        this.sendResponse(source, ControlLayer.ResendResponseResent.create(request.streamId, request.streamPartition, request.subId))
+    _sendResent(request, source) {
+        if (source != null) {
+            this.sendResponse(source, ControlLayer.ResendResponseResent.create(
+                request.streamId,
+                request.streamPartition,
+                request.subId
+            ))
+        }
     }
 
-    _emitNoResend(request, source) {
-        this.sendResponse(source, ControlLayer.ResendResponseNoResend.create(request.streamId, request.streamPartition, request.subId))
+    _sendNoResend(request, source) {
+        if (source != null) {
+            this.sendResponse(source, ControlLayer.ResendResponseNoResend.create(
+                request.streamId,
+                request.streamPartition,
+                request.subId
+            ))
+        }
     }
 
     _emitError(request, error) {

--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -18,15 +18,12 @@ class RequestStream extends Readable {
 }
 
 class ResendHandler {
-    constructor(resendStrategies, sendResponse, sendUnicast, notifyError) {
+    constructor(resendStrategies, sendResponse, notifyError) {
         if (resendStrategies == null) {
             throw new Error('resendStrategies not given')
         }
         if (sendResponse == null) {
             throw new Error('sendResponse not given')
-        }
-        if (sendUnicast == null) {
-            throw new Error('sendUnicast not given')
         }
         if (notifyError == null) {
             throw new Error('notifyError not given')
@@ -34,7 +31,6 @@ class ResendHandler {
 
         this.resendStrategies = [...resendStrategies]
         this.sendResponse = sendResponse
-        this.sendUnicast = sendUnicast
         this.notifyError = notifyError
     }
 
@@ -109,7 +105,7 @@ class ResendHandler {
 
     _sendUnicast(unicastMessage, source) {
         if (source != null) {
-            this.sendUnicast(source, unicastMessage)
+            this.sendResponse(source, unicastMessage)
         }
     }
 

--- a/test/integration/l3-resend-requests.test.js
+++ b/test/integration/l3-resend-requests.test.js
@@ -1,11 +1,14 @@
 const intoStream = require('into-stream')
+const { UnicastMessage } = require('streamr-client-protocol').ControlLayer
 
 const { startNetworkNode, startStorageNode, startTracker } = require('../../src/composition')
-const { eventsToArray, waitForEvent, LOCALHOST } = require('../util')
+const { waitForEvent, waitForStreamToEnd, LOCALHOST } = require('../util')
 const Node = require('../../src/logic/Node')
-const NetworkNode = require('../../src/NetworkNode')
 
-const collectNetworkNodeEvents = (node) => eventsToArray(node, Object.values(NetworkNode.events))
+const typesOfStreamItems = async (stream) => {
+    const arr = await waitForStreamToEnd(stream)
+    return arr.map((msg) => msg.type)
+}
 
 /**
  * This test verifies that a node can fulfill resend requests at L3. A resend
@@ -116,38 +119,50 @@ describe('resend requests are fulfilled at L3', () => {
     })
 
     test('requestResendLast', async () => {
-        const events = collectNetworkNodeEvents(contactNode)
-        contactNode.requestResendLast('streamId', 0, 'subId', 10)
+        const stream = contactNode.requestResendLast('streamId', 0, 'subId', 10)
+        const events = await typesOfStreamItems(stream)
 
-        await waitForEvent(contactNode, NetworkNode.events.RESENT)
+        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
-            NetworkNode.events.RESENDING,
-            NetworkNode.events.UNICAST,
-            NetworkNode.events.UNICAST,
-            NetworkNode.events.UNICAST,
-            NetworkNode.events.RESENT,
+            UnicastMessage.TYPE,
+            UnicastMessage.TYPE,
+            UnicastMessage.TYPE,
         ])
     })
 
     test('requestResendFrom', async () => {
-        const events = collectNetworkNodeEvents(contactNode)
-        contactNode.requestResendFrom('streamId', 0, 'subId', 666, 0, 'publisherId', 'msgChainId')
+        const stream = contactNode.requestResendFrom(
+            'streamId',
+            0,
+            'subId',
+            666,
+            0,
+            'publisherId',
+            'msgChainId'
+        )
+        const events = await typesOfStreamItems(stream)
 
-        await waitForEvent(contactNode, NetworkNode.events.RESENT)
+        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
-            NetworkNode.events.RESENDING,
-            NetworkNode.events.UNICAST,
-            NetworkNode.events.RESENT,
+            UnicastMessage.TYPE,
         ])
     })
 
     test('requestResendRange', async () => {
-        const events = collectNetworkNodeEvents(contactNode)
-        contactNode.requestResendRange('streamId', 0, 'subId', 666, 0, 999, 0, 'publisherId', 'msgChainId')
+        const stream = contactNode.requestResendRange(
+            'streamId',
+            0,
+            'subId',
+            666,
+            0,
+            999,
+            0,
+            'publisherId',
+            'msgChainId'
+        )
+        const events = await typesOfStreamItems(stream)
 
-        await waitForEvent(contactNode, NetworkNode.events.NO_RESEND)
-        expect(events).toEqual([
-            NetworkNode.events.NO_RESEND
-        ])
+        expect(stream.fulfilled).toEqual(false)
+        expect(events).toEqual([])
     })
 })


### PR DESCRIPTION
- Fixes #273 
- This change set is _not_ backwards compatible. Thus a major version upgrade should be made once this is landed.
 
Since responses to resend requests are consumed only via `ReadableStream` from broker, there really isn't much point in keeping these unused resend events in NetworkNode. Thus removed them from `NetworkNode` and the corresponding logic from `Node` and `ResendHandler` classes.

Also made a small refactor to `ResendHandler` which allows us to get rid of one extra callback argument.