### PR TITLE
Replace startNode in favor of startNetworkNode

### DIFF
--- a/bin/node.js
+++ b/bin/node.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-const { startNode } = require('../src/composition')
+const { startNetworkNode } = require('../src/composition')
 
 const port = process.argv[2] || 30301
 const ip = process.argv[3] || '127.0.0.1'
 const tracker = process.argv[4] || 'ws://127.0.0.1:30300'
 
-startNode(ip, port, 'node' + port)
+startNetworkNode(ip, port, 'node' + port)
     .then((node) => {
         node.addBootstrapTracker(tracker)
     })

--- a/src/composition.js
+++ b/src/composition.js
@@ -5,10 +5,8 @@ const TrackerNode = require('./protocol/TrackerNode')
 const NodeToNode = require('./protocol/NodeToNode')
 const { peerTypes } = require('./protocol/PeerBook')
 const Tracker = require('./logic/Tracker')
-const Node = require('./logic/Node')
 const NetworkNode = require('./NetworkNode')
 const { startEndpoint } = require('./connection/WsEndpoint')
-const { StreamIdAndPartition } = require('./identifiers')
 
 function startTracker(host, port, id = uuidv4(), maxNeighborsPerNode = 4, advertisedWsUrl = null) {
     const identity = {
@@ -24,24 +22,6 @@ function startTracker(host, port, id = uuidv4(), maxNeighborsPerNode = 4, advert
             maxNeighborsPerNode
         }
         return new Tracker(opts)
-    })
-}
-
-function startNode(host, port, id = uuidv4(), resendStrategies = [], advertisedWsUrl = null) {
-    const identity = {
-        'streamr-peer-id': id,
-        'streamr-peer-type': peerTypes.NODE
-    }
-    return startEndpoint(host, port, identity, advertisedWsUrl).then((endpoint) => {
-        const opts = {
-            id,
-            protocols: {
-                trackerNode: new TrackerNode(endpoint),
-                nodeToNode: new NodeToNode(endpoint)
-            },
-            resendStrategies
-        }
-        return new Node(opts)
     })
 }
 
@@ -83,8 +63,6 @@ function startStorageNode(host, port, id = uuidv4(), storages = [], advertisedWs
 
 module.exports = {
     startTracker,
-    startNode,
     startNetworkNode,
     startStorageNode,
-    StreamIdAndPartition
 }

--- a/test/integration/message-propagation.test.js
+++ b/test/integration/message-propagation.test.js
@@ -1,8 +1,6 @@
 const { MessageLayer } = require('streamr-client-protocol')
 
-const Node = require('../../src/logic/Node')
-const { StreamIdAndPartition } = require('../../src/identifiers')
-const { startTracker, startNode } = require('../../src/composition')
+const { startTracker, startNetworkNode } = require('../../src/composition')
 const { waitForCondition, LOCALHOST } = require('../../test/util')
 
 const { StreamMessage } = MessageLayer
@@ -18,10 +16,10 @@ describe('message propagation in network', () => {
         tracker = await startTracker(LOCALHOST, 33300, 'tracker')
 
         await Promise.all([
-            startNode('127.0.0.1', 33312, 'node-1'),
-            startNode('127.0.0.1', 33313, 'node-2'),
-            startNode('127.0.0.1', 33314, 'node-3'),
-            startNode('127.0.0.1', 33315, 'node-4')
+            startNetworkNode('127.0.0.1', 33312, 'node-1'),
+            startNetworkNode('127.0.0.1', 33313, 'node-2'),
+            startNetworkNode('127.0.0.1', 33314, 'node-3'),
+            startNetworkNode('127.0.0.1', 33315, 'node-4')
         ]).then((res) => {
             [n1, n2, n3, n4] = res
         });
@@ -43,56 +41,62 @@ describe('message propagation in network', () => {
         const n3Messages = []
         const n4Messages = []
 
-        n1.on(Node.events.MESSAGE_PROPAGATED, (streamMessage) => n1Messages.push({
+        n1.addMessageListener((streamMessage) => n1Messages.push({
             streamId: streamMessage.messageId.streamId,
             streamPartition: streamMessage.messageId.streamPartition,
             payload: streamMessage.getParsedContent()
         }))
-        n2.on(Node.events.MESSAGE_PROPAGATED, (streamMessage) => n2Messages.push({
+        n2.addMessageListener((streamMessage) => n2Messages.push({
             streamId: streamMessage.messageId.streamId,
             streamPartition: streamMessage.messageId.streamPartition,
             payload: streamMessage.getParsedContent()
         }))
-        n3.on(Node.events.MESSAGE_PROPAGATED, (streamMessage) => n3Messages.push({
+        n3.addMessageListener((streamMessage) => n3Messages.push({
             streamId: streamMessage.messageId.streamId,
             streamPartition: streamMessage.messageId.streamPartition,
             payload: streamMessage.getParsedContent()
         }))
-        n4.on(Node.events.MESSAGE_PROPAGATED, (streamMessage) => n4Messages.push({
+        n4.addMessageListener((streamMessage) => n4Messages.push({
             streamId: streamMessage.messageId.streamId,
             streamPartition: streamMessage.messageId.streamPartition,
             payload: streamMessage.getParsedContent()
         }))
 
-        n2.subscribeToStreamIfHaveNotYet(new StreamIdAndPartition('stream-1', 0))
-        n3.subscribeToStreamIfHaveNotYet(new StreamIdAndPartition('stream-1', 0))
+        n2.subscribe('stream-1', 0)
+        n3.subscribe('stream-1', 0)
 
         for (let i = 1; i <= 5; ++i) {
-            const streamMessage = StreamMessage.create(
-                ['stream-1', 0, i, 0, 'publisher-id', 'sessionId'],
-                i === 1 ? null : [i - 1, 0],
-                StreamMessage.CONTENT_TYPES.MESSAGE,
-                StreamMessage.ENCRYPTION_TYPES.NONE,
+            n1.publish(
+                'stream-1',
+                0,
+                i,
+                0,
+                'publisherId',
+                'msgChainId',
+                i === 1 ? null : i - 1,
+                i === 1 ? null : 0,
                 {
                     messageNo: i
                 },
                 StreamMessage.SIGNATURE_TYPES.NONE,
                 null
             )
-            n1.onDataReceived(streamMessage)
 
-            const streamMessage2 = StreamMessage.create(
-                ['stream-2', 0, i * 100, 0, 'publisher-id', 'sessionId'],
-                i === 1 ? null : [(i - 1) * 100, 0],
-                StreamMessage.CONTENT_TYPES.MESSAGE,
-                StreamMessage.ENCRYPTION_TYPES.NONE,
+            n4.publish(
+                'stream-2',
+                0,
+                i * 100,
+                0,
+                'publisherId',
+                'msgChainId',
+                i === 1 ? null : (i - 1) * 100,
+                i === 1 ? null : 0,
                 {
                     messageNo: i * 100
                 },
                 StreamMessage.SIGNATURE_TYPES.NONE,
                 null
             )
-            n4.onDataReceived(streamMessage2)
         }
 
         await waitForCondition(() => n1Messages.length === 5)

--- a/test/integration/tracker.test.js
+++ b/test/integration/tracker.test.js
@@ -1,4 +1,4 @@
-const { startNode, startTracker } = require('../../src/composition')
+const { startNetworkNode, startTracker } = require('../../src/composition')
 const { LOCALHOST, waitForEvent } = require('../../test/util')
 const TrackerServer = require('../../src/protocol/TrackerServer')
 
@@ -11,7 +11,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
         tracker = await startTracker(LOCALHOST, 32400, 'tracker')
         expect(tracker.protocols.trackerServer.endpoint.connections.size).toBe(0)
 
-        node1 = await startNode(LOCALHOST, 33371, 'node1')
+        node1 = await startNetworkNode(LOCALHOST, 33371, 'node1')
         await node1.addBootstrapTracker(tracker.getAddress())
 
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
@@ -19,7 +19,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
 
         expect(node1.protocols.trackerNode.endpoint.connections.size).toBe(1)
 
-        node2 = await startNode(LOCALHOST, 33372, 'node2')
+        node2 = await startNetworkNode(LOCALHOST, 33372, 'node2')
         await node2.addBootstrapTracker(tracker.getAddress())
 
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)


### PR DESCRIPTION
- Replace `startNode` with `startNetworkNode` in all remaining tests that haven't been refactored.
- Remove `startNetworkNode` from external API -- *major version upgrade*
- Remove `StreamIdAndPartition` from external API, because only used internally.