### PR TITLE
Fix empty topology bug

### DIFF
--- a/src/logic/OverlayTopology.js
+++ b/src/logic/OverlayTopology.js
@@ -39,11 +39,12 @@ class OverlayTopology {
     }
 
     state() {
-        return Object.assign(...Object.entries(this.nodes).map(([nodeId, neighbors]) => {
+        const entries = Object.entries(this.nodes)
+        return entries.length ? Object.assign(...entries.map(([nodeId, neighbors]) => {
             return {
                 [nodeId]: [...neighbors].sort()
             }
-        }))
+        })) : {}
     }
 
     formInstructions(nodeId) {

--- a/test/unit/OverlayTopology.test.js
+++ b/test/unit/OverlayTopology.test.js
@@ -251,6 +251,19 @@ test('unknown nodes are discarded', () => {
     })
 })
 
+test('test case when all nodes leave topology', () => {
+    const topology = new OverlayTopology(3, (arr) => arr, (arr) => arr[0])
+
+    expect(topology.state()).toEqual({})
+    topology.update('node-1', [])
+    expect(topology.state()).toEqual({
+        'node-1': [
+        ]
+    })
+    topology.leave('node-1')
+    expect(topology.state()).toEqual({})
+})
+
 // TODO: remove or write better, since not the best way to test randomness
 test('100 rounds of typical operation does not lead to invariant exception', () => {
     maxNeighborsPerNodeArray.forEach((maxNeighborsPerNode) => {


### PR DESCRIPTION
We need some kind TTL for empty topology.
`NETWORK-9` in Sentry