### PR TITLE
Fix WsEndpoint#stop

### DIFF
--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -240,13 +240,21 @@ class WsEndpoint extends EventEmitter {
         return p
     }
 
-    stop(callback = () => {}) {
+    stop() {
         clearInterval(this.checkConnectionsInterval)
         this.connections.forEach((connection) => {
             connection.terminate()
         })
 
-        return this.wss.close(callback)
+        return new Promise((resolve, reject) => {
+            this.wss.close((err) => {
+                if (err) {
+                    reject(err)
+                } else {
+                    resolve()
+                }
+            })
+        })
     }
 
     isConnected(address) {

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -249,14 +249,14 @@ class Node extends EventEmitter {
         }
     }
 
-    stop(cb) {
+    stop() {
         this.debug('stopping')
         this.resendHandler.stop()
         this._clearConnectToBootstrapTrackersInterval()
         this._disconnectFromAllNodes()
         this._disconnectFromTrackers()
         this.messageBuffer.clear()
-        return this.protocols.nodeToNode.stop(cb)
+        return this.protocols.nodeToNode.stop()
     }
 
     _disconnectFromTrackers() {

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -80,9 +80,9 @@ module.exports = class Tracker extends EventEmitter {
         this.protocols.trackerServer.sendStorageNodes(source, streamId, foundStorageNodes)
     }
 
-    stop(cb) {
+    stop() {
         this.debug('stopping tracker')
-        return this.protocols.trackerServer.stop(cb)
+        return this.protocols.trackerServer.stop()
     }
 
     getAddress() {

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -63,8 +63,8 @@ class NodeToNode extends BasicProtocol {
         return this.endpoint.getAddress()
     }
 
-    stop(cb) {
-        return this.endpoint.stop(cb)
+    stop() {
+        return this.endpoint.stop()
     }
 
     onPeerConnected(peerId) {

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -20,8 +20,8 @@ class TrackerNode extends BasicProtocol {
         return this.endpoint.send(trackerAddress, encoder.findStorageNodesMessage(streamId))
     }
 
-    stop(cb) {
-        this.endpoint.stop(cb)
+    stop() {
+        this.endpoint.stop()
     }
 
     onMessageReceived(message) {

--- a/src/protocol/TrackerServer.js
+++ b/src/protocol/TrackerServer.js
@@ -26,8 +26,8 @@ class TrackerServer extends BasicProtocol {
         return this.endpoint.getAddress()
     }
 
-    stop(cb) {
-        return this.endpoint.stop(cb)
+    stop() {
+        return this.endpoint.stop()
     }
 
     onPeerConnected(peerId) {

--- a/test/unit/network.node.test.js
+++ b/test/unit/network.node.test.js
@@ -2,10 +2,9 @@ const { startNetworkNode } = require('../../src/composition')
 const { LOCALHOST } = require('../util')
 
 describe('NetworkNode creation', () => {
-    it('should be able to start and stop successfully', async (done) => {
-        await startNetworkNode(LOCALHOST, 30370).then((networkNode) => {
-            expect(networkNode.protocols.nodeToNode.endpoint.getAddress()).toEqual('ws://127.0.0.1:30370')
-            networkNode.stop(() => done())
-        })
+    it('should be able to start and stop successfully', async () => {
+        const networkNode = await startNetworkNode(LOCALHOST, 30370)
+        expect(networkNode.protocols.nodeToNode.endpoint.getAddress()).toEqual('ws://127.0.0.1:30370')
+        await networkNode.stop()
     })
 })

--- a/test/unit/tracker.test.js
+++ b/test/unit/tracker.test.js
@@ -2,9 +2,9 @@ const { LOCALHOST } = require('../util')
 const { startTracker } = require('../../src/composition')
 
 describe('tracker creation', () => {
-    it('should be able to start and stop successfully', async (done) => {
+    it('should be able to start and stop successfully', async () => {
         const tracker = await startTracker(LOCALHOST, 30300, 'tracker')
         expect(tracker.getAddress()).toEqual('ws://127.0.0.1:30300')
-        tracker.stop(() => done())
+        await tracker.stop()
     })
 })


### PR DESCRIPTION
Invoking `await tracker.stop()` or `await node.stop()` didn't really wait for websocket server to close because a Promise wasn't actually returned. Fixed this.

Also got rid of callback-style stop since we aren't really using it. 

See: https://github.com/websockets/ws/blob/master/lib/websocket-server.js#L133