### PR TITLE
NetworkNode#publish take StreamMessage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3383,6 +3383,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "heap": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -6730,12 +6735,14 @@
       }
     },
     "streamr-client-protocol": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-2.2.5.tgz",
-      "integrity": "sha512-dDQtE9z8nlD56IuG8pryrVzM4QxIW44WO/IP6R6QL1vXHqwaL6za65FdvTTW14DEBVXbTokkYmTxTxU89IIfIA==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-2.2.10.tgz",
+      "integrity": "sha512-xwIwaH9tPeYVrCiXhl4uENSzG6eHD/LjGTe+yinfOvvJSVCAsvDfLY7bHzIX6s1no0H7Zy2PuqQb3/tmG164zA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.4.5",
-        "debug": "^3.1.0"
+        "debug": "^3.1.0",
+        "eventemitter3": "^4.0.0",
+        "heap": "^0.2.6"
       },
       "dependencies": {
         "debug": {
@@ -6745,6 +6752,11 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,15 +54,15 @@
     "pidusage": "^2.0.17",
     "speedometer": "^1.1.0",
     "streamr-client": "^2.1.1",
-    "streamr-client-protocol": "^2.2.5",
+    "streamr-client-protocol": "^2.2.10",
     "uuid": "3.3.2",
-    "ws": "^7.1.0"
+    "ws": "^7.1.1"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
+    "eslint": "^6.1.0",
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-config-streamr-nodejs": "^1.1.0",
-    "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-import-order": "2.1.4",
     "into-stream": "^5.1.0",
     "jest": "^24.7.1",

--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -1,12 +1,10 @@
-const { MessageLayer, ControlLayer } = require('streamr-client-protocol')
+const { ControlLayer } = require('streamr-client-protocol')
 
 const { StorageResendStrategy,
     AskNeighborsResendStrategy,
     StorageNodeResendStrategy } = require('./logic/resendStrategies')
 const Node = require('./logic/Node')
 const { StreamIdAndPartition } = require('./identifiers')
-
-const { StreamMessage } = MessageLayer
 
 /*
 Convenience wrapper for building client-facing functionality. Used by broker.
@@ -32,26 +30,7 @@ class NetworkNode extends Node {
         this.opts.storages.forEach((storage) => this.addMessageListener(storage.store.bind(storage)))
     }
 
-    publish(streamId,
-        streamPartition,
-        timestamp,
-        sequenceNo,
-        publisherId,
-        msgChainId,
-        previousTimestamp,
-        previousSequenceNo,
-        content,
-        signatureType,
-        signature) {
-        const streamMessage = StreamMessage.create(
-            [streamId, streamPartition, timestamp, sequenceNo, publisherId, msgChainId],
-            previousTimestamp != null ? [previousTimestamp, previousSequenceNo] : null,
-            StreamMessage.CONTENT_TYPES.MESSAGE,
-            StreamMessage.ENCRYPTION_TYPES.NONE,
-            content,
-            signatureType,
-            signature
-        )
+    publish(streamMessage) {
         this.onDataReceived(streamMessage)
     }
 

--- a/test/integration/do-not-propagate-to-sender-optimization.test.js
+++ b/test/integration/do-not-propagate-to-sender-optimization.test.js
@@ -1,3 +1,4 @@
+const { StreamMessage } = require('streamr-client-protocol').MessageLayer
 const { wait, waitForEvent } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker } = require('../../src/composition')
@@ -48,9 +49,22 @@ describe('optimization: do not propagate to sender', () => {
     // In a fully-connected network the number of duplicates should be (n-1)(n-2) instead of (n-1)^2 when not
     // propagating received messages back to their source
     test('total duplicates == 2 in a fully-connected network of 3 nodes', async () => {
-        n1.publish('stream-id', 0, 100, 0, 'publisher', 'session', 99, 0, {
-            hello: 'world'
-        }, null, 0)
+        n1.publish(StreamMessage.from({
+            streamId: 'stream-id',
+            streamPartition: 0,
+            timestamp: 100,
+            sequenceNumber: 0,
+            publisherId: 'publisher',
+            msgChainId: 'session',
+            previousTimestamp: 99,
+            previousSequenceNumber: 0,
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {
+                hello: 'world'
+            },
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
+        }))
         await wait(250)
 
         expect(n1.metrics.get('onDataReceived:ignoring:duplicate')

--- a/test/integration/message-duplication.test.js
+++ b/test/integration/message-duplication.test.js
@@ -1,3 +1,4 @@
+const { StreamMessage } = require('streamr-client-protocol').MessageLayer
 const { waitForCondition, waitForEvent } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker } = require('../../src/composition')
@@ -48,12 +49,34 @@ describe('duplicate message detection and avoidance', () => {
         }
 
         // Produce data
-        contactNode.publish('stream-id', 0, 100, 0, 'publisher-id', 'session-id', 90, 0, {
-            hello: 'world'
-        })
-        contactNode.publish('stream-id', 0, 120, 0, 'publisher-id', 'session-id', 100, 0, {
-            foo: 'bar'
-        })
+        contactNode.publish(StreamMessage.from({
+            streamId: 'stream-id',
+            streamPartition: 0,
+            timestamp: 100,
+            sequenceNumber: 0,
+            publisherId: 'publisher-id',
+            msgChainId: 'session-id',
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {
+                hello: 'world'
+            },
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
+        }))
+        contactNode.publish(StreamMessage.from({
+            streamId: 'stream-id',
+            streamPartition: 0,
+            timestamp: 120,
+            sequenceNumber: 0,
+            publisherId: 'publisher-id',
+            msgChainId: 'session-id',
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {
+                foo: 'bar'
+            },
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
+        }))
 
         await waitForCondition(() => totalMessages > 9)
     })

--- a/test/integration/message-propagation.test.js
+++ b/test/integration/message-propagation.test.js
@@ -1,10 +1,8 @@
-const { MessageLayer } = require('streamr-client-protocol')
+const { StreamMessage } = require('streamr-client-protocol').MessageLayer
 const { waitForCondition } = require('streamr-test-utils')
 
 const { startTracker, startNetworkNode } = require('../../src/composition')
 const { LOCALHOST } = require('../../test/util')
-
-const { StreamMessage } = MessageLayer
 
 describe('message propagation in network', () => {
     let tracker
@@ -67,37 +65,39 @@ describe('message propagation in network', () => {
         n3.subscribe('stream-1', 0)
 
         for (let i = 1; i <= 5; ++i) {
-            n1.publish(
-                'stream-1',
-                0,
-                i,
-                0,
-                'publisherId',
-                'msgChainId',
-                i === 1 ? null : i - 1,
-                i === 1 ? null : 0,
-                {
+            n1.publish(StreamMessage.from({
+                streamId: 'stream-1',
+                streamPartition: 0,
+                timestamp: i,
+                sequenceNumber: 0,
+                publisherId: 'publisherId',
+                msgChainId: 'msgChainId',
+                previousTimestamp: i === 1 ? null : i - 1,
+                previousSequenceNumber: i === 1 ? null : 0,
+                contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+                encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+                content: {
                     messageNo: i
                 },
-                StreamMessage.SIGNATURE_TYPES.NONE,
-                null
-            )
+                signatureType: StreamMessage.SIGNATURE_TYPES.NONE
+            }))
 
-            n4.publish(
-                'stream-2',
-                0,
-                i * 100,
-                0,
-                'publisherId',
-                'msgChainId',
-                i === 1 ? null : (i - 1) * 100,
-                i === 1 ? null : 0,
-                {
+            n4.publish(StreamMessage.from({
+                streamId: 'stream-2',
+                streamPartition: 0,
+                timestamp: i * 100,
+                sequenceNumber: 0,
+                publisherId: 'publisherId',
+                msgChainId: 'msgChainId',
+                previousTimestamp: i === 1 ? null : (i - 1) * 100,
+                previousSequenceNumber: i === 1 ? null : 0,
+                contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+                encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+                content: {
                     messageNo: i * 100
                 },
-                StreamMessage.SIGNATURE_TYPES.NONE,
-                null
-            )
+                signatureType: StreamMessage.SIGNATURE_TYPES.NONE
+            }))
         }
 
         await waitForCondition(() => n1Messages.length === 5)

--- a/test/integration/nodeMessageBuffering.test.js
+++ b/test/integration/nodeMessageBuffering.test.js
@@ -47,20 +47,19 @@ describe('message buffering of Node', () => {
         destinationNode.subscribe('id', 0)
 
         // "Client" pushes data
-        sourceNode.publish(
-            'id',
-            0,
-            1,
-            0,
-            'publisher-id',
-            'session-id',
-            null,
-            null,
-            {
+        sourceNode.publish(StreamMessage.from({
+            streamId: 'id',
+            streamPartition: 0,
+            timestamp: 1,
+            sequenceNumber: 0,
+            publisherId: 'publisher-id',
+            msgChainId: 'session-id',
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {
                 hello: 'world'
             },
-            StreamMessage.SIGNATURE_TYPES.NONE,
-            null
-        )
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
+        }))
     })
 })

--- a/test/integration/tracker-assigns-storage-node-to-streams.test.js
+++ b/test/integration/tracker-assigns-storage-node-to-streams.test.js
@@ -1,3 +1,4 @@
+const { StreamMessage } = require('streamr-client-protocol').MessageLayer
 const { waitForEvent } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker, startStorageNode } = require('../../src/composition')
@@ -37,8 +38,30 @@ describe('tracker assigns storage node to streams', () => {
     })
 
     it('existing streams are assigned to storage node', async () => {
-        subscriberOne.publish('stream-1', 0, 5, 0, 'publisherId', 'msgChainId', null, null, {}, 0, '')
-        subscriberTwo.publish('stream-2', 0, 10, 0, 'publisherId', 'msgChainId', null, null, {}, 0, '')
+        subscriberOne.publish(StreamMessage.from({
+            streamId: 'stream-1',
+            streamPartition: 0,
+            timestamp: 5,
+            sequenceNumber: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {},
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
+        }))
+        subscriberTwo.publish(StreamMessage.from({
+            streamId: 'stream-2',
+            streamPartition: 0,
+            timestamp: 10,
+            sequenceNumber: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {},
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
+        }))
 
         const [msg1] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)
         const [msg2] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)
@@ -47,8 +70,30 @@ describe('tracker assigns storage node to streams', () => {
     })
 
     it('new streams are assigned to storage node', async () => {
-        subscriberOne.publish('new-stream-1', 0, 5, 0, 'publisherId', 'msgChainId', null, null, {}, 0, '')
-        subscriberTwo.publish('new-stream-2', 0, 10, 0, 'publisherId', 'msgChainId', null, null, {}, 0, '')
+        subscriberOne.publish(StreamMessage.from({
+            streamId: 'new-stream-1',
+            streamPartition: 0,
+            timestamp: 5,
+            sequenceNumber: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {},
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
+        }))
+        subscriberTwo.publish(StreamMessage.from({
+            streamId: 'new-stream-2',
+            streamPartition: 0,
+            timestamp: 10,
+            sequenceNumber: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
+            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            content: {},
+            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
+        }))
 
         const [msg1] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)
         const [msg2] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)


### PR DESCRIPTION
Fixes #309 

Method `NetworkNode#publish` now takes a `StreamMessage` in its parameter. 

*Not* backwards compatible. Broker will need to be changed to accommodate this change.