### PR TITLE
fix crashing of network on invalid numbering

### DIFF
--- a/src/logic/DuplicateMessageDetector.js
+++ b/src/logic/DuplicateMessageDetector.js
@@ -42,6 +42,14 @@ class NumberPair {
     }
 }
 
+class InvalidNumberingError extends Error {
+    constructor() {
+        super('pre-condition: previousNumber < number')
+        // exclude this constructor from stack trace
+        Error.captureStackTrace(this, InvalidNumberingError)
+    }
+}
+
 class GapMisMatchError extends Error {
     constructor(...args) {
         super(...args)
@@ -83,7 +91,7 @@ class DuplicateMessageDetector {
      */
     markAndCheck(previousNumber, number) {
         if (previousNumber && previousNumber.greaterThanOrEqual(number)) {
-            throw new Error('pre-condition: previousNumber < number')
+            throw new InvalidNumberingError()
         }
 
         if (this.gaps.length === 0) {
@@ -157,5 +165,6 @@ class DuplicateMessageDetector {
 module.exports = {
     NumberPair,
     GapMisMatchError,
+    InvalidNumberingError,
     DuplicateMessageDetector
 }

--- a/test/unit/DuplicateMessageDetector.test.js
+++ b/test/unit/DuplicateMessageDetector.test.js
@@ -1,6 +1,7 @@
 const { DuplicateMessageDetector,
     NumberPair,
-    GapMisMatchError } = require('../../src/logic/DuplicateMessageDetector')
+    GapMisMatchError,
+    InvalidNumberingError } = require('../../src/logic/DuplicateMessageDetector')
 
 test('starts empty', () => {
     const detector = new DuplicateMessageDetector()
@@ -174,9 +175,9 @@ describe('erroneous messages that overlap gaps', () => {
 test('checks that number > previousNumber', () => {
     const detector = new DuplicateMessageDetector()
     expect(() => detector.markAndCheck(new NumberPair(5, 0), new NumberPair(1, 0)))
-        .toThrowError('pre-condition: previousNumber < number')
+        .toThrowError(InvalidNumberingError)
     expect(() => detector.markAndCheck(new NumberPair(5, 5), new NumberPair(5, 5)))
-        .toThrowError('pre-condition: previousNumber < number')
+        .toThrowError(InvalidNumberingError)
 })
 
 test('lowest gaps get dropped when reaching maximum number of gaps', () => {


### PR DESCRIPTION
Fixes #320 

Don't crash node in the presence of a message with invalid numbering. Instead emit a `debug` message and increment metrics counter of error type.