### PR TITLE
NET-47: UNSEEN_MESSAGE_RECEIVED event

### DIFF
--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -35,7 +35,7 @@ class NetworkNode extends Node {
     }
 
     addMessageListener(cb) {
-        this.on(Node.events.MESSAGE_PROPAGATED, cb)
+        this.on(Node.events.UNSEEN_MESSAGE_RECEIVED, cb)
     }
 
     subscribe(streamId, streamPartition) {

--- a/test/integration/message-propagation.test.js
+++ b/test/integration/message-propagation.test.js
@@ -143,6 +143,42 @@ describe('message propagation in network', () => {
         ])
         expect(n2Messages).toEqual(n1Messages)
         expect(n3Messages).toEqual(n2Messages)
-        expect(n4Messages).toEqual([])
+        expect(n4Messages).toEqual([
+            {
+                streamId: 'stream-2',
+                streamPartition: 0,
+                payload: {
+                    messageNo: 100
+                },
+            },
+            {
+                streamId: 'stream-2',
+                streamPartition: 0,
+                payload: {
+                    messageNo: 200
+                },
+            },
+            {
+                streamId: 'stream-2',
+                streamPartition: 0,
+                payload: {
+                    messageNo: 300
+                },
+            },
+            {
+                streamId: 'stream-2',
+                streamPartition: 0,
+                payload: {
+                    messageNo: 400
+                },
+            },
+            {
+                streamId: 'stream-2',
+                streamPartition: 0,
+                payload: {
+                    messageNo: 500
+                },
+            }
+        ])
     })
 })

--- a/test/integration/tracker-assigns-storage-node-to-streams.test.js
+++ b/test/integration/tracker-assigns-storage-node-to-streams.test.js
@@ -63,8 +63,8 @@ describe('tracker assigns storage node to streams', () => {
             signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
         }))
 
-        const [msg1] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)
-        const [msg2] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)
+        const [msg1] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
+        const [msg2] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
         expect(msg1.getStreamId()).toEqual('stream-1')
         expect(msg2.getStreamId()).toEqual('stream-2')
     })
@@ -95,8 +95,8 @@ describe('tracker assigns storage node to streams', () => {
             signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
         }))
 
-        const [msg1] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)
-        const [msg2] = await waitForEvent(storageNode, Node.events.MESSAGE_PROPAGATED)
+        const [msg1] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
+        const [msg2] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
         expect(msg1.getStreamId()).toEqual('new-stream-1')
         expect(msg2.getStreamId()).toEqual('new-stream-2')
     })


### PR DESCRIPTION
- Add new event `UNSEEN_MESSAGE_RECEIVED` to class `Node` that is emitted after duplicate detection but before actual message propagation. Also refactor some of the logic between duplicate detection and propagation a little.
- `NetworkNode#addMessageListener` now binds callbacks to event  `UNSEEN_MESSAGE_RECEIVED` instead of `MESSAGE_PROPAGATED`.
- Fix few tests