### PR TITLE
BasicProtocol: do not remove from peerbook

### DIFF
--- a/src/protocol/BasicProtocol.js
+++ b/src/protocol/BasicProtocol.js
@@ -23,12 +23,7 @@ module.exports = class BasicProtocol extends EventEmitter {
         })
 
         this.endpoint.on(endpointEvents.PEER_DISCONNECTED, ({ address, reason }) => {
-            try {
-                this.onPeerDisconnected(this.peerBook.getPeerId(address), reason)
-                this.peerBook.remove(address)
-            } catch (e) {
-                console.error(e)
-            }
+            this.onPeerDisconnected(this.peerBook.getPeerId(address), reason)
         })
     }
 


### PR DESCRIPTION
Miroslav noticed that there may still be incoming messages in buffer even after disconnection of socket. We convert IP address to peerId every time we receive message, but we are removing this mapping on disconnect. Change code so that on disconnect we not remove mapping. Need to figure out cleaning strategy in separate PR (See NET-74) 