### PR TITLE
Fix Dockerfile & tracker.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 # Use official node runtime as base image
 FROM node:10.15.3-alpine
 
-ARG NPM_TOKEN
-
 # Set the working directory to /app
 WORKDIR /app
 
 # Copy app code
 COPY . /app
 
+# Logging level
+ENV DEBUG=streamr:logic:*
+
 # Install package.json dependencies (yes, clean up must be part of same RUN command because of layering)
-RUN apk add --update python build-base && npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN && npm install && apk del python build-base && rm -rf /var/cache/apk/*
+RUN apk add --update python build-base && npm ci && apk del python build-base && rm -rf /var/cache/apk/*
+#RUN apk add --update python build-base && npm ci && apk del python build-base && rm -rf /var/cache/apk/*
 
 # Make port available to the world outside this container
 EXPOSE 30300

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ ENV DEBUG=streamr:logic:*
 
 # Install package.json dependencies (yes, clean up must be part of same RUN command because of layering)
 RUN apk add --update python build-base && npm ci && apk del python build-base && rm -rf /var/cache/apk/*
-#RUN apk add --update python build-base && npm ci && apk del python build-base && rm -rf /var/cache/apk/*
 
 # Make port available to the world outside this container
 EXPOSE 30300

--- a/bin/tracker.js
+++ b/bin/tracker.js
@@ -3,12 +3,14 @@
 const { startTracker } = require('../src/composition')
 
 const port = process.argv[2] || 30300
-const ip = process.argv[3] || '127.0.0.1'
+const host = process.argv[3] || null
 const maxNeighborsPerNode = parseInt(process.argv[4], 10) || 4
 const id = `tracker-${port}`
 
 startTracker(ip, port, id, maxNeighborsPerNode)
-    .then(() => {})
+    .then(() => {
+        console.info('Tracker %s listening on %s:%d', id, ip, port)
+    })
     .catch((err) => {
         console.error(err)
         process.exit(1)

--- a/bin/tracker.js
+++ b/bin/tracker.js
@@ -7,10 +7,8 @@ const host = process.argv[3] || null
 const maxNeighborsPerNode = parseInt(process.argv[4], 10) || 4
 const id = `tracker-${port}`
 
-startTracker(ip, port, id, maxNeighborsPerNode)
-    .then(() => {
-        console.info('Tracker %s listening on %s:%d', id, ip, port)
-    })
+startTracker(host, port, id, maxNeighborsPerNode)
+    .then(() => {})
     .catch((err) => {
         console.error(err)
         process.exit(1)

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -363,7 +363,7 @@ class Node extends EventEmitter {
         this.bootstrapTrackerAddresses.forEach((address) => {
             this.protocols.trackerNode.connectToTracker(address)
                 .catch((err) => {
-                    console.error(`Could not connect to tracker ${address} because '${err}'`)
+                    console.error('Could not connect to tracker %s because %j', address, err)
                 })
         })
     }


### PR DESCRIPTION
Current combination of Dockerfile and tracker.js would bind on 127.0.0.1 causing it to bind on interface loopback `lo`. Fixed it so that default host is null.