### PR TITLE
Fix for verifyIsSetUp bug

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -159,7 +159,7 @@ class Node extends EventEmitter {
             nodeIds.push(node)
         }))
 
-        const currentNodes = this.streams.getAllNodesForStream(streamId)
+        const currentNodes = this.streams.isSetUp(streamId) ? this.streams.getAllNodesForStream(streamId) : []
         const nodesToUnsubscribeFrom = currentNodes.filter((node) => !nodeIds.includes(node))
 
         nodesToUnsubscribeFrom.forEach((node) => {


### PR DESCRIPTION
```
2|main-helsinki-3  | 2019-10-31T20:39:22: Error: Stream <REDACTED>::0 is not set up
2|main-helsinki-3  | 2019-10-31T20:39:22:     at StreamManager._verifyThatIsSetUp (/home/ubuntu/.nvm/versions/node/v10.16.3/lib/node_modules/streamr-broker/node_modules/streamr-network/src/logic/StreamManager.js:141:19)
2|main-helsinki-3  | 2019-10-31T20:39:22:     at StreamManager.getInboundNodesForStream (/home/ubuntu/.nvm/versions/node/v10.16.3/lib/node_modules/streamr-broker/node_modules/streamr-network/src/logic/StreamManager.js:112:14)
2|main-helsinki-3  | 2019-10-31T20:39:22:     at StreamManager.getAllNodesForStream (/home/ubuntu/.nvm/versions/node/v10.16.3/lib/node_modules/streamr-broker/node_modules/streamr-network/src/logic/StreamManager.js:117:37)
2|main-helsinki-3  | 2019-10-31T20:39:22:     at NetworkNode.onTrackerInstructionReceived (/home/ubuntu/.nvm/versions/node/v10.16.3/lib/node_modules/streamr-broker/node_modules/streamr-network/src/logic/Node.js:162:43)
```

We implicitly verify `isSetUp(stream) == true` in the beginning of the function but because of `await Promise.all(...)` this invariant may actually become false after the `await`.