### PR TITLE
prepare for streamr-client-protocol-js 3.0.0

### DIFF
--- a/test/integration/l1-resend-requests.test.js
+++ b/test/integration/l1-resend-requests.test.js
@@ -31,7 +31,8 @@ describe('resend requests are fulfilled at L1', () => {
                     sequenceNo: 50,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 756,
@@ -40,7 +41,8 @@ describe('resend requests are fulfilled at L1', () => {
                     previousSequenceNo: 50,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 800,
@@ -49,7 +51,8 @@ describe('resend requests are fulfilled at L1', () => {
                     previousSequenceNo: 0,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 }
             ]),
             requestFrom: () => intoStream.object([
@@ -58,7 +61,8 @@ describe('resend requests are fulfilled at L1', () => {
                     sequenceNo: 50,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
             ]),
             requestRange: () => intoStream.object([]),

--- a/test/integration/l2-resend-requests.test.js
+++ b/test/integration/l2-resend-requests.test.js
@@ -40,7 +40,8 @@ describe('resend requests are fulfilled at L2', () => {
                     sequenceNo: 50,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
             ]),
             requestFrom: () => intoStream.object([]),
@@ -57,7 +58,8 @@ describe('resend requests are fulfilled at L2', () => {
                     previousSequenceNo: 50,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 800,
@@ -66,7 +68,8 @@ describe('resend requests are fulfilled at L2', () => {
                     previousSequenceNo: 0,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 900,
@@ -75,14 +78,16 @@ describe('resend requests are fulfilled at L2', () => {
                     previousSequenceNo: 0,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 512012,
                     sequenceNo: 0,
                     publisherId: 'publisherId2',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 }
             ]),
             requestRange: () => intoStream.object([]),

--- a/test/integration/l3-resend-requests.test.js
+++ b/test/integration/l3-resend-requests.test.js
@@ -52,7 +52,8 @@ describe('resend requests are fulfilled at L3', () => {
                     previousSequenceNo: 50,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 800,
@@ -61,7 +62,8 @@ describe('resend requests are fulfilled at L3', () => {
                     previousSequenceNo: 0,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 950,
@@ -70,7 +72,8 @@ describe('resend requests are fulfilled at L3', () => {
                     previousSequenceNo: 0,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 }
             ]),
             requestFrom: () => intoStream.object([
@@ -79,7 +82,8 @@ describe('resend requests are fulfilled at L3', () => {
                     sequenceNo: 0,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 }
             ]),
             requestRange: () => intoStream.object([]),

--- a/test/integration/request-resend-from-uninvolved-node.test.js
+++ b/test/integration/request-resend-from-uninvolved-node.test.js
@@ -43,7 +43,8 @@ describe('request resend from uninvolved node', () => {
                     previousSequenceNo: 50,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
                 {
                     timestamp: 800,
@@ -52,7 +53,8 @@ describe('request resend from uninvolved node', () => {
                     previousSequenceNo: 0,
                     publisherId: 'publisherId',
                     msgChainId: 'msgChainId',
-                    data: {}
+                    data: {},
+                    signatureType: 0
                 },
             ])
         }])


### PR DESCRIPTION
Prepare for streamr-client-protocol-js major version upgrade 3.0.0 by using pre-release version 3.0.0-0 and fixing issues.