### PR TITLE
Improve handling of GapMisMatchError

### DIFF
--- a/src/logic/DuplicateMessageDetector.js
+++ b/src/logic/DuplicateMessageDetector.js
@@ -51,8 +51,9 @@ class InvalidNumberingError extends Error {
 }
 
 class GapMisMatchError extends Error {
-    constructor(...args) {
-        super(...args)
+    constructor(state, previousNumber, number) {
+        super('pre-condition: gap overlap in given numbers:'
+            + ` previousNumber=${previousNumber}, number=${number}, state=${state}`)
         Error.captureStackTrace(this, GapMisMatchError) // exclude this constructor from stack trace
     }
 }
@@ -119,7 +120,7 @@ class DuplicateMessageDetector {
             }
             if (previousNumber.greaterThanOrEqual(lowerBound)) {
                 if (number.greaterThan(upperBound)) {
-                    throw new GapMisMatchError('pre-condition: gap overlap in given numbers')
+                    throw new GapMisMatchError(this.toString(), previousNumber, number)
                 }
                 if (previousNumber.equalTo(lowerBound)) {
                     if (number.equalTo(upperBound)) {
@@ -144,7 +145,7 @@ class DuplicateMessageDetector {
                 return true
             }
             if (number.greaterThan(lowerBound)) {
-                throw new GapMisMatchError('pre-condition: gap overlap in given numbers')
+                throw new GapMisMatchError(this.toString(), previousNumber, number)
             }
         }
         return false


### PR DESCRIPTION
`DuplicateMessageDetector` will throw a `GapMisMatchError` when a publisher is violating the numbering rules of message chains. Essentially this error was treated as invariant / pre-condition earlier, but it is not really an invariant / pre-condition of the server logic per se. Instead it really a pre-condition / variant of the client.

Changed code to
- not crash server on `GapMisMatchError`
- warn in server logs when a `GapMisMatchError` is detected
- log more details about numbering in `GapMisMatchError`