### PR TITLE
refactor: ResendHandler

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="JavaScriptLibraryMappings">
     <file url="file://$PROJECT_DIR$" libraries="{network/node_modules}" />
-    <file url="PROJECT" libraries="{network/node_modules}" />
+    <file url="PROJECT" libraries="{@types/jest, network/node_modules}" />
     <includedPredefinedLibrary name="Node.js Core" />
   </component>
 </project>

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -13,6 +13,7 @@ const { InvalidNumberingError } = require('../logic/DuplicateMessageDetector')
 
 const StreamManager = require('./StreamManager')
 const ResendHandler = require('./ResendHandler')
+const proxyRequestStream = require('./proxyRequestStream')
 
 const events = Object.freeze({
     MESSAGE_RECEIVED: 'streamr:node:message-received',
@@ -64,11 +65,7 @@ class Node extends EventEmitter {
 
         this.streams = new StreamManager()
         this.messageBuffer = new MessageBuffer(this.opts.bufferTimeoutInMs, this.opts.bufferMaxSize)
-        this.resendHandler = new ResendHandler(
-            this.opts.resendStrategies,
-            this.protocols.nodeToNode.send.bind(this.protocols.nodeToNode),
-            console.error.bind(console)
-        )
+        this.resendHandler = new ResendHandler(this.opts.resendStrategies, console.error.bind(console))
 
         this.trackers = new Set()
 
@@ -130,7 +127,15 @@ class Node extends EventEmitter {
             source === null ? 'local' : `from ${source}`,
             request.constructor.name,
             request.subId)
-        return this.resendHandler.handleRequest(request, source)
+        const requestStream = this.resendHandler.handleRequest(request, source)
+        if (source != null) {
+            proxyRequestStream(
+                (data) => this.protocols.nodeToNode.send(source, data),
+                request,
+                requestStream
+            )
+        }
+        return requestStream
     }
 
     async onTrackerInstructionReceived(instructionMessage) {

--- a/src/logic/proxyRequestStream.js
+++ b/src/logic/proxyRequestStream.js
@@ -1,0 +1,23 @@
+const { ResendResponseResending,
+    ResendResponseResent,
+    ResendResponseNoResend } = require('streamr-client-protocol').ControlLayer
+
+module.exports = function proxyRequestStream(sendFn, request, requestStream) {
+    const { streamId, streamPartition, subId } = request
+    let fulfilled = false
+    requestStream
+        .once('data', () => {
+            sendFn(ResendResponseResending.create(streamId, streamPartition, subId))
+            fulfilled = true
+        })
+        .on('data', (unicastMessage) => {
+            sendFn(unicastMessage)
+        })
+        .on('end', () => {
+            if (fulfilled) {
+                sendFn(ResendResponseResent.create(streamId, streamPartition, subId))
+            } else {
+                sendFn(ResendResponseNoResend.create(streamId, streamPartition, subId))
+            }
+        })
+}

--- a/test/integration/l1-resend-requests.test.js
+++ b/test/integration/l1-resend-requests.test.js
@@ -76,7 +76,6 @@ describe('resend requests are fulfilled at L1', () => {
         const stream = contactNode.requestResendLast('streamId', 0, 'subId', 10)
         const events = await typesOfStreamItems(stream)
 
-        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
             UnicastMessage.TYPE,
             UnicastMessage.TYPE,
@@ -96,7 +95,6 @@ describe('resend requests are fulfilled at L1', () => {
         )
         const events = await typesOfStreamItems(stream)
 
-        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
             UnicastMessage.TYPE,
         ])
@@ -116,7 +114,6 @@ describe('resend requests are fulfilled at L1', () => {
         )
         const events = await typesOfStreamItems(stream)
 
-        expect(stream.fulfilled).toEqual(false)
         expect(events).toEqual([])
     })
 })

--- a/test/integration/l2-resend-requests.test.js
+++ b/test/integration/l2-resend-requests.test.js
@@ -114,7 +114,6 @@ describe('resend requests are fulfilled at L2', () => {
         const stream = contactNode.requestResendLast('streamId', 0, 'subId', 10)
         const events = await typesOfStreamItems(stream)
 
-        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
             UnicastMessage.TYPE,
         ])
@@ -132,7 +131,6 @@ describe('resend requests are fulfilled at L2', () => {
         )
         const events = await typesOfStreamItems(stream)
 
-        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
             UnicastMessage.TYPE,
             UnicastMessage.TYPE,
@@ -155,7 +153,6 @@ describe('resend requests are fulfilled at L2', () => {
         )
         const events = await typesOfStreamItems(stream)
 
-        expect(stream.fulfilled).toEqual(false)
         expect(events).toEqual([])
     })
 })

--- a/test/integration/l3-resend-requests.test.js
+++ b/test/integration/l3-resend-requests.test.js
@@ -122,8 +122,6 @@ describe('resend requests are fulfilled at L3', () => {
     test('requestResendLast', async () => {
         const stream = contactNode.requestResendLast('streamId', 0, 'subId', 10)
         const events = await typesOfStreamItems(stream)
-
-        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
             UnicastMessage.TYPE,
             UnicastMessage.TYPE,
@@ -142,8 +140,6 @@ describe('resend requests are fulfilled at L3', () => {
             'msgChainId'
         )
         const events = await typesOfStreamItems(stream)
-
-        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
             UnicastMessage.TYPE,
         ])
@@ -162,8 +158,6 @@ describe('resend requests are fulfilled at L3', () => {
             'msgChainId'
         )
         const events = await typesOfStreamItems(stream)
-
-        expect(stream.fulfilled).toEqual(false)
         expect(events).toEqual([])
     })
 })

--- a/test/integration/request-resend-from-uninvolved-node.test.js
+++ b/test/integration/request-resend-from-uninvolved-node.test.js
@@ -81,7 +81,6 @@ describe('request resend from uninvolved node', () => {
         const stream = uninvolvedNode.requestResendLast('streamId', 0, 'subId', 10)
         const events = await typesOfStreamItems(stream)
 
-        expect(stream.fulfilled).toEqual(true)
         expect(events).toEqual([
             UnicastMessage.TYPE,
             UnicastMessage.TYPE,

--- a/test/unit/proxyRequestStream.test.js
+++ b/test/unit/proxyRequestStream.test.js
@@ -1,0 +1,73 @@
+const intoStream = require('into-stream')
+const {
+    ResendResponseResending,
+    ResendResponseNoResend,
+    ResendResponseResent,
+    UnicastMessage,
+    ResendLastRequest,
+} = require('streamr-client-protocol').ControlLayer
+const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+
+const proxyRequestStream = require('../../src/logic/proxyRequestStream')
+
+describe('proxyRequestStream', () => {
+    let sendFn
+    let request
+
+    beforeEach(() => {
+        sendFn = jest.fn()
+        request = ResendLastRequest.create('streamId', 0, 'subId', 10, 'sessionToken')
+    })
+
+    it('empty requestStream causes only NoResend to be sent', (done) => {
+        const stream = intoStream.object([])
+        proxyRequestStream(sendFn, request, stream)
+        stream.on('end', () => {
+            expect(sendFn.mock.calls).toEqual([
+                [ResendResponseNoResend.create('streamId', 0, 'subId')]
+            ])
+            done()
+        })
+    })
+
+    it('requestStream with messages causes Resending, Unicast(s), and Resent to be sent', (done) => {
+        const firstMessage = StreamMessage.from({
+            streamId: 'streamId',
+            streamPartition: 0,
+            timestamp: 10000000,
+            sequenceNumber: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            content: {
+                hello: 'world'
+            }
+        })
+        const secondMessage = StreamMessage.from({
+            streamId: 'streamId',
+            streamPartition: 0,
+            timestamp: 20000000,
+            sequenceNumber: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            content: {
+                moi: 'maailma'
+            }
+        })
+        const stream = intoStream.object([
+            UnicastMessage.create('subId', firstMessage),
+            UnicastMessage.create('subId', secondMessage)
+        ])
+
+        proxyRequestStream(sendFn, request, stream)
+
+        stream.on('end', () => {
+            expect(sendFn.mock.calls).toEqual([
+                [ResendResponseResending.create('streamId', 0, 'subId')],
+                [UnicastMessage.create('subId', firstMessage)],
+                [UnicastMessage.create('subId', secondMessage)],
+                [ResendResponseResent.create('streamId', 0, 'subId')],
+            ])
+            done()
+        })
+    })
+})


### PR DESCRIPTION
- Separation of concerns: extract handling of resend proxying (i.e. sending) from `ResendHandler` to separate function `proxyRequestStream`.
- Unit test for `proxyRequestStream`
- Remove unused boolean field `requestStream.fulfilled`
- Fixing of existing resend tests
- Update IntelliJ to work with jest types