### PR TITLE
Cancel resend when node disconnects

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -349,6 +349,7 @@ class Node extends EventEmitter {
 
     onNodeDisconnected(node) {
         this.metrics.inc('onNodeDisconnected')
+        this.resendHandler.cancelResendsOfNode(node)
         this.streams.removeNodeFromAllStreams(node)
         this.debug('removed all subscriptions of node %s', node)
         this._sendStatusToAllTrackers()

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -23,7 +23,7 @@ const events = Object.freeze({
     NODE_UNSUBSCRIBED: 'streamr:node:node-unsubscribed',
     NODE_DISCONNECTED: 'streamr:node:node-disconnected',
     SUBSCRIPTION_REQUEST: 'streamr:node:subscription-received',
-    MESSAGE_DELIVERY_FAILED: 'streamr:node:message-delivery-failed',
+    RESEND_REQUEST_RECEIVED: 'streamr:node:resend-request-received',
 })
 
 const MIN_NUM_OF_OUTBOUND_NODES_FOR_PROPAGATION = 1
@@ -127,6 +127,8 @@ class Node extends EventEmitter {
             source === null ? 'local' : `from ${source}`,
             request.constructor.name,
             request.subId)
+        this.emit(events.RESEND_REQUEST_RECEIVED, request, source)
+
         const requestStream = this.resendHandler.handleRequest(request, source)
         if (source != null) {
             proxyRequestStream(

--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -1,5 +1,31 @@
 const { Readable } = require('stream')
 
+class ResendBookkeeper {
+    constructor() {
+        this.resends = {} // nodeId => Set[Ctx]
+    }
+
+    add(node, ctx) {
+        if (this.resends[node] == null) {
+            this.resends[node] = new Set()
+        }
+        this.resends[node].add(ctx)
+    }
+
+    getContexts(node) {
+        return this.resends[node] == null ? [] : this.resends[node]
+    }
+
+    delete(node, ctx) {
+        if (this.resends[node] != null) {
+            this.resends[node].delete(ctx)
+            if (this.resends[node].size === 0) {
+                delete this.resends[node]
+            }
+        }
+    }
+}
+
 class ResendHandler {
     constructor(resendStrategies, notifyError) {
         if (resendStrategies == null) {
@@ -11,6 +37,7 @@ class ResendHandler {
 
         this.resendStrategies = [...resendStrategies]
         this.notifyError = notifyError
+        this.ongoingResends = new ResendBookkeeper()
     }
 
     handleRequest(request, source) {
@@ -22,7 +49,14 @@ class ResendHandler {
         return requestStream
     }
 
+    cancelResendsOfNode(node) {
+        this.ongoingResends.getContexts(node).forEach((ctx) => ctx.cancel())
+    }
+
     stop() {
+        Object.keys(this.ongoingResends).forEach((node) => {
+            this.cancelResendsOfNode(node)
+        })
         this.resendStrategies.forEach((resendStrategy) => {
             if (resendStrategy.stop) {
                 resendStrategy.stop()
@@ -31,17 +65,33 @@ class ResendHandler {
     }
 
     async _loopThruResendStrategies(request, source, requestStream) {
-        let isRequestFulfilled = false
-
-        for (let i = 0; i < this.resendStrategies.length && !isRequestFulfilled; ++i) {
-            const responseStream = this.resendStrategies[i].getResendResponseStream(request, source)
-                .on('data', requestStream.push.bind(requestStream))
-
-            // eslint-disable-next-line no-await-in-loop
-            isRequestFulfilled = await this._readStreamUntilEndOrError(responseStream, request)
+        const ctx = {
+            stop: false,
+            responseStream: null,
+            cancel: () => {
+                ctx.stop = true
+                if (ctx.responseStream != null) {
+                    ctx.responseStream.destroy()
+                }
+            }
         }
+        this.ongoingResends.add(source, ctx)
 
-        requestStream.push(null)
+        try {
+            for (let i = 0; i < this.resendStrategies.length && !ctx.stop; ++i) {
+                ctx.responseStream = this.resendStrategies[i].getResendResponseStream(request, source)
+                    .on('data', requestStream.push.bind(requestStream))
+
+                // eslint-disable-next-line no-await-in-loop
+                if (await this._readStreamUntilEndOrError(ctx.responseStream, request)) {
+                    ctx.stop = true
+                }
+            }
+
+            requestStream.push(null)
+        } finally {
+            this.ongoingResends.delete(source, ctx)
+        }
     }
 
     _readStreamUntilEndOrError(responseStream, request) {

--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -12,8 +12,13 @@ class ResendBookkeeper {
         this.resends[node].add(ctx)
     }
 
-    getContexts(node) {
-        return this.resends[node] == null ? [] : this.resends[node]
+    popContexts(node) {
+        if (this.resends[node] == null) {
+            return []
+        }
+        const contexts = this.resends[node]
+        delete this.resends[node]
+        return contexts
     }
 
     delete(node, ctx) {
@@ -50,7 +55,7 @@ class ResendHandler {
     }
 
     cancelResendsOfNode(node) {
-        this.ongoingResends.getContexts(node).forEach((ctx) => ctx.cancel())
+        this.ongoingResends.popContexts(node).forEach((ctx) => ctx.cancel())
     }
 
     stop() {

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -18,6 +18,7 @@ const events = Object.freeze({
     RESEND_RESPONSE: 'streamr:node-node:resend-response',
     UNICAST_RECEIVED: 'streamr:node-node:unicast-received'
 })
+
 const eventPerType = {}
 eventPerType[ControlLayer.BroadcastMessage.TYPE] = events.DATA_RECEIVED
 eventPerType[ControlLayer.UnicastMessage.TYPE] = events.UNICAST_RECEIVED

--- a/test/integration/resends-cancelled-on-disconnect.test.js
+++ b/test/integration/resends-cancelled-on-disconnect.test.js
@@ -1,0 +1,131 @@
+const { Readable } = require('stream')
+
+const intoStream = require('into-stream')
+const { waitForEvent, wait } = require('streamr-test-utils')
+
+const { startNetworkNode, startStorageNode, startTracker } = require('../../src/composition')
+const { LOCALHOST } = require('../util')
+const Node = require('../../src/logic/Node')
+/**
+ * This test verifies that a node does not attempt to send a resend response to
+ * a node that previously requested a resend but then promptly disconnected.
+ *
+ * Flow (roughly):
+ *  1. Node C connects to another node S
+ *  2. Node C sends resend request to S
+ *  3. Node C disconnects from node S
+ *  4. Node S should  _not_ send a response to C anymore*
+ */
+
+const createSlowStream = () => {
+    const messages = [
+        {
+            timestamp: 756,
+            sequenceNo: 0,
+            previousTimestamp: 666,
+            previousSequenceNo: 50,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            data: {},
+            signatureType: 0
+        },
+        {
+            timestamp: 800,
+            sequenceNo: 0,
+            previousTimestamp: 756,
+            previousSequenceNo: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            data: {},
+            signatureType: 0
+        },
+        {
+            timestamp: 950,
+            sequenceNo: 0,
+            previousTimestamp: 800,
+            previousSequenceNo: 0,
+            publisherId: 'publisherId',
+            msgChainId: 'msgChainId',
+            data: {},
+            signatureType: 0
+        }
+    ]
+
+    const stream = new Readable({
+        objectMode: true,
+        read() {}
+    })
+
+    for (let i = 0; i < messages.length; ++i) {
+        setTimeout(() => stream.push(messages[i]), i * 100)
+    }
+
+    return stream
+}
+
+describe('resend cancellation on disconnect', () => {
+    let tracker
+    let contactNode
+    let neighborOne
+    let neighborTwo
+    let neighborThree
+
+    beforeAll(async () => {
+        tracker = await startTracker(LOCALHOST, 28650, 'tracker')
+        contactNode = await startNetworkNode(LOCALHOST, 28651, 'contactNode', [{
+            store: () => {},
+            requestLast: () => intoStream.object([]),
+            requestFrom: () => intoStream.object([]),
+            requestRange: () => intoStream.object([]),
+        }])
+        neighborOne = await startNetworkNode(LOCALHOST, 28652, 'neighborOne', [{
+            store: () => {},
+            requestLast: () => createSlowStream(),
+            requestFrom: () => intoStream.object([]),
+            requestRange: () => intoStream.object([]),
+        }])
+        neighborTwo = await startNetworkNode(LOCALHOST, 28653, 'neighborTwo', [])
+        neighborThree = await startStorageNode(LOCALHOST, 28654, 'neighborThree', [{
+            store: () => {},
+            requestLast: () => createSlowStream(),
+            requestFrom: () => intoStream.object([]),
+            requestRange: () => intoStream.object([]),
+        }])
+
+        contactNode.subscribe('streamId', 0)
+        neighborOne.subscribe('streamId', 0)
+        neighborTwo.subscribe('streamId', 0)
+        neighborThree.subscribe('streamId', 0)
+
+        contactNode.addBootstrapTracker(tracker.getAddress())
+        neighborOne.addBootstrapTracker(tracker.getAddress())
+        neighborTwo.addBootstrapTracker(tracker.getAddress())
+        neighborThree.addBootstrapTracker(tracker.getAddress())
+
+        await Promise.all([
+            waitForEvent(contactNode, Node.events.NODE_SUBSCRIBED),
+            waitForEvent(neighborOne, Node.events.NODE_SUBSCRIBED),
+            waitForEvent(neighborTwo, Node.events.NODE_SUBSCRIBED),
+            waitForEvent(neighborThree, Node.events.NODE_SUBSCRIBED)
+        ])
+    })
+
+    afterAll(async () => {
+        await tracker.stop()
+        await contactNode.stop()
+        await neighborOne.stop()
+        await neighborTwo.stop()
+        await neighborThree.stop()
+    })
+
+    test('nodes do not attempt to fulfill a resend request after requesting node disconnects', async () => {
+        contactNode.requestResendLast('streamId', 0, 'subId', 10)
+        await Promise.race([
+            waitForEvent(neighborOne, Node.events.RESEND_REQUEST_RECEIVED),
+            waitForEvent(neighborTwo, Node.events.RESEND_REQUEST_RECEIVED),
+            waitForEvent(neighborThree, Node.events.RESEND_REQUEST_RECEIVED),
+        ])
+        await contactNode.stop()
+        return wait(500) // will throw if sending to non-connected address
+    })
+})


### PR DESCRIPTION
Fixes #358 

If node X has ongoing resend request(s) from node Y, and then node X suddenly decides to disconnect, the ongoing resend requests should be canceled.

- [x] Integration test reproducing issue
- [x] First go at solution
- [x] Refactoring 