### PR TITLE
Cancel ongoing resends if send rejects

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -132,7 +132,16 @@ class Node extends EventEmitter {
         const requestStream = this.resendHandler.handleRequest(request, source)
         if (source != null) {
             proxyRequestStream(
-                (data) => this.protocols.nodeToNode.send(source, data),
+                async (data) => {
+                    try {
+                        this.protocols.nodeToNode.send(source, data)
+                    } catch (e) {
+                        // TODO: catch specific error
+                        const requests = this.resendHandler.cancelResendsOfNode(source)
+                        console.warn('Failed to send resend response to %s,\n\tcancelling resends %j,\n\tError %s',
+                            source, requests, e)
+                    }
+                },
                 request,
                 requestStream
             )

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -134,7 +134,7 @@ class Node extends EventEmitter {
             proxyRequestStream(
                 async (data) => {
                     try {
-                        this.protocols.nodeToNode.send(source, data)
+                        await this.protocols.nodeToNode.send(source, data)
                     } catch (e) {
                         // TODO: catch specific error
                         const requests = this.resendHandler.cancelResendsOfNode(source)

--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -18,7 +18,7 @@ class ResendBookkeeper {
         }
         const contexts = this.resends[node]
         delete this.resends[node]
-        return contexts
+        return [...contexts]
     }
 
     delete(node, ctx) {
@@ -55,7 +55,9 @@ class ResendHandler {
     }
 
     cancelResendsOfNode(node) {
-        this.ongoingResends.popContexts(node).forEach((ctx) => ctx.cancel())
+        const contexts = this.ongoingResends.popContexts(node)
+        contexts.forEach((ctx) => ctx.cancel())
+        return contexts.map((ctx) => ctx.request)
     }
 
     stop() {
@@ -71,6 +73,7 @@ class ResendHandler {
 
     async _loopThruResendStrategies(request, source, requestStream) {
         const ctx = {
+            request,
             stop: false,
             responseStream: null,
             cancel: () => {


### PR DESCRIPTION
As previous PR #366 did not fix issue #358 in production, as `disconnect` event does not seem to occur when killing brokers, implemented an additional check in this PR. If `send` function rejects when trying to respond to a resend request, cancel all the ongoing resends of the source node.