### PR TITLE
ResendHandler: handle responeStream 'close' event

### DIFF
--- a/src/logic/ResendHandler.js
+++ b/src/logic/ResendHandler.js
@@ -151,6 +151,9 @@ class ResendHandler {
                 .on('end', () => {
                     resolve(numOfMessages > 0)
                 })
+                .on('close', () => {
+                    resolve(numOfMessages > 0)
+                })
         })
     }
 }


### PR DESCRIPTION
If a responseStream is closed prematurely by user of library, the `await` within the loop in method `_loopThruResendStrategies` never resolves/rejects. Thus resources are never freed and the reconnection counter does not decrement.