### PR TITLE
Fix promises

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,12 @@ const ERROR = 2
 
 module.exports = exports = {
     extends: [
-        'streamr-nodejs'
+        'streamr-nodejs',
+        'plugin:promise/recommended'
     ],
     rules: {
         'max-len': [WARN, { code: 150 }],
-        'max-classes-per-file': DISABLED
+        'max-classes-per-file': DISABLED,
+        'promise/always-return': WARN
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,6 +2324,12 @@
         "lodash.find": "^4.2.0"
       }
     },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-config-streamr-nodejs": "^1.1.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-import-order": "2.1.4",
+    "eslint-plugin-promise": "^4.2.1",
     "into-stream": "^5.1.1",
     "jest": "^25.1.0",
     "portfinder": "^1.0.25",

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -347,8 +347,6 @@ class Node extends EventEmitter {
                 })
             })
         }
-
-        return false
     }
 
     async _unsubscribeFromStreamOnNode(node, streamId) {

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -345,7 +345,6 @@ class Node extends EventEmitter {
                     streamId,
                     node
                 })
-                return true
             })
         }
 

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -333,6 +333,7 @@ class Node extends EventEmitter {
         }
     }
 
+    // eslint-disable-next-line consistent-return
     async _subscribeToStreamOnNode(node, streamId) {
         if (!this.streams.hasInboundNode(streamId, node)) {
             // more strict, so when we get reject from connect, it will be caught

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -335,17 +335,21 @@ class Node extends EventEmitter {
 
     async _subscribeToStreamOnNode(node, streamId) {
         if (!this.streams.hasInboundNode(streamId, node)) {
-            await this.protocols.nodeToNode.sendSubscribe(node, streamId)
+            // more strict, so when we get reject from from connect, it will be catched
+            return this.protocols.nodeToNode.sendSubscribe(node, streamId).then(() => {
+                this.streams.addInboundNode(streamId, node)
+                this.streams.addOutboundNode(streamId, node)
 
-            this.streams.addInboundNode(streamId, node)
-            this.streams.addOutboundNode(streamId, node)
-
-            // TODO get prove message from node that we successfully subscribed
-            this.emit(events.NODE_SUBSCRIBED, {
-                streamId,
-                node
+                // TODO get prove message from node that we successfully subscribed
+                this.emit(events.NODE_SUBSCRIBED, {
+                    streamId,
+                    node
+                })
+                return true
             })
         }
+
+        return false
     }
 
     async _unsubscribeFromStreamOnNode(node, streamId) {

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -335,7 +335,7 @@ class Node extends EventEmitter {
 
     async _subscribeToStreamOnNode(node, streamId) {
         if (!this.streams.hasInboundNode(streamId, node)) {
-            // more strict, so when we get reject from from connect, it will be catched
+            // more strict, so when we get reject from connect, it will be caught
             return this.protocols.nodeToNode.sendSubscribe(node, streamId).then(() => {
                 this.streams.addInboundNode(streamId, node)
                 this.streams.addOutboundNode(streamId, node)

--- a/src/logic/resendStrategies.js
+++ b/src/logic/resendStrategies.js
@@ -176,8 +176,11 @@ class ProxiedResend {
         this.nodeToNode.send(neighborId, this.request).then(() => {
             this.currentNeighbor = neighborId
             this._resetTimeout()
+            return true
         }, () => {
             this._askNextNeighbor()
+        }).catch((e) => {
+            console.error(`Failed to _askNextNeighbor: ${neighborId}, error ${e}`)
         })
     }
 
@@ -386,7 +389,9 @@ class StorageNodeResendStrategy {
             this.trackerNode.findStorageNodes(tracker, streamIdAndPartition).then(
                 () => this.pendingTrackerResponse.addEntry(request, responseStream),
                 () => responseStream.push(null)
-            )
+            ).catch((e) => {
+                console.error(`Failed to _requestStorageNodes, error: ${e}`)
+            })
         }
     }
 

--- a/src/logic/resendStrategies.js
+++ b/src/logic/resendStrategies.js
@@ -176,7 +176,6 @@ class ProxiedResend {
         this.nodeToNode.send(neighborId, this.request).then(() => {
             this.currentNeighbor = neighborId
             this._resetTimeout()
-            return true
         }, () => {
             this._askNextNeighbor()
         }).catch((e) => {

--- a/test/unit/ResendHandler.test.js
+++ b/test/unit/ResendHandler.test.js
@@ -375,13 +375,14 @@ describe('ResendHandler', () => {
             }
 
             let streamHasEnded = false
-            await waitForStreamToEnd(resendHandler.handleRequest(request, 'source'))
+            // eslint-disable-next-line promise/catch-or-return
+            waitForStreamToEnd(resendHandler.handleRequest(request, 'source'))
                 .finally(() => {
                     streamHasEnded = true
                 })
 
             setTimeout(() => {
-                expect(streamHasEnded).toEqual(true)
+                expect(streamHasEnded).toEqual(false)
                 done()
             }, maxInactivityPeriodInMs + 10)
         })

--- a/test/unit/ResendHandler.test.js
+++ b/test/unit/ResendHandler.test.js
@@ -375,12 +375,13 @@ describe('ResendHandler', () => {
             }
 
             let streamHasEnded = false
-            waitForStreamToEnd(resendHandler.handleRequest(request, 'source'))
+            await waitForStreamToEnd(resendHandler.handleRequest(request, 'source'))
                 .finally(() => {
                     streamHasEnded = true
                 })
+
             setTimeout(() => {
-                expect(streamHasEnded).toEqual(false)
+                expect(streamHasEnded).toEqual(true)
                 done()
             }, maxInactivityPeriodInMs + 10)
         })


### PR DESCRIPTION
- Installed `eslint-plugin-promise`, so it'll force some promise rules.
- Change a bit `_subscribeToStreamOnNode`, so no more `uncaught exception in promise` from `connect` function
- @harbu need your help. in file: `test/unit/ResendHandler.test.js` I found missed `await` or it was expected? Anyway when I put `await` back, `streamHasEnded` is always `true`. 