### PR TITLE
Add disconnection timer to node

### DIFF
--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -334,6 +334,8 @@ class Node extends EventEmitter {
         const timeouts = [...this.sendStatusTimeout.values()]
         timeouts.forEach((timeout) => clearTimeout(timeout))
 
+        Object.values(this.disconnectionTimers).forEach((timeout) => clearTimeout(timeout))
+
         this._clearConnectToBootstrapTrackersInterval()
         this.messageBuffer.clear()
         return this.protocols.nodeToNode.stop()
@@ -398,6 +400,7 @@ class Node extends EventEmitter {
         if (!this.streams.isNodePresent(node)) {
             this._clearDisconnectionTimer(node)
             this.disconnectionTimers[node] = setTimeout(() => {
+                delete this.disconnectionTimers[node]
                 if (!this.streams.isNodePresent(node)) {
                     this.debug('no shared streams with node %s, disconnecting', node)
                     this.protocols.nodeToNode.disconnectFromNode(node, disconnectionReasons.NO_SHARED_STREAMS)

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -44,6 +44,7 @@ class Node extends EventEmitter {
             sendStatusToAllTrackersInterval: 1000,
             bufferTimeoutInMs: 60 * 1000,
             bufferMaxSize: 10000,
+            disconnectionWaitTime: 10 * 1000,
             protocols: [],
             resendStrategies: []
         }
@@ -90,6 +91,8 @@ class Node extends EventEmitter {
 
         this.started = new Date().toLocaleString()
         this.metrics = new Metrics(this.peerInfo.peerId)
+
+        this.disconnectionTimers = {}
 
         this.seenButNotPropagated = new LRU({
             max: this.opts.bufferMaxSize,
@@ -180,7 +183,11 @@ class Node extends EventEmitter {
         this.subscribeToStreamIfHaveNotYet(streamId)
 
         const connectedNodes = []
-        await allSettled(nodeAddresses.map((nodeAddress) => this.protocols.nodeToNode.connectToNode(nodeAddress))).then((results) => {
+        await allSettled(nodeAddresses.map(async (nodeAddress) => {
+            const node = await this.protocols.nodeToNode.connectToNode(nodeAddress)
+            this._clearDisconnectionTimer(node)
+            return node
+        })).then((results) => {
             results.forEach((result) => {
                 if (result.status === 'fulfilled') {
                     connectedNodes.push(result.value)
@@ -389,8 +396,13 @@ class Node extends EventEmitter {
         this.streams.removeNodeFromStream(streamId, node)
 
         if (!this.streams.isNodePresent(node)) {
-            this.protocols.nodeToNode.disconnectFromNode(node, disconnectionReasons.NO_SHARED_STREAMS)
-            return node
+            this._clearDisconnectionTimer(node)
+            this.disconnectionTimers[node] = setTimeout(() => {
+                if (!this.streams.isNodePresent(node)) {
+                    this.debug('no shared streams with node %s, disconnecting', node)
+                    this.protocols.nodeToNode.disconnectFromNode(node, disconnectionReasons.NO_SHARED_STREAMS)
+                }
+            }, this.opts.disconnectionWaitTime)
         }
 
         return this.protocols.nodeToNode.sendUnsubscribe(node, streamId)
@@ -434,6 +446,13 @@ class Node extends EventEmitter {
         if (this.connectToBoostrapTrackersInterval) {
             clearInterval(this.connectToBoostrapTrackersInterval)
             this.connectToBoostrapTrackersInterval = null
+        }
+    }
+
+    _clearDisconnectionTimer(nodeId) {
+        if (this.disconnectionTimers[nodeId] != null) {
+            clearTimeout(this.disconnectionTimers[nodeId])
+            delete this.disconnectionTimers[nodeId]
         }
     }
 

--- a/test/integration/tracker-node-reconnect-instructions.test.js
+++ b/test/integration/tracker-node-reconnect-instructions.test.js
@@ -67,6 +67,7 @@ describe('Check tracker instructions to node', () => {
         )
 
         await waitForEvent(nodeOne.protocols.trackerNode, TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED)
+        await waitForEvent(nodeOne, Node.events.NODE_DISCONNECTED)
 
         expect(nodeOne.protocols.trackerNode.endpoint.getPeers().size).toBe(1)
 

--- a/test/integration/tracker-node-reconnect-instructions.test.js
+++ b/test/integration/tracker-node-reconnect-instructions.test.js
@@ -26,6 +26,11 @@ describe('Check tracker instructions to node', () => {
         nodeOne = await startNetworkNode(LOCALHOST, 30952, 'node-1')
         nodeTwo = await startNetworkNode(LOCALHOST, 30953, 'node-2')
 
+        // TODO: a better way of achieving this would be to pass via constructor, but currently not possible when using
+        // startNetworkNode function
+        nodeOne.opts.disconnectionWaitTime = 200
+        nodeTwo.opts.disconnectionWaitTime = 200
+
         nodeOne.subscribe(streamId, 0)
         nodeTwo.subscribe(streamId, 0)
 
@@ -50,7 +55,7 @@ describe('Check tracker instructions to node', () => {
         })
     })
 
-    it('if tracker sends empty list of nodes, so node-one will disconnect from node two', async () => {
+    it('if tracker sends empty list of nodes, node one will disconnect from node two', async () => {
         await Promise.all([
             waitForEvent(nodeOne, Node.events.NODE_SUBSCRIBED),
             waitForEvent(nodeTwo, Node.events.NODE_SUBSCRIBED)

--- a/test/integration/unsubscribe-from-stream.test.js
+++ b/test/integration/unsubscribe-from-stream.test.js
@@ -19,6 +19,11 @@ describe('node unsubscribing from a stream', () => {
         nodeA.addBootstrapTracker(tracker.getAddress())
         nodeB.addBootstrapTracker(tracker.getAddress())
 
+        // TODO: a better way of achieving this would be to pass via constructor, but currently not possible when using
+        // startNetworkNode function
+        nodeA.opts.disconnectionWaitTime = 200
+        nodeB.opts.disconnectionWaitTime = 200
+
         nodeA.subscribe('s', 1)
         nodeB.subscribe('s', 1)
         nodeA.subscribe('s', 2)


### PR DESCRIPTION
Cherry-picked from WebRTC branch.

Upon noticing that there are no shared streams, a node will now wait a pre-determined time (`disconnectionWaitTime`) before actually disconnecting from the other node. If during this time a new connection is formed between the two nodes, or if after the timeout the two nodes have shared streams again, the disconnection will be canceled. This allows nodes to be more resilient in the face of connection churn caused by tracker instructions during network stabilisation.