### PR TITLE
Upgrade protocol library to 5.x

### DIFF
--- a/bin/publisher.js
+++ b/bin/publisher.js
@@ -7,7 +7,7 @@ const CURRENT_VERSION = require('../package.json').version
 const { startNetworkNode } = require('../src/composition')
 const { StreamIdAndPartition } = require('../src/identifiers')
 
-const { StreamMessage } = MessageLayer
+const { StreamMessage, MessageID, MessageRef } = MessageLayer
 
 program
     .version(CURRENT_VERSION)
@@ -39,17 +39,13 @@ startNetworkNode(program.ip, program.port, publisherId)
             const timestamp = Date.now()
             const msg = 'Hello world, ' + new Date().toLocaleString()
 
-            const streamMessage = StreamMessage.create(
-                [streamId, partition, timestamp, sequenceNumber, publisherId, messageChainId],
-                lastTimestamp == null ? null : [lastTimestamp, sequenceNumber - 1],
-                StreamMessage.CONTENT_TYPES.MESSAGE,
-                StreamMessage.ENCRYPTION_TYPES.NONE,
-                {
+            const streamMessage = new StreamMessage({
+                messageId: new MessageID(streamId, partition, timestamp, sequenceNumber, publisherId, messageChainId),
+                prevMsgRef: lastTimestamp == null ? null : new MessageRef(lastTimestamp, sequenceNumber - 1),
+                content: {
                     msg
                 },
-                StreamMessage.SIGNATURE_TYPES.NONE,
-                null
-            )
+            })
             publisher.publish(streamMessage)
 
             sequenceNumber += 1

--- a/examples/mqtt/mqtt.js
+++ b/examples/mqtt/mqtt.js
@@ -1,7 +1,7 @@
 const mqtt = require('mqtt')
 const { startNetworkNode } = require('../../src/composition')
 const { MessageLayer } = require('streamr-client-protocol')
-const { StreamMessage } = MessageLayer
+const { StreamMessage, MessageID, MessageRef } = MessageLayer
 
 const port = process.argv[2] || 40300
 const ip = process.argv[3] || '127.0.0.1'
@@ -31,17 +31,13 @@ startNetworkNode(ip, port, id)
 
             if (data.VP.desi) {
                 const timestamp = Date.now()
-                const streamMessage = StreamMessage.create(
-                    [streamId, 0, timestamp, sequenceNumber, id, streamId],
-                    lastTimestamp == null ? null : [lastTimestamp, sequenceNumber - 1],
-                    StreamMessage.CONTENT_TYPES.MESSAGE,
-                    StreamMessage.ENCRYPTION_TYPES.NONE,
-                    {
+                const streamMessage = new StreamMessage({
+                    messageId: new MessageID(streamId, 0, timestamp, sequenceNumber, id, streamId),
+                    prevMsgRef: lastTimestamp == null ? null : new MessageRef(lastTimestamp, sequenceNumber - 1),
+                    content: {
                         data
                     },
-                    StreamMessage.SIGNATURE_TYPES.NONE,
-                    null
-                )
+                })
                 mqttNode.publish(streamMessage)
 
                 console.log('---')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-network",
-  "version": "17.9.0-beta.0",
+  "version": "17.9.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -324,12 +324,12 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
-      "integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz",
+      "integrity": "sha512-+a2M/u7r15o3dV1NEizr9bRi+KUVnrs/qYxF0Z06DAPx/4VCWaz1WA7EcbE+uqGgt39lp5akWGmHsTseIkHkHg==",
       "requires": {
         "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -1770,6 +1770,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1838,6 +1843,15 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+      "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -2096,10 +2110,15 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+    },
     "core-js-pure": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3543,6 +3562,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -5932,6 +5956,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-addon-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
+      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -6453,6 +6482,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/promise-memoize/-/promise-memoize-1.2.1.tgz",
+      "integrity": "sha1-cflVSpic9r+Jh7Q6UhMtXHkxJlc="
+    },
     "promise.allsettled": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
@@ -6649,9 +6683,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7076,6 +7110,23 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
+    "secp256k1": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.1.tgz",
+      "integrity": "sha512-iGRjbGAKfXMqhtdkkuNxsgJQfJO8Oo78Rm7DAvsG3XKngq+nJIOGqrCSXcQqIVsmCj0wFanE5uTKFxV3T9j2wg==",
+      "requires": {
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+          "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA=="
+        }
+      }
+    },
     "secure-json-parse": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.1.0.tgz",
@@ -7130,6 +7181,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
       "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+    },
+    "sha3": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.2.tgz",
+      "integrity": "sha512-agYUtkzMsdFTQkM3ECyt6YW0552fyEb0tYZkl7olurS1Vg2Ms5+2SdF4VFPC1jnwtiXMb8b0fSyuAGZh+q2mAw==",
+      "requires": {
+        "buffer": "5.5.0"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -7489,27 +7548,44 @@
         "streamr-client-protocol": "^4.1.1",
         "webpack-node-externals": "^1.7.2",
         "ws": "^7.2.1"
+      },
+      "dependencies": {
+        "streamr-client-protocol": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-4.1.1.tgz",
+          "integrity": "sha512-BvdVjKdpooLhoIj1PjCLOaTiZzmPOWPsU03+RgPVfs/mPTJz2eRQ1pTxj8sphQ6nvcb6VH8XCP7JfyKuRLWgEA==",
+          "requires": {
+            "@babel/runtime-corejs3": "^7.4.5",
+            "debug": "^3.1.0",
+            "eventemitter3": "^4.0.0",
+            "heap": "^0.2.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            }
+          }
+        }
       }
     },
     "streamr-client-protocol": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-4.1.1.tgz",
-      "integrity": "sha512-BvdVjKdpooLhoIj1PjCLOaTiZzmPOWPsU03+RgPVfs/mPTJz2eRQ1pTxj8sphQ6nvcb6VH8XCP7JfyKuRLWgEA==",
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/streamr-client-protocol/-/streamr-client-protocol-5.0.0-beta.4.tgz",
+      "integrity": "sha512-BZVLqiQUVRW04eIcPYSSPMX5qjhXzzjaOUFSfWH7OUiFomRMCe/KxpyCbmGytF5SLJ22b3o01fQVTkMHwgLWiw==",
       "requires": {
-        "@babel/runtime-corejs3": "^7.4.5",
-        "debug": "^3.1.0",
+        "@babel/runtime-corejs3": "^7.9.6",
+        "core-js": "^3.6.5",
+        "debug": "^4.1.1",
         "eventemitter3": "^4.0.0",
-        "heap": "^0.2.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
+        "heap": "^0.2.6",
+        "promise-memoize": "^1.2.1",
+        "secp256k1": "^4.0.1",
+        "sha3": "^2.1.2"
       }
     },
     "streamr-test-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-network",
-  "version": "17.8.0",
+  "version": "17.9.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-network",
-  "version": "17.9.0-beta.0",
+  "version": "17.9.0-beta.1",
   "description": "Streamr P2P network",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "qs": "^6.9.4",
     "speedometer": "^1.1.0",
     "streamr-client": "^3.2.1",
-    "streamr-client-protocol": "^4.1.1",
+    "streamr-client-protocol": "^5.0.0-beta.4",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v17.4.0",
     "uuid": "^8.0.0",
     "ws": "^7.2.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-network",
-  "version": "17.8.0",
+  "version": "17.9.0-beta.0",
   "description": "Streamr P2P network",
   "repository": {
     "type": "git",

--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -1,4 +1,4 @@
-const { ControlLayer } = require('streamr-client-protocol')
+const { ControlLayer, MessageLayer } = require('streamr-client-protocol')
 
 const { StorageResendStrategy,
     AskNeighborsResendStrategy,
@@ -47,20 +47,22 @@ class NetworkNode extends Node {
         this.unsubscribeFromStream(new StreamIdAndPartition(streamId, streamPartition))
     }
 
-    requestResendLast(streamId, streamPartition, requestId, number) {
-        const request = ControlLayer.ResendLastRequest.create(streamId, streamPartition, requestId, number)
+    requestResendLast(streamId, streamPartition, requestId, numberLast) {
+        const request = new ControlLayer.ResendLastRequest({
+            requestId, streamId, streamPartition, numberLast
+        })
         return this.requestResend(request, null)
     }
 
     requestResendFrom(streamId, streamPartition, requestId, fromTimestamp, fromSequenceNo, publisherId, msgChainId) {
-        const request = ControlLayer.ResendFromRequest.create(
+        const request = new ControlLayer.ResendFromRequest({
+            requestId,
             streamId,
             streamPartition,
-            requestId,
-            [fromTimestamp, fromSequenceNo],
+            fromMsgRef: new MessageLayer.MessageRef(fromTimestamp, fromSequenceNo),
             publisherId,
             msgChainId
-        )
+        })
         return this.requestResend(request, null)
     }
 
@@ -73,15 +75,15 @@ class NetworkNode extends Node {
         toSequenceNo,
         publisherId,
         msgChainId) {
-        const request = ControlLayer.ResendRangeRequest.create(
+        const request = new ControlLayer.ResendRangeRequest({
+            requestId,
             streamId,
             streamPartition,
-            requestId,
-            [fromTimestamp, fromSequenceNo],
-            [toTimestamp, toSequenceNo],
+            fromMsgRef: new MessageLayer.MessageRef(fromTimestamp, fromSequenceNo),
+            toMsgRef: new MessageLayer.MessageRef(toTimestamp, toSequenceNo),
             publisherId,
             msgChainId
-        )
+        })
         return this.requestResend(request, null)
     }
 

--- a/src/composition.js
+++ b/src/composition.js
@@ -1,4 +1,5 @@
 const { v4: uuidv4 } = require('uuid')
+const Protocol = require('streamr-client-protocol')
 
 const TrackerServer = require('./protocol/TrackerServer')
 const TrackerNode = require('./protocol/TrackerNode')
@@ -56,4 +57,5 @@ module.exports = {
     startTracker,
     startNetworkNode,
     startStorageNode,
+    Protocol,
 }

--- a/src/logic/proxyRequestStream.js
+++ b/src/logic/proxyRequestStream.js
@@ -7,7 +7,9 @@ module.exports = function proxyRequestStream(sendFn, request, requestStream) {
     let fulfilled = false
     requestStream
         .once('data', () => {
-            sendFn(ResendResponseResending.create(streamId, streamPartition, requestId))
+            sendFn(new ResendResponseResending({
+                requestId, streamId, streamPartition
+            }))
             fulfilled = true
         })
         .on('data', (unicastMessage) => {
@@ -15,9 +17,13 @@ module.exports = function proxyRequestStream(sendFn, request, requestStream) {
         })
         .on('end', () => {
             if (fulfilled) {
-                sendFn(ResendResponseResent.create(streamId, streamPartition, requestId))
+                sendFn(new ResendResponseResent({
+                    requestId, streamId, streamPartition
+                }))
             } else {
-                sendFn(ResendResponseNoResend.create(streamId, streamPartition, requestId))
+                sendFn(new ResendResponseNoResend({
+                    requestId, streamId, streamPartition
+                }))
             }
         })
 }

--- a/test/integration/do-not-propagate-to-sender-optimization.test.js
+++ b/test/integration/do-not-propagate-to-sender-optimization.test.js
@@ -1,4 +1,4 @@
-const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
 const { wait } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker } = require('../../src/composition')
@@ -43,21 +43,12 @@ describe('optimization: do not propagate to sender', () => {
     // propagating received messages back to their source
     test('total duplicates == 2 in a fully-connected network of 3 nodes', async () => {
         await wait(1000)
-        n1.publish(StreamMessage.from({
-            streamId: 'stream-id',
-            streamPartition: 0,
-            timestamp: 100,
-            sequenceNumber: 0,
-            publisherId: 'publisher',
-            msgChainId: 'session',
-            previousTimestamp: 99,
-            previousSequenceNumber: 0,
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        n1.publish(new StreamMessage({
+            messageId: new MessageID('stream-id', 0, 100, 0, 'publisher', 'session'),
+            prevMsgRef: new MessageRef(99, 0),
             content: {
                 hello: 'world'
             },
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }))
         await wait(250)
 

--- a/test/integration/l2-resend-requests.test.js
+++ b/test/integration/l2-resend-requests.test.js
@@ -6,8 +6,8 @@ const { startNetworkNode, startTracker } = require('../../src/composition')
 const { LOCALHOST } = require('../util')
 const Node = require('../../src/logic/Node')
 
-const { UnicastMessage } = ControlLayer
-const { StreamMessage } = MessageLayer
+const { UnicastMessage, ControlMessage } = ControlLayer
+const { StreamMessage, MessageID, MessageRef } = MessageLayer
 
 const typesOfStreamItems = async (stream) => {
     const arr = await waitForStreamToEnd(stream)
@@ -38,15 +38,10 @@ describe('resend requests are fulfilled at L2', () => {
         n1 = await startNetworkNode(LOCALHOST, 28612, 'n1', [{
             store: () => {},
             requestLast: () => intoStream.object([
-                StreamMessage.create(
-                    ['streamId', 0, 666, 50, 'publisherId', 'msgChainId'],
-                    null,
-                    StreamMessage.CONTENT_TYPES.MESSAGE,
-                    StreamMessage.ENCRYPTION_TYPES.NONE,
-                    {},
-                    StreamMessage.SIGNATURE_TYPES.ETH,
-                    'signature'
-                ),
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 666, 50, 'publisherId', 'msgChainId'),
+                    content: {},
+                }),
             ]),
             requestFrom: () => intoStream.object([]),
             requestRange: () => intoStream.object([]),
@@ -55,42 +50,25 @@ describe('resend requests are fulfilled at L2', () => {
             store: () => {},
             requestLast: () => intoStream.object([]),
             requestFrom: () => intoStream.object([
-                StreamMessage.create(
-                    ['streamId', 0, 756, 0, 'publisherId', 'msgChainId'],
-                    [666, 50],
-                    StreamMessage.CONTENT_TYPES.MESSAGE,
-                    StreamMessage.ENCRYPTION_TYPES.NONE,
-                    {},
-                    StreamMessage.SIGNATURE_TYPES.ETH,
-                    'signature'
-                ),
-                StreamMessage.create(
-                    ['streamId', 0, 800, 0, 'publisherId', 'msgChainId'],
-                    [756, 0],
-                    StreamMessage.CONTENT_TYPES.MESSAGE,
-                    StreamMessage.ENCRYPTION_TYPES.NONE,
-                    {},
-                    StreamMessage.SIGNATURE_TYPES.ETH,
-                    'signature'
-                ),
-                StreamMessage.create(
-                    ['streamId', 0, 900, 0, 'publisherId', 'msgChainId'],
-                    [800, 0],
-                    StreamMessage.CONTENT_TYPES.MESSAGE,
-                    StreamMessage.ENCRYPTION_TYPES.NONE,
-                    {},
-                    StreamMessage.SIGNATURE_TYPES.ETH,
-                    'signature'
-                ),
-                StreamMessage.create(
-                    ['streamId', 0, 512012, 0, 'publisherId2', 'msgChainId'],
-                    null,
-                    StreamMessage.CONTENT_TYPES.MESSAGE,
-                    StreamMessage.ENCRYPTION_TYPES.NONE,
-                    {},
-                    StreamMessage.SIGNATURE_TYPES.ETH,
-                    'signature'
-                ),
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
+                    prevMsgRef: new MessageRef(666, 50),
+                    content: {},
+                }),
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
+                    prevMsgRef: new MessageRef(756, 0),
+                    content: {},
+                }),
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 900, 0, 'publisherId', 'msgChainId'),
+                    prevMsgRef: new MessageRef(800, 0),
+                    content: {},
+                }),
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 512012, 0, 'publisherId2', 'msgChainId'),
+                    content: {},
+                }),
             ]),
             requestRange: () => intoStream.object([]),
         }])
@@ -122,7 +100,7 @@ describe('resend requests are fulfilled at L2', () => {
         const events = await typesOfStreamItems(stream)
 
         expect(events).toEqual([
-            UnicastMessage.TYPE,
+            ControlMessage.TYPES.UnicastMessage,
         ])
     })
 
@@ -139,10 +117,10 @@ describe('resend requests are fulfilled at L2', () => {
         const events = await typesOfStreamItems(stream)
 
         expect(events).toEqual([
-            UnicastMessage.TYPE,
-            UnicastMessage.TYPE,
-            UnicastMessage.TYPE,
-            UnicastMessage.TYPE,
+            ControlMessage.TYPES.UnicastMessage,
+            ControlMessage.TYPES.UnicastMessage,
+            ControlMessage.TYPES.UnicastMessage,
+            ControlMessage.TYPES.UnicastMessage,
         ])
     })
 

--- a/test/integration/message-duplication.test.js
+++ b/test/integration/message-duplication.test.js
@@ -1,4 +1,4 @@
-const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
 const { waitForCondition, waitForEvent, wait } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker } = require('../../src/composition')
@@ -51,33 +51,17 @@ describe('duplicate message detection and avoidance', () => {
         }
 
         // Produce data
-        contactNode.publish(StreamMessage.from({
-            streamId: 'stream-id',
-            streamPartition: 0,
-            timestamp: 100,
-            sequenceNumber: 0,
-            publisherId: 'publisher-id',
-            msgChainId: 'session-id',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        contactNode.publish(new StreamMessage({
+            messageId: new MessageID('stream-id', 0, 100, 0, 'publisher', 'session'),
             content: {
                 hello: 'world'
             },
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }))
-        contactNode.publish(StreamMessage.from({
-            streamId: 'stream-id',
-            streamPartition: 0,
-            timestamp: 120,
-            sequenceNumber: 0,
-            publisherId: 'publisher-id',
-            msgChainId: 'session-id',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        contactNode.publish(new StreamMessage({
+            messageId: new MessageID('stream-id', 0, 120, 0, 'publisher', 'session'),
             content: {
-                foo: 'bar'
+                hello: 'world'
             },
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }))
 
         await waitForCondition(() => totalMessages > 9)

--- a/test/integration/message-propagation.test.js
+++ b/test/integration/message-propagation.test.js
@@ -1,4 +1,4 @@
-const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
 const { waitForCondition } = require('streamr-test-utils')
 
 const { startTracker, startNetworkNode } = require('../../src/composition')
@@ -65,38 +65,20 @@ describe('message propagation in network', () => {
         n3.subscribe('stream-1', 0)
 
         for (let i = 1; i <= 5; ++i) {
-            n1.publish(StreamMessage.from({
-                streamId: 'stream-1',
-                streamPartition: 0,
-                timestamp: i,
-                sequenceNumber: 0,
-                publisherId: 'publisherId',
-                msgChainId: 'msgChainId',
-                previousTimestamp: i === 1 ? null : i - 1,
-                previousSequenceNumber: i === 1 ? null : 0,
-                contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            n1.publish(new StreamMessage({
+                messageId: new MessageID('stream-1', 0, i, 0, 'publisherId', 'msgChainId'),
+                prevMsgRef: i === 1 ? null : new MessageRef(i - 1, 0),
                 content: {
                     messageNo: i
                 },
-                signatureType: StreamMessage.SIGNATURE_TYPES.NONE
             }))
 
-            n4.publish(StreamMessage.from({
-                streamId: 'stream-2',
-                streamPartition: 0,
-                timestamp: i * 100,
-                sequenceNumber: 0,
-                publisherId: 'publisherId',
-                msgChainId: 'msgChainId',
-                previousTimestamp: i === 1 ? null : (i - 1) * 100,
-                previousSequenceNumber: i === 1 ? null : 0,
-                contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-                encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+            n4.publish(new StreamMessage({
+                messageId: new MessageID('stream-2', 0, i * 100, 0, 'publisherId', 'msgChainId'),
+                prevMsgRef: i === 1 ? null : new MessageRef((i - 1) * 100, 0),
                 content: {
                     messageNo: i * 100
                 },
-                signatureType: StreamMessage.SIGNATURE_TYPES.NONE
             }))
         }
 

--- a/test/integration/nodeMessageBuffering.test.js
+++ b/test/integration/nodeMessageBuffering.test.js
@@ -49,19 +49,11 @@ describe('message buffering of Node', () => {
         destinationNode.subscribe('id', 0)
 
         // "Client" pushes data
-        sourceNode.publish(StreamMessage.from({
-            streamId: 'id',
-            streamPartition: 0,
-            timestamp: 1,
-            sequenceNumber: 0,
-            publisherId: 'publisher-id',
-            msgChainId: 'session-id',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        sourceNode.publish(new StreamMessage({
+            messageId: new MessageID('id', 0, 1, 0, 'publisher-id', 'session-id'),
             content: {
                 hello: 'world'
             },
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }))
     })
 })

--- a/test/integration/resends-cancelled-on-disconnect.test.js
+++ b/test/integration/resends-cancelled-on-disconnect.test.js
@@ -1,6 +1,6 @@
 const { Readable } = require('stream')
 
-const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
 const intoStream = require('into-stream')
 const { waitForEvent, wait } = require('streamr-test-utils')
 
@@ -20,48 +20,21 @@ const Node = require('../../src/logic/Node')
 
 const createSlowStream = () => {
     const messages = [
-        StreamMessage.from({
-            streamId: 'streamId',
-            streamPartition: 0,
-            timestamp: 756,
-            sequenceNumber: 0,
-            publisherId: 'publisherId',
-            msgChainId: 'msgChainId',
-            previousTimestamp: 666,
-            previousSequenceNumber: 50,
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        new StreamMessage({
+            messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
+            prevMsgRef: new MessageRef(666, 50),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }),
-        StreamMessage.from({
-            streamId: 'streamId',
-            streamPartition: 0,
-            timestamp: 800,
-            sequenceNumber: 0,
-            publisherId: 'publisherId',
-            msgChainId: 'msgChainId',
-            previousTimestamp: 756,
-            previousSequenceNumber: 0,
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        new StreamMessage({
+            messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
+            prevMsgRef: new MessageRef(756, 0),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }),
-        StreamMessage.from({
-            streamId: 'streamId',
-            streamPartition: 0,
-            timestamp: 950,
-            sequenceNumber: 0,
-            publisherId: 'publisherId',
-            msgChainId: 'msgChainId',
-            previousTimestamp: 800,
-            previousSequenceNumber: 0,
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        new StreamMessage({
+            messageId: new MessageID('streamId', 0, 950, 0, 'publisherId', 'msgChainId'),
+            prevMsgRef: new MessageRef(800, 0),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
-        })
+        }),
     ]
 
     const stream = new Readable({

--- a/test/integration/tracker-assigns-storage-node-to-streams.test.js
+++ b/test/integration/tracker-assigns-storage-node-to-streams.test.js
@@ -1,4 +1,4 @@
-const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { StreamMessage, MessageID } = require('streamr-client-protocol').MessageLayer
 const { waitForEvent } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker, startStorageNode } = require('../../src/composition')
@@ -33,32 +33,16 @@ describe('tracker assigns storage node to streams', () => {
     })
 
     it('existing streams are assigned to storage node', async () => {
-        subscriberOne.publish(StreamMessage.from({
-            streamId: 'stream-1',
-            streamPartition: 0,
-            timestamp: 5,
-            sequenceNumber: 0,
-            publisherId: 'publisherId',
-            msgChainId: 'msgChainId',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        subscriberOne.publish(new StreamMessage({
+            messageId: new MessageID('stream-1', 0, 5, 0, 'publisherId', 'msgChainId'),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
         }))
 
         const [msg1] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
 
-        subscriberTwo.publish(StreamMessage.from({
-            streamId: 'stream-2',
-            streamPartition: 0,
-            timestamp: 10,
-            sequenceNumber: 0,
-            publisherId: 'publisherId',
-            msgChainId: 'msgChainId',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        subscriberTwo.publish(new StreamMessage({
+            messageId: new MessageID('stream-2', 0, 10, 0, 'publisherId', 'msgChainId'),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
         }))
 
         const [msg2] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
@@ -67,31 +51,15 @@ describe('tracker assigns storage node to streams', () => {
     })
 
     it('new streams are assigned to storage node', async () => {
-        subscriberOne.publish(StreamMessage.from({
-            streamId: 'new-stream-1',
-            streamPartition: 0,
-            timestamp: 5,
-            sequenceNumber: 0,
-            publisherId: 'publisherId',
-            msgChainId: 'msgChainId',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        subscriberOne.publish(new StreamMessage({
+            messageId: new MessageID('new-stream-1', 0, 5, 0, 'publisherId', 'msgChainId'),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
         }))
         const [msg1] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
 
-        subscriberTwo.publish(StreamMessage.from({
-            streamId: 'new-stream-2',
-            streamPartition: 0,
-            timestamp: 10,
-            sequenceNumber: 0,
-            publisherId: 'publisherId',
-            msgChainId: 'msgChainId',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        subscriberTwo.publish(new StreamMessage({
+            messageId: new MessageID('new-stream-2', 0, 10, 0, 'publisherId', 'msgChainId'),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE,
         }))
         const [msg2] = await waitForEvent(storageNode, Node.events.UNSEEN_MESSAGE_RECEIVED)
 

--- a/test/integration/tracker-assigns-storage-to-empty-stream.test.js
+++ b/test/integration/tracker-assigns-storage-to-empty-stream.test.js
@@ -1,5 +1,5 @@
 const intoStream = require('into-stream')
-const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
 const { waitForEvent, waitForCondition, waitForStreamToEnd } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker, startStorageNode } = require('../../src/composition')
@@ -23,62 +23,27 @@ describe('tracker assigns storage node to streams on any resend', () => {
         storageNode = await startStorageNode(LOCALHOST, 18634, 'storageNode', [{
             store: () => {},
             requestLast: () => intoStream.object([
-                StreamMessage.from({
-                    streamId: 'streamId',
-                    streamPartition: 0,
-                    timestamp: 756,
-                    sequenceNumber: 0,
-                    publisherId: 'publisherId',
-                    msgChainId: 'msgChainId',
-                    previousTimestamp: 666,
-                    previousSequenceNumber: 50,
-                    contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-                    encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
+                    prevMsgRef: new MessageRef(666, 50),
                     content: {},
-                    signatureType: StreamMessage.SIGNATURE_TYPES.NONE
                 }),
-                StreamMessage.from({
-                    streamId: 'streamId',
-                    streamPartition: 0,
-                    timestamp: 800,
-                    sequenceNumber: 0,
-                    publisherId: 'publisherId',
-                    msgChainId: 'msgChainId',
-                    previousTimestamp: 756,
-                    previousSequenceNumber: 0,
-                    contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-                    encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
+                    prevMsgRef: new MessageRef(756, 0),
                     content: {},
-                    signatureType: StreamMessage.SIGNATURE_TYPES.NONE
                 }),
-                StreamMessage.from({
-                    streamId: 'streamId',
-                    streamPartition: 0,
-                    timestamp: 950,
-                    sequenceNumber: 0,
-                    publisherId: 'publisherId',
-                    msgChainId: 'msgChainId',
-                    previousTimestamp: 800,
-                    previousSequenceNumber: 0,
-                    contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-                    encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 950, 0, 'publisherId', 'msgChainId'),
+                    prevMsgRef: new MessageRef(800, 0),
                     content: {},
-                    signatureType: StreamMessage.SIGNATURE_TYPES.NONE
-                })
+                }),
             ]),
             requestFrom: () => intoStream.object([
-                StreamMessage.from({
-                    streamId: 'streamId',
-                    streamPartition: 0,
-                    timestamp: 666,
-                    sequenceNumber: 0,
-                    publisherId: 'publisherId',
-                    msgChainId: 'msgChainId',
-                    contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-                    encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+                new StreamMessage({
+                    messageId: new MessageID('streamId', 0, 666, 0, 'publisherId', 'msgChainId'),
                     content: {},
-                    signatureType: StreamMessage.SIGNATURE_TYPES.NONE
-                })
+                }),
             ]),
             requestRange: () => intoStream.object([]),
         }])

--- a/test/integration/unsubscribe-from-stream.test.js
+++ b/test/integration/unsubscribe-from-stream.test.js
@@ -1,4 +1,4 @@
-const { StreamMessage } = require('streamr-client-protocol').MessageLayer
+const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
 const { waitForEvent } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker } = require('../../src/composition')
@@ -53,29 +53,13 @@ describe('node unsubscribing from a stream', () => {
         nodeB.unsubscribe('s', 2)
         await waitForEvent(nodeA, Node.events.NODE_UNSUBSCRIBED)
 
-        nodeA.publish(StreamMessage.from({
-            streamId: 's',
-            streamPartition: 2,
-            timestamp: 0,
-            sequenceNumber: 0,
-            publisherId: '',
-            msgChainId: '',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        nodeA.publish(new StreamMessage({
+            messageId: new MessageID('s', 2, 0, 0, 'publisherId', 'msgChainId'),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }))
-        nodeA.publish(StreamMessage.from({
-            streamId: 's',
-            streamPartition: 1,
-            timestamp: 0,
-            sequenceNumber: 0,
-            publisherId: '',
-            msgChainId: '',
-            contentType: StreamMessage.CONTENT_TYPES.MESSAGE,
-            encryptionType: StreamMessage.ENCRYPTION_TYPES.NONE,
+        nodeA.publish(new StreamMessage({
+            messageId: new MessageID('s', 1, 0, 0, 'publisherId', 'msgChainId'),
             content: {},
-            signatureType: StreamMessage.SIGNATURE_TYPES.NONE
         }))
         await waitForEvent(nodeB, Node.events.UNSEEN_MESSAGE_RECEIVED)
         expect(actual).toEqual(['s::1'])

--- a/test/unit/MemoryStorage.test.js
+++ b/test/unit/MemoryStorage.test.js
@@ -3,7 +3,7 @@ const { MessageLayer } = require('streamr-client-protocol')
 const MemoryStorage = require('../../src/storage/MemoryStorage')
 const { StreamIdAndPartition } = require('../../src/identifiers')
 
-const { StreamMessage } = MessageLayer
+const { StreamMessage, MessageID, MessageRef } = MessageLayer
 
 let streamMessages = []
 const MAX = 10
@@ -16,17 +16,13 @@ const { id, partition } = streamObj
 let memoryStorage
 
 for (let i = 0; i < MAX; i++) {
-    const streamMessage = StreamMessage.create(
-        [id, partition, i, 0, 'publisher-id', 'sessionId'],
-        i === 0 ? null : [i - 1, 0],
-        StreamMessage.CONTENT_TYPES.MESSAGE,
-        StreamMessage.ENCRYPTION_TYPES.NONE,
-        {
+    const streamMessage = new StreamMessage({
+        messageId: new MessageID(id, partition, i, 0, 'publisher-id', 'sessionId'),
+        prevMsgRef: i === 0 ? null : new MessageRef(i - 1, 0),
+        content: {
             messageNo: i
         },
-        StreamMessage.SIGNATURE_TYPES.NONE,
-        null
-    )
+    })
     streamMessages.push(streamMessage)
 }
 

--- a/test/unit/encoder.test.js
+++ b/test/unit/encoder.test.js
@@ -34,7 +34,11 @@ describe('encoder', () => {
     })
 
     it('check encoding WRAPPER', () => {
-        const payload = ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId')
+        const payload = new ControlLayer.ResendResponseNoResend({
+            requestId: 'requestId',
+            streamId: 'streamId',
+            streamPartition: 0,
+        })
         const actual = encoder.wrapperMessage(payload)
         expect(JSON.parse(actual)).toEqual({
             code: encoder.WRAPPER,
@@ -46,7 +50,11 @@ describe('encoder', () => {
     })
 
     it('check decoding WRAPPER', () => {
-        const payload = ControlLayer.ResendResponseNoResend.create('streamId', 0, 'requestId')
+        const payload = new ControlLayer.ResendResponseNoResend({
+            requestId: 'requestId',
+            streamId: 'streamId',
+            streamPartition: 0,
+        })
         const wrapperMessage = encoder.decode('source', JSON.stringify({
             code: encoder.WRAPPER,
             version,


### PR DESCRIPTION
Start using the new major version of the protocol library, `5.x`. Main changes in the new library version:

- The constructor interfaces of ControlLayer messages and `StreamMessage`s have been unified (the changes in this PR are mostly related to this refactoring)
- Adds support for ControlLayer version `2` and drops support for version `0`
- The serialization/deserialization of messages is a lot faster
- The lib contains utility classes for message validation (not used in `network` yet, but will be used in the future)