### PR TITLE
Add try/catch to encoder

### DIFF
--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -104,7 +104,9 @@ class WsEndpoint extends EventEmitter {
             maxPayloadLength: 1024 * 1024,
             idleTimeout: 0,
             upgrade: (res, req, context) => {
-                res.writeStatus(`101 Switching Protocols\nstreamr-peer-id: ${this.peerInfo.peerId}\nstreamr-peer-type: ${this.peerInfo.peerType}`)
+                res.writeStatus('101 Switching Protocols')
+                    .writeHeader('streamr-peer-id', this.peerInfo.peerId)
+                    .writeHeader('streamr-peer-type', this.peerInfo.peerType)
 
                 /* This immediately calls open handler, you must not use res after this call */
                 res.upgrade({

--- a/src/helpers/MessageEncoder.js
+++ b/src/helpers/MessageEncoder.js
@@ -21,7 +21,14 @@ const encode = (type, payload) => {
 }
 
 const decode = (source, message) => {
-    const { code, payload } = JSON.parse(message)
+    let code
+    let payload
+
+    try {
+        ({ code, payload } = JSON.parse(message))
+    } catch (e) {
+        return undefined
+    }
 
     switch (code) {
         case msgTypes.STATUS:

--- a/src/helpers/MessageEncoder.js
+++ b/src/helpers/MessageEncoder.js
@@ -58,7 +58,8 @@ const decode = (source, message) => {
             return new WrapperMessage(ControlLayer.ControlMessage.deserialize(payload.serializedControlLayerPayload, false), source)
 
         default:
-            throw new Error(`Unknown message type: ${code}`)
+            console.warn(`Got from "${source}" unknown message type with content: "${message}"`)
+            return undefined
     }
 }
 

--- a/src/protocol/NodeToNode.js
+++ b/src/protocol/NodeToNode.js
@@ -4,7 +4,7 @@ const { v4: uuidv4 } = require('uuid')
 const { ControlLayer } = require('streamr-client-protocol')
 
 const encoder = require('../helpers/MessageEncoder')
-const { msgTypes } = require('../messages/messageTypes')
+const WrapperMessage = require('../messages/WrapperMessage')
 const endpointEvents = require('../connection/WsEndpoint').events
 
 const events = Object.freeze({
@@ -96,7 +96,7 @@ class NodeToNode extends EventEmitter {
 
     onMessageReceived(peerInfo, rawMessage) {
         const message = encoder.decode(peerInfo.peerId, rawMessage)
-        if (message.getCode() === msgTypes.WRAPPER) {
+        if (message instanceof WrapperMessage) {
             this.emit(eventPerType[message.controlLayerPayload.type], message.controlLayerPayload, message.getSource())
         }
     }

--- a/src/protocol/TrackerNode.js
+++ b/src/protocol/TrackerNode.js
@@ -33,15 +33,17 @@ class TrackerNode extends EventEmitter {
 
     onMessageReceived(peerInfo, rawMessage) {
         const message = encoder.decode(peerInfo.peerId, rawMessage)
-        switch (message.getCode()) {
-            case encoder.INSTRUCTION:
-                this.emit(events.TRACKER_INSTRUCTION_RECEIVED, peerInfo.peerId, message)
-                break
-            case encoder.STORAGE_NODES:
-                this.emit(events.STORAGE_NODES_RECEIVED, message)
-                break
-            default:
-                break
+        if (message) {
+            switch (message.getCode()) {
+                case encoder.INSTRUCTION:
+                    this.emit(events.TRACKER_INSTRUCTION_RECEIVED, peerInfo.peerId, message)
+                    break
+                case encoder.STORAGE_NODES:
+                    this.emit(events.STORAGE_NODES_RECEIVED, message)
+                    break
+                default:
+                    break
+            }
         }
     }
 

--- a/src/protocol/TrackerServer.js
+++ b/src/protocol/TrackerServer.js
@@ -51,18 +51,20 @@ class TrackerServer extends EventEmitter {
 
     onMessageReceived(peerInfo, rawMessage) {
         const message = encoder.decode(peerInfo.peerId, rawMessage)
-        switch (message.getCode()) {
-            case encoder.STATUS:
-                this.emit(events.NODE_STATUS_RECEIVED, {
-                    statusMessage: message,
-                    isStorage: peerInfo.isStorage()
-                })
-                break
-            case encoder.FIND_STORAGE_NODES:
-                this.emit(events.FIND_STORAGE_NODES_REQUEST, message)
-                break
-            default:
-                break
+        if (message) {
+            switch (message.getCode()) {
+                case encoder.STATUS:
+                    this.emit(events.NODE_STATUS_RECEIVED, {
+                        statusMessage: message,
+                        isStorage: peerInfo.isStorage()
+                    })
+                    break
+                case encoder.FIND_STORAGE_NODES:
+                    this.emit(events.FIND_STORAGE_NODES_REQUEST, message)
+                    break
+                default:
+                    break
+            }
         }
     }
 }

--- a/test/unit/encoder.test.js
+++ b/test/unit/encoder.test.js
@@ -140,9 +140,27 @@ describe('encoder', () => {
         expect(unicastMessage.getNodeAddresses()).toEqual(['ws://node-1', 'ws://node-2'])
     })
 
-    it('encoder doesnt throw exception if failed to JSON.parse', () => {
+    it('encoder.decode doesnt throw exception if failed to JSON.parse', () => {
         expect(() => {
             const message = encoder.decode('source', 'JUST_TEXT_NOT_JSON')
+            expect(message).toBeUndefined()
+        }).not.toThrowError()
+    })
+
+    it('encoder.decode doesnt throw exception if unknown message type', () => {
+        expect(() => {
+            const message = encoder.decode('source', JSON.stringify({
+                code: '777777',
+                version,
+                payload: {
+                    streamId: 'stream-id',
+                    streamPartition: 0,
+                    nodeAddresses: [
+                        'ws://node-1',
+                        'ws://node-2'
+                    ]
+                }
+            }))
             expect(message).toBeUndefined()
         }).not.toThrowError()
     })

--- a/test/unit/encoder.test.js
+++ b/test/unit/encoder.test.js
@@ -139,5 +139,12 @@ describe('encoder', () => {
         expect(unicastMessage.getStreamId()).toEqual(new StreamIdAndPartition('stream-id', 0))
         expect(unicastMessage.getNodeAddresses()).toEqual(['ws://node-1', 'ws://node-2'])
     })
+
+    it('encoder doesnt throw exception if failed to JSON.parse', () => {
+        expect(() => {
+            const message = encoder.decode('source', 'JUST_TEXT_NOT_JSON')
+            expect(message).toBeUndefined()
+        }).not.toThrowError()
+    })
 })
 


### PR DESCRIPTION
Now `encoder` doesn't crash when:
- gets not `JSON`
- unknown message type