### PR TITLE
Instruction counter

### DIFF
--- a/src/helpers/MessageEncoder.js
+++ b/src/helpers/MessageEncoder.js
@@ -38,6 +38,7 @@ const decode = (source, message) => {
             return new InstructionMessage(
                 new StreamIdAndPartition(payload.streamId, payload.streamPartition),
                 payload.nodeAddresses,
+                payload.counter,
                 source
             )
 
@@ -66,10 +67,11 @@ const decode = (source, message) => {
 module.exports = {
     decode,
     statusMessage: (status) => encode(msgTypes.STATUS, status),
-    instructionMessage: (streamId, nodeAddresses) => encode(msgTypes.INSTRUCTION, {
+    instructionMessage: (streamId, nodeAddresses, counter) => encode(msgTypes.INSTRUCTION, {
         streamId: streamId.id,
         streamPartition: streamId.partition,
-        nodeAddresses
+        nodeAddresses,
+        counter
     }),
     findStorageNodesMessage: (streamId) => encode(msgTypes.FIND_STORAGE_NODES, {
         streamId: streamId.id,

--- a/src/logic/InstructionCounter.js
+++ b/src/logic/InstructionCounter.js
@@ -25,8 +25,8 @@ module.exports = class InstructionCounter {
     }
 
     removeStream(streamKey) {
-        Object.values(this.counters).forEach((counterPerStream) => {
-            delete counterPerStream[streamKey]
+        Object.keys(this.counters).forEach((nodeId) => {
+            delete this.counters[nodeId][streamKey]
         })
     }
 

--- a/src/logic/InstructionCounter.js
+++ b/src/logic/InstructionCounter.js
@@ -1,0 +1,42 @@
+module.exports = class InstructionCounter {
+    constructor() {
+        this.counters = {} // nodeId => streamKey => integer
+    }
+
+    setOrIncrement(nodeId, streamKey) {
+        this._getAndSetIfNecessary(nodeId, streamKey)
+        this.counters[nodeId][streamKey] += 1
+        return this.counters[nodeId][streamKey]
+    }
+
+    filterStatus(statusMessage) {
+        const filteredStreams = {}
+        Object.entries(statusMessage.status.streams).forEach(([streamKey, entry]) => {
+            const currentCounter = this._getAndSetIfNecessary(statusMessage.getSource(), streamKey)
+            if (entry.counter >= currentCounter) {
+                filteredStreams[streamKey] = entry
+            }
+        })
+        return filteredStreams
+    }
+
+    removeNode(nodeId) {
+        delete this.counters[nodeId]
+    }
+
+    removeStream(streamKey) {
+        Object.values(this.counters).forEach((counterPerStream) => {
+            delete counterPerStream[streamKey]
+        })
+    }
+
+    _getAndSetIfNecessary(nodeId, streamKey) {
+        if (this.counters[nodeId] === undefined) {
+            this.counters[nodeId] = {}
+        }
+        if (this.counters[nodeId][streamKey] === undefined) {
+            this.counters[nodeId][streamKey] = 0
+        }
+        return this.counters[nodeId][streamKey]
+    }
+}

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -210,7 +210,7 @@ class Node extends EventEmitter {
         }
 
         if (nodeAddresses.length !== nodeIds.length) {
-            this.debug('error: failed to fulfill tracker instructions')
+            this.debug('error: failed to fulfill all tracker instructions')
         }
 
         const currentNodes = this.streams.isSetUp(streamId) ? this.streams.getAllNodesForStream(streamId) : []
@@ -223,6 +223,9 @@ class Node extends EventEmitter {
                 }
             })
         })
+
+        const counter = instructionMessage.getCounter()
+        this.streams.updateCounter(streamId, counter)
     }
 
     onDataReceived(streamMessage, source = null) {

--- a/src/logic/StreamManager.js
+++ b/src/logic/StreamManager.js
@@ -19,7 +19,8 @@ module.exports = class StreamManager {
         this.streams.set(streamId.key(), {
             detectors: new Map(), // "publisherId-msgChainId" => DuplicateMessageDetector
             inboundNodes: new Set(), // Nodes that I am subscribed to for messages
-            outboundNodes: new Set() // Nodes (and clients) that subscribe to me for messages
+            outboundNodes: new Set(), // Nodes (and clients) that subscribe to me for messages
+            counter: 0
         })
     }
 
@@ -39,6 +40,10 @@ module.exports = class StreamManager {
                 : new NumberPair(previousMessageReference.timestamp, previousMessageReference.sequenceNumber),
             new NumberPair(messageId.timestamp, messageId.sequenceNumber)
         )
+    }
+
+    updateCounter(streamId, counter) {
+        this.streams.get(streamId.key()).counter = counter
     }
 
     addInboundNode(streamId, node) {
@@ -90,7 +95,7 @@ module.exports = class StreamManager {
 
     getStreamsWithConnections(tracker, trackersRing) {
         const result = {}
-        this.streams.forEach(({ inboundNodes, outboundNodes }, streamKey) => {
+        this.streams.forEach(({ inboundNodes, outboundNodes, counter }, streamKey) => {
             let addToStatus = true
 
             if (tracker && trackersRing) {
@@ -101,7 +106,8 @@ module.exports = class StreamManager {
             if (addToStatus) {
                 result[streamKey] = {
                     inboundNodes: [...inboundNodes],
-                    outboundNodes: [...outboundNodes]
+                    outboundNodes: [...outboundNodes],
+                    counter
                 }
             }
         })

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -4,6 +4,7 @@ const createDebug = require('debug')
 
 const TrackerServer = require('../protocol/TrackerServer')
 const { StreamIdAndPartition } = require('../identifiers')
+const InstructionCounter = require('./InstructionCounter')
 const Metrics = require('../metrics')
 
 const OverlayTopology = require('./OverlayTopology')

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -28,6 +28,7 @@ module.exports = class Tracker extends EventEmitter {
         }
 
         this.overlayPerStream = {} // streamKey => overlayTopology, where streamKey = streamId::partition
+        this.instructionCounter = new InstructionCounter()
         this.storageNodes = new Map()
 
         this.protocols = opts.protocols
@@ -47,8 +48,7 @@ module.exports = class Tracker extends EventEmitter {
         this.metrics.inc('processNodeStatus')
 
         const source = statusMessage.getSource()
-        const status = statusMessage.getStatus()
-        const { streams } = status
+        const streams = this.instructionCounter.filterStatus(statusMessage)
 
         if (isStorage) {
             this.storageNodes.set(source, streams)
@@ -173,8 +173,9 @@ module.exports = class Tracker extends EventEmitter {
             Object.entries(instructions).forEach(([nodeId, newNeighbors]) => {
                 this.metrics.inc('sendInstruction')
                 try {
-                    this.protocols.trackerServer.sendInstruction(nodeId, StreamIdAndPartition.fromKey(streamKey), newNeighbors)
-                    this.debug('sent instruction %j for stream %s to node %s', newNeighbors, streamKey, nodeId)
+                    const counterValue = this.instructionCounter.setOrIncrement(nodeId, streamKey)
+                    this.protocols.trackerServer.sendInstruction(nodeId, StreamIdAndPartition.fromKey(streamKey), newNeighbors, counterValue)
+                    this.debug('sent instruction %j (%d) for stream %s to node %s', newNeighbors, counterValue, streamKey, nodeId)
                 } catch (e) {
                     console.error(`Failed to _formAndSendInstructions to node ${nodeId}, streamKey ${streamKey}, because of ${e}`)
                 }
@@ -190,8 +191,10 @@ module.exports = class Tracker extends EventEmitter {
 
     _leaveAndCheckEmptyOverlay(streamKey, overlayTopology, node) {
         overlayTopology.leave(node)
+        this.instructionCounter.removeNode(node)
 
         if (overlayTopology.isEmpty()) {
+            this.instructionCounter.removeStream(streamKey)
             delete this.overlayPerStream[streamKey]
         }
     }

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -4,9 +4,9 @@ const createDebug = require('debug')
 
 const TrackerServer = require('../protocol/TrackerServer')
 const { StreamIdAndPartition } = require('../identifiers')
-const InstructionCounter = require('./InstructionCounter')
 const Metrics = require('../metrics')
 
+const InstructionCounter = require('./InstructionCounter')
 const OverlayTopology = require('./OverlayTopology')
 
 const isEmpty = (obj) => Object.keys(obj).length === 0 && obj.constructor === Object

--- a/src/messages/InstructionMessage.js
+++ b/src/messages/InstructionMessage.js
@@ -2,7 +2,7 @@ const { msgTypes } = require('./messageTypes')
 const NetworkMessage = require('./NetworkMessage')
 
 module.exports = class InstructionMessage extends NetworkMessage {
-    constructor(streamId, nodeAddresses = [], source = null) {
+    constructor(streamId, nodeAddresses = [], counter = 0, source = null) {
         super(msgTypes.INSTRUCTION, source)
         if (typeof streamId === 'undefined') {
             throw new Error('streamId cant be undefined')
@@ -10,6 +10,7 @@ module.exports = class InstructionMessage extends NetworkMessage {
 
         this.streamId = streamId
         this.nodeAddresses = nodeAddresses
+        this.counter = counter
     }
 
     getStreamId() {
@@ -18,5 +19,9 @@ module.exports = class InstructionMessage extends NetworkMessage {
 
     getNodeAddresses() {
         return this.nodeAddresses
+    }
+
+    getCounter() {
+        return this.counter
     }
 }

--- a/src/messages/StatusMessage.js
+++ b/src/messages/StatusMessage.js
@@ -13,18 +13,4 @@ module.exports = class StatusMessage extends NetworkMessage {
     getStatus() {
         return this.status
     }
-
-    setStatus(status) {
-        this.status = status
-        return this
-    }
-
-    toJSON() {
-        return {
-            version: this.getVersion(),
-            code: this.getCode(),
-            source: this.getSource(),
-            status: this.getStatus()
-        }
-    }
 }

--- a/src/protocol/TrackerServer.js
+++ b/src/protocol/TrackerServer.js
@@ -19,9 +19,9 @@ class TrackerServer extends EventEmitter {
         this.endpoint.on(endpointEvents.MESSAGE_RECEIVED, (peerInfo, message) => this.onMessageReceived(peerInfo, message))
     }
 
-    sendInstruction(receiverNodeId, streamId, listOfNodeIds) {
+    sendInstruction(receiverNodeId, streamId, listOfNodeIds, counter) {
         const listOfNodeAddresses = listOfNodeIds.map((nodeId) => this.endpoint.resolveAddress(nodeId))
-        this.endpoint.sendSync(receiverNodeId, encoder.instructionMessage(streamId, listOfNodeAddresses))
+        this.endpoint.sendSync(receiverNodeId, encoder.instructionMessage(streamId, listOfNodeAddresses, counter))
     }
 
     sendStorageNodes(receiverNodeId, streamId, listOfNodeIds) {

--- a/test/integration/counter-filtering-in-tracker.test.js
+++ b/test/integration/counter-filtering-in-tracker.test.js
@@ -1,0 +1,98 @@
+const { wait, waitForEvent } = require('streamr-test-utils')
+
+const { PeerInfo } = require('../../src/connection/PeerInfo')
+const { startTracker } = require('../../src/composition')
+const TrackerNode = require('../../src/protocol/TrackerNode')
+const { startEndpoint } = require('../../src/connection/WsEndpoint')
+const { LOCALHOST } = require('../util')
+
+const WAIT_TIME = 200
+
+const formStatus = (counter1, counter2, nodes1, nodes2) => ({
+    streams: {
+        'stream-1::0': {
+            inboundNodes: nodes1,
+            outboundNodes: nodes1,
+            counter: counter1
+        },
+        'stream-2::0': {
+            inboundNodes: nodes2,
+            outboundNodes: nodes2,
+            counter: counter2
+        }
+    }
+})
+
+describe('tracker: counter filtering', () => {
+    let tracker
+    let trackerNode1
+    let trackerNode2
+
+    beforeEach(async () => {
+        tracker = await startTracker(LOCALHOST, 30410, 'tracker')
+        const endpoint1 = await startEndpoint('127.0.0.1', 28662, PeerInfo.newNode('trackerNode1'), null)
+        const endpoint2 = await startEndpoint('127.0.0.1', 28663, PeerInfo.newNode('trackerNode2'), null)
+        trackerNode1 = new TrackerNode(endpoint1)
+        trackerNode2 = new TrackerNode(endpoint2)
+        trackerNode1.connectToTracker(tracker.getAddress())
+        trackerNode2.connectToTracker(tracker.getAddress())
+
+        await Promise.all([
+            waitForEvent(trackerNode1, TrackerNode.events.CONNECTED_TO_TRACKER),
+            waitForEvent(trackerNode2, TrackerNode.events.CONNECTED_TO_TRACKER)
+        ])
+
+        trackerNode1.sendStatus('tracker', formStatus(0, 0, [], []))
+        trackerNode2.sendStatus('tracker', formStatus(0, 0, [], []))
+
+        const res = await Promise.all([
+            waitForEvent(trackerNode1, TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED),
+            waitForEvent(trackerNode1, TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED),
+            waitForEvent(trackerNode2, TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED),
+            waitForEvent(trackerNode2, TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED)
+        ])
+        expect(res.map(([_, instructionMessage]) => instructionMessage.getCounter())).toEqual([1, 1, 1, 1])
+    })
+
+    afterEach(async () => {
+        await trackerNode1.stop()
+        await trackerNode2.stop()
+        await tracker.stop()
+    })
+
+    test('handles status messages with counters equal or more to current counter(s)', async () => {
+        trackerNode1.sendStatus('tracker', formStatus(1, 666, [], []))
+
+        let numOfInstructions = 0
+        trackerNode1.on(TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED, () => {
+            numOfInstructions += 1
+        })
+
+        await wait(WAIT_TIME)
+        expect(numOfInstructions).toEqual(2)
+    })
+
+    test('ignores status messages with counters less than current counter(s)', async () => {
+        trackerNode1.sendStatus('tracker', formStatus(0, 0, [], []))
+
+        let numOfInstructions = 0
+        trackerNode1.on(TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED, () => {
+            numOfInstructions += 1
+        })
+
+        await wait(WAIT_TIME)
+        expect(numOfInstructions).toEqual(0)
+    })
+
+    test('partly handles status messages with mixed counters compared to current counters', async () => {
+        trackerNode1.sendStatus('tracker', formStatus(1, 0, [], []))
+
+        let numOfInstructions = 0
+        trackerNode1.on(TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED, () => {
+            numOfInstructions += 1
+        })
+
+        await wait(WAIT_TIME)
+        expect(numOfInstructions).toEqual(1)
+    })
+})

--- a/test/integration/counter-filtering-in-tracker.test.js
+++ b/test/integration/counter-filtering-in-tracker.test.js
@@ -29,9 +29,9 @@ describe('tracker: counter filtering', () => {
     let trackerNode2
 
     beforeEach(async () => {
-        tracker = await startTracker(LOCALHOST, 30410, 'tracker')
-        const endpoint1 = await startEndpoint('127.0.0.1', 28662, PeerInfo.newNode('trackerNode1'), null)
-        const endpoint2 = await startEndpoint('127.0.0.1', 28663, PeerInfo.newNode('trackerNode2'), null)
+        tracker = await startTracker(LOCALHOST, 30420, 'tracker')
+        const endpoint1 = await startEndpoint('127.0.0.1', 30421, PeerInfo.newNode('trackerNode1'), null)
+        const endpoint2 = await startEndpoint('127.0.0.1', 30422, PeerInfo.newNode('trackerNode2'), null)
         trackerNode1 = new TrackerNode(endpoint1)
         trackerNode2 = new TrackerNode(endpoint2)
         trackerNode1.connectToTracker(tracker.getAddress())

--- a/test/integration/delivery-of-messages-protocol-layer.test.js
+++ b/test/integration/delivery-of-messages-protocol-layer.test.js
@@ -108,7 +108,7 @@ describe('delivery of messages in protocol layer', () => {
     })
 
     test('sendInstruction is delivered', async () => {
-        trackerServer.sendInstruction('trackerNode', new StreamIdAndPartition('stream', 10), ['trackerNode'])
+        trackerServer.sendInstruction('trackerNode', new StreamIdAndPartition('stream', 10), ['trackerNode'], 15)
         const [trackerId, msg] = await waitForEvent(trackerNode, TrackerNode.events.TRACKER_INSTRUCTION_RECEIVED)
 
         expect(trackerId).toEqual('trackerServer')
@@ -116,6 +116,7 @@ describe('delivery of messages in protocol layer', () => {
         expect(msg.getSource()).toEqual('trackerServer')
         expect(msg.getStreamId()).toEqual(new StreamIdAndPartition('stream', 10))
         expect(msg.getNodeAddresses()).toEqual(['ws://127.0.0.1:28513'])
+        expect(msg.getCounter()).toEqual(15)
     })
 
     test('resendLastRequest is delivered', async () => {

--- a/test/unit/InstructionCounter.test.js
+++ b/test/unit/InstructionCounter.test.js
@@ -1,0 +1,216 @@
+const InstructionCounter = require('../../src/logic/InstructionCounter')
+const StatusMessage = require('../../src/messages/StatusMessage')
+
+describe('InstructionCounter', () => {
+    let instructionCounter
+
+    beforeEach(() => {
+        instructionCounter = new InstructionCounter()
+    })
+
+    it('filterStatus returns all if counters have not been set', () => {
+        const status = {
+            streams: {
+                'stream-1': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 1
+                },
+                'stream-2': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 3
+                },
+            }
+        }
+        const filtered = instructionCounter.filterStatus(new StatusMessage(status, 'node'))
+
+        expect(filtered).toEqual(status.streams)
+    })
+
+    it('filterStatus filters streams according to counters', () => {
+        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1')
+
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+
+        instructionCounter.setOrIncrement('node', 'stream-3')
+
+        const status = {
+            streams: {
+                'stream-1': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 1
+                },
+                'stream-2': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 3
+                },
+                'stream-3': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 0
+                },
+            }
+        }
+        const filtered = instructionCounter.filterStatus(new StatusMessage(status, 'node'))
+
+        expect(filtered).toEqual({
+            'stream-2': {
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 3
+            },
+        })
+    })
+
+    it('filterStatus is node-specific', () => {
+        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1')
+
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+
+        instructionCounter.setOrIncrement('node', 'stream-3')
+        instructionCounter.setOrIncrement('node', 'stream-3')
+        instructionCounter.setOrIncrement('node', 'stream-3')
+
+        const status = {
+            streams: {
+                'stream-1': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 1
+                },
+                'stream-2': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 3
+                },
+                'stream-3': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 0
+                },
+            }
+        }
+        const filtered = instructionCounter.filterStatus(new StatusMessage(status, 'another-node'))
+
+        expect(filtered).toEqual(status.streams)
+    })
+
+    it('removeNode unsets counters', () => {
+        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1')
+
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+
+        instructionCounter.setOrIncrement('node', 'stream-3')
+        instructionCounter.setOrIncrement('node', 'stream-3')
+        instructionCounter.setOrIncrement('node', 'stream-3')
+
+        const status = {
+            streams: {
+                'stream-1': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 1
+                },
+                'stream-2': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 3
+                },
+                'stream-3': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 0
+                },
+            }
+        }
+
+        instructionCounter.removeNode('node')
+        const filtered = instructionCounter.filterStatus(new StatusMessage(status, 'node'))
+
+        expect(filtered).toEqual(status.streams)
+    })
+
+    it('removeStream unsets counters', () => {
+        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1')
+        instructionCounter.setOrIncrement('node', 'stream-1')
+
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+        instructionCounter.setOrIncrement('node', 'stream-2')
+
+        instructionCounter.setOrIncrement('node', 'stream-3')
+        instructionCounter.setOrIncrement('node', 'stream-3')
+        instructionCounter.setOrIncrement('node', 'stream-3')
+
+        const status = {
+            streams: {
+                'stream-1': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 1
+                },
+                'stream-2': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 3
+                },
+                'stream-3': {
+                    inboundNodes: [],
+                    outboundNodes: [],
+                    counter: 0
+                },
+            }
+        }
+
+        instructionCounter.removeStream('stream-3')
+        const filtered = instructionCounter.filterStatus(new StatusMessage(status, 'node'))
+
+        expect(filtered).toEqual({
+            'stream-2': {
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 3
+            },
+            'stream-3': {
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 0
+            },
+        })
+    })
+
+    test('setOrIncrement returns node/stream-specific counter value', () => {
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(1)
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(2)
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(3)
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-2')).toEqual(1)
+        expect(instructionCounter.setOrIncrement('node-b', 'stream-1')).toEqual(1)
+        expect(instructionCounter.setOrIncrement('node-b', 'stream-1')).toEqual(2)
+        expect(instructionCounter.setOrIncrement('node-b', 'stream-2')).toEqual(1)
+        expect(instructionCounter.setOrIncrement('node-b', 'stream-3')).toEqual(1)
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(4)
+
+        instructionCounter.removeStream('stream-1')
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(1)
+        expect(instructionCounter.setOrIncrement('node-b', 'stream-1')).toEqual(1)
+
+        instructionCounter.removeNode('node-a')
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-1')).toEqual(1)
+        expect(instructionCounter.setOrIncrement('node-a', 'stream-2')).toEqual(1)
+    })
+})

--- a/test/unit/StreamManager.test.js
+++ b/test/unit/StreamManager.test.js
@@ -119,11 +119,13 @@ describe('StreamManager', () => {
         expect(manager.getStreamsWithConnections()).toEqual({
             'stream-id-2::0': {
                 inboundNodes: ['node-1', 'node-2'],
-                outboundNodes: ['node-3']
+                outboundNodes: ['node-3'],
+                counter: 0
             },
             'stream-id::0': {
                 inboundNodes: ['node-1', 'node-2'],
-                outboundNodes: ['node-1', 'node-3']
+                outboundNodes: ['node-1', 'node-3'],
+                counter: 0
             }
         })
         expect(manager.getAllNodesForStream(streamId)).toEqual(['node-1', 'node-2', 'node-3'])
@@ -173,11 +175,13 @@ describe('StreamManager', () => {
         expect(manager.getStreamsWithConnections()).toEqual({
             'stream-id-2::0': {
                 inboundNodes: ['node-1', 'node-2'],
-                outboundNodes: []
+                outboundNodes: [],
+                counter: 0
             },
             'stream-id::0': {
                 inboundNodes: ['node-2'],
-                outboundNodes: ['node-3']
+                outboundNodes: ['node-3'],
+                counter: 0
             }
         })
 
@@ -218,15 +222,18 @@ describe('StreamManager', () => {
         expect(manager.getStreamsWithConnections()).toEqual({
             'stream-1::0': {
                 inboundNodes: [],
-                outboundNodes: ['should-not-be-removed']
+                outboundNodes: ['should-not-be-removed'],
+                counter: 0
             },
             'stream-1::1': {
                 inboundNodes: ['should-not-be-removed'],
-                outboundNodes: ['should-not-be-removed']
+                outboundNodes: ['should-not-be-removed'],
+                counter: 0
             },
             'stream-2::0': {
                 inboundNodes: ['should-not-be-removed'],
-                outboundNodes: []
+                outboundNodes: [],
+                counter: 0
             }
         })
 
@@ -258,7 +265,42 @@ describe('StreamManager', () => {
         expect(manager.getStreamsWithConnections()).toEqual({
             'stream-2::0': {
                 inboundNodes: ['n1'],
-                outboundNodes: ['n1']
+                outboundNodes: ['n1'],
+                counter: 0
+            }
+        })
+    })
+
+    test('updating counter', () => {
+        manager.setUpStream(new StreamIdAndPartition('stream-1', 0))
+        manager.setUpStream(new StreamIdAndPartition('stream-2', 0))
+
+        expect(manager.getStreamsWithConnections()).toEqual({
+            'stream-1::0': {
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 0
+            },
+            'stream-2::0': {
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 0
+            }
+        })
+
+        manager.updateCounter(new StreamIdAndPartition('stream-1', 0), 50)
+        manager.updateCounter(new StreamIdAndPartition('stream-2', 0), 100)
+
+        expect(manager.getStreamsWithConnections()).toEqual({
+            'stream-1::0': {
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 50
+            },
+            'stream-2::0': {
+                inboundNodes: [],
+                outboundNodes: [],
+                counter: 100
             }
         })
     })

--- a/test/unit/encoder.test.js
+++ b/test/unit/encoder.test.js
@@ -9,8 +9,8 @@ const WrapperMessage = require('../../src/messages/WrapperMessage')
 const { StreamIdAndPartition } = require('../../src/identifiers')
 
 describe('encoder', () => {
-    it('check streamMessage encoding/decoding', () => {
-        const json = encoder.instructionMessage(new StreamIdAndPartition('stream-id', 0), ['node-1', 'node-2'])
+    it('check encoding INSTRUCTION', () => {
+        const json = encoder.instructionMessage(new StreamIdAndPartition('stream-id', 0), ['ws://node-1', 'ws://node-2'], 15)
         expect(JSON.parse(json)).toEqual({
             code: encoder.INSTRUCTION,
             version,
@@ -18,19 +18,37 @@ describe('encoder', () => {
                 streamId: 'stream-id',
                 streamPartition: 0,
                 nodeAddresses: [
-                    'node-1',
-                    'node-2'
-                ]
+                    'ws://node-1',
+                    'ws://node-2'
+                ],
+                counter: 15
             }
         })
+    })
 
-        const source = '127.0.0.1'
-        const streamMessage = encoder.decode(source, json)
+    it('check decoding INSTRUCTION', () => {
+        const instructionMessage = encoder.decode('127.0.0.1', JSON.stringify({
+            code: encoder.INSTRUCTION,
+            version,
+            payload: {
+                streamId: 'stream-id',
+                streamPartition: 0,
+                nodeAddresses: [
+                    'ws://node-1',
+                    'ws://node-2'
+                ],
+                counter: 15
+            }
+        }))
 
-        expect(streamMessage).toBeInstanceOf(InstructionMessage)
-        expect(streamMessage.getSource()).toEqual('127.0.0.1')
-        expect(streamMessage.getStreamId()).toEqual(new StreamIdAndPartition('stream-id', 0))
-        expect(streamMessage.getNodeAddresses()).toEqual(['node-1', 'node-2'])
+        expect(instructionMessage).toBeInstanceOf(InstructionMessage)
+        expect(instructionMessage.getVersion()).toEqual(version)
+        expect(instructionMessage.getCode()).toEqual(encoder.INSTRUCTION)
+        expect(instructionMessage.getSource()).toEqual('127.0.0.1')
+
+        expect(instructionMessage.getStreamId()).toEqual(new StreamIdAndPartition('stream-id', 0))
+        expect(instructionMessage.getNodeAddresses()).toEqual(['ws://node-1', 'ws://node-2'])
+        expect(instructionMessage.getCounter()).toEqual(15)
     })
 
     it('check encoding WRAPPER', () => {


### PR DESCRIPTION
Add counters to instruction messages and status messages.

- Tracker keeps a counter per `(nodeId, streamId)` pair. Tracker increments this counter each time it sends an instruction to `nodeId` for stream `streamId`.
- Upon receiving an instruction from the tracker, node `nodeId` will execute the instructions and then update its internal counter for `streamId` to match the one provided in the instruction. 
- When it is time for node `nodeId` to send a status message to tracker, for each stream, it will include the associated counter value it has stored internally.
- Upon receiving a status message from node `nodeId`, tracker will filter the streams in the message according to counters. The tracker will only handle those streams whose associated counter in the status message is (greater than or) equal to the tracker's current internal counter. 