### PR TITLE
Instruction Throttling

### DIFF
--- a/src/logic/InstructionThrottler.js
+++ b/src/logic/InstructionThrottler.js
@@ -9,7 +9,6 @@ module.exports = class InstructionThrottler {
         this.handling = false
         this.handleFn = handleFn
         this.queue = {} // streamId => instructionMessage
-        this.timeout = null
     }
 
     add(instructionMessage) {
@@ -25,11 +24,6 @@ module.exports = class InstructionThrottler {
 
     isIdle() {
         return !this.handling
-    }
-
-    clear() {
-        this.queue = {}
-        clearTimeout(this.timeout)
     }
 
     async _invokeHandleFnWithLock() {

--- a/src/logic/InstructionThrottler.js
+++ b/src/logic/InstructionThrottler.js
@@ -1,0 +1,56 @@
+/**
+ * InstructionThrottler makes sure that
+ *  1. no more than one instruction is handled at a time
+ *  2. any new instructions arriving while an instruction is being handled are queued in a
+ *     way where only the most latest instruction per streamId is kept in queue.
+ */
+module.exports = class InstructionThrottler {
+    constructor(handleFn) {
+        this.handling = false
+        this.handleFn = handleFn
+        this.queue = {} // streamId => instructionMessage
+        this.timeout = null
+    }
+
+    add(instructionMessage) {
+        this.queue[instructionMessage.getStreamId()] = instructionMessage
+        if (!this.handling) {
+            this._invokeHandleFnWithLock()
+        }
+    }
+
+    removeStreamId(streamId) {
+        delete this.queue[streamId]
+    }
+
+    isIdle() {
+        return !this.handling
+    }
+
+    clear() {
+        this.queue = {}
+        clearTimeout(this.timeout)
+    }
+
+    async _invokeHandleFnWithLock() {
+        const streamIds = Object.keys(this.queue)
+        const streamId = streamIds[0]
+        const instructionMessage = this.queue[streamId]
+        delete this.queue[streamId]
+
+        this.handling = true
+        try {
+            await this.handleFn(instructionMessage)
+        } finally {
+            if (this._isQueueEmpty()) {
+                this.handling = false
+            } else {
+                this._invokeHandleFnWithLock()
+            }
+        }
+    }
+
+    _isQueueEmpty() {
+        return Object.keys(this.queue).length === 0
+    }
+}

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -351,7 +351,6 @@ class Node extends EventEmitter {
 
         this._clearConnectToBootstrapTrackersInterval()
         this.messageBuffer.clear()
-        this.instructionThrottler.clear()
         return this.protocols.nodeToNode.stop()
     }
 

--- a/src/logic/Node.js
+++ b/src/logic/Node.js
@@ -15,6 +15,7 @@ const Metrics = require('../metrics')
 const { GapMisMatchError, InvalidNumberingError } = require('./DuplicateMessageDetector')
 const StreamManager = require('./StreamManager')
 const ResendHandler = require('./ResendHandler')
+const InstructionThrottler = require('./InstructionThrottler')
 const proxyRequestStream = require('./proxyRequestStream')
 
 const events = Object.freeze({
@@ -98,6 +99,8 @@ class Node extends EventEmitter {
             max: this.opts.bufferMaxSize,
             maxAge: this.opts.bufferMaxSize
         })
+
+        this.instructionThrottler = new InstructionThrottler(this.handleTrackerInstruction.bind(this))
     }
 
     onConnectedToTracker(tracker) {
@@ -120,6 +123,7 @@ class Node extends EventEmitter {
     async unsubscribeFromStream(streamId) {
         this.debug('unsubscribeFromStream: remove %s from streams', streamId)
         const nodes = this.streams.removeStream(streamId)
+        this.instructionThrottler.removeStreamId(streamId)
 
         await allSettled(nodes.map((nodeAddress) => this.protocols.nodeToNode.sendUnsubscribe(nodeAddress, streamId))).then((results) => {
             results.forEach((result) => {
@@ -165,10 +169,15 @@ class Node extends EventEmitter {
         return requestStream
     }
 
-    async onTrackerInstructionReceived(trackerId, instructionMessage) {
+    onTrackerInstructionReceived(trackerId, instructionMessage) {
+        this.instructionThrottler.add(instructionMessage)
+    }
+
+    async handleTrackerInstruction(instructionMessage) {
         const streamId = instructionMessage.getStreamId()
         const nodeAddresses = instructionMessage.getNodeAddresses()
         const counter = instructionMessage.getCounter()
+        const trackerId = instructionMessage.getSource()
 
         // Check that tracker matches expected tracker
         const expectedTrackerId = this.trackersRing.get(streamId.key())
@@ -342,6 +351,7 @@ class Node extends EventEmitter {
 
         this._clearConnectToBootstrapTrackersInterval()
         this.messageBuffer.clear()
+        this.instructionThrottler.clear()
         return this.protocols.nodeToNode.stop()
     }
 

--- a/test/unit/InstructionThrottler.test.js
+++ b/test/unit/InstructionThrottler.test.js
@@ -1,0 +1,102 @@
+const { waitForCondition } = require('streamr-test-utils')
+
+const InstructionMessage = require('../../src/messages/InstructionMessage')
+const InstructionThrottler = require('../../src/logic/InstructionThrottler')
+
+describe('InstructionThrottler', () => {
+    let handlerCb
+    let instructionThrottler
+
+    beforeEach(() => {
+        handlerCb = jest.fn().mockResolvedValue(true)
+        instructionThrottler = new InstructionThrottler(handlerCb)
+    })
+
+    function createInstruction(streamId, counter) {
+        return new InstructionMessage(streamId, [], counter)
+    }
+
+    it('all instructions are handled when inserting a burst of them with distinct streams', async () => {
+        instructionThrottler.add(createInstruction('stream-1', 1))
+        instructionThrottler.add(createInstruction('stream-2', 2))
+        instructionThrottler.add(createInstruction('stream-3', 3))
+        instructionThrottler.add(createInstruction('stream-4', 4))
+        instructionThrottler.add(createInstruction('stream-5', 5))
+
+        await waitForCondition(() => instructionThrottler.isIdle())
+
+        expect(handlerCb.mock.calls).toEqual([
+            [createInstruction('stream-1', 1)],
+            [createInstruction('stream-2', 2)],
+            [createInstruction('stream-3', 3)],
+            [createInstruction('stream-4', 4)],
+            [createInstruction('stream-5', 5)],
+        ])
+    })
+
+    it('first and last instructions handled when inserting a burst of them with identical keys (throttle)', async () => {
+        instructionThrottler.add(createInstruction('stream-1', 1))
+        instructionThrottler.add(createInstruction('stream-1', 2))
+        instructionThrottler.add(createInstruction('stream-1', 3))
+        instructionThrottler.add(createInstruction('stream-1', 4))
+        instructionThrottler.add(createInstruction('stream-1', 5))
+
+        await waitForCondition(() => instructionThrottler.isIdle())
+
+        expect(handlerCb.mock.calls).toEqual([
+            [createInstruction('stream-1', 1)],
+            [createInstruction('stream-1', 5)]
+        ])
+    })
+
+    it('all instructions are handled when inserting them slowly with identical keys (no throttle)', async () => {
+        instructionThrottler.add(createInstruction('stream-1', 1))
+        await waitForCondition(() => instructionThrottler.isIdle())
+        instructionThrottler.add(createInstruction('stream-1', 2))
+        await waitForCondition(() => instructionThrottler.isIdle())
+        instructionThrottler.add(createInstruction('stream-1', 3))
+        await waitForCondition(() => instructionThrottler.isIdle())
+        instructionThrottler.add(createInstruction('stream-1', 4))
+        await waitForCondition(() => instructionThrottler.isIdle())
+        instructionThrottler.add(createInstruction('stream-1', 5))
+
+        await waitForCondition(() => instructionThrottler.isIdle())
+
+        expect(handlerCb.mock.calls).toEqual([
+            [createInstruction('stream-1', 1)],
+            [createInstruction('stream-1', 2)],
+            [createInstruction('stream-1', 3)],
+            [createInstruction('stream-1', 4)],
+            [createInstruction('stream-1', 5)],
+        ])
+    })
+
+    it('max one handlerCb is awaited for at a time', async () => {
+        const events = []
+        handlerCb.mockReset().mockImplementation(() => {
+            events.push('in')
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    resolve(true)
+                    events.push('out')
+                }, 20)
+            })
+        })
+
+        instructionThrottler.add(createInstruction('stream-1', 1))
+        instructionThrottler.add(createInstruction('stream-2', 2))
+        instructionThrottler.add(createInstruction('stream-3', 3))
+        instructionThrottler.add(createInstruction('stream-4', 4))
+        instructionThrottler.add(createInstruction('stream-5', 5))
+
+        await waitForCondition(() => !instructionThrottler.handling)
+
+        expect(events).toEqual([
+            'in', 'out',
+            'in', 'out',
+            'in', 'out',
+            'in', 'out',
+            'in', 'out',
+        ])
+    })
+})


### PR DESCRIPTION
In this PR the logic of instruction handling on node side is changed as follows.

1. Node maintains an instance of `InstructionThrottler` during its lifecycle.
2. Upon receiving an instruction from tracker, it calls `InstructionThrottler#add` to enqueue the instruction.
3. `InstructionThrottler` invokes a callback supplied by Node (i.e. `Node#handleTrackerInstruction`) whenever a new instruction should be handled.

The class `InstructionThrottler` makes sure that no more than one instruction is handled at a time. While an instruction is being handled and a new instruction arrives, it enqueues the new instruction. If several instructions with the same streamId arrive during handling, it will keep only the latest one around (basically the one with the highest counter).

## Some considerations
- This does add complexity to the instruction handling logic. It would be nice if we could somehow check if this change brings more stability to the network.
-  A previous version of this change had a less strict invariant. It allowed for more than one instruction to be handled at a time given that they operate on different streams. (So basically max 1 instruction under handling at a time per streamId.)