### PR TITLE
Make startNetworkNode, startStorageNode take objects instead of argument lists

### DIFF
--- a/bin/tracker.js
+++ b/bin/tracker.js
@@ -16,7 +16,7 @@ program
     .option('--port <port>', 'port', 30300)
     .option('--ip <ip>', 'ip', '0.0.0.0')
     .option('--maxNeighborsPerNode <maxNeighborsPerNode>', 'maxNeighborsPerNode', 4)
-    .option('--exposeHttpEndpoints', 'expose http endpoints')
+    .option('--attachHttpEndpoints', 'attach http endpoints')
     .option('--apiKey <apiKey>', 'apiKey for StreamrClient', undefined)
     .option('--streamId <streamId>', 'streamId for StreamrClient', undefined)
     .option('--sentryDns <sentryDns>', 'sentryDns', undefined)
@@ -57,7 +57,7 @@ async function main() {
             id,
             maxNeighborsPerNode: Number.parseInt(program.maxNeighborsPerNode, 10),
             name,
-            exposeHttpEndpoints: program.exposeHttpEndpoints,
+            attachHttpEndpoints: program.attachHttpEndpoints,
             privateKeyFileName: program.privateKeyFileName,
             certFileName: program.certFileName
         })
@@ -65,7 +65,7 @@ async function main() {
         const trackerObj = {}
         const fields = [
             'ip', 'port', 'maxNeighborsPerNode', 'privateKeyFileName', 'certFileName', 'metrics',
-            'metricsInterval', 'apiKey', 'streamId', 'sentryDns', 'exposeHttpEndpoints']
+            'metricsInterval', 'apiKey', 'streamId', 'sentryDns', 'attachHttpEndpoints']
         fields.forEach((prop) => {
             trackerObj[prop] = program[prop]
         })

--- a/src/NetworkNode.js
+++ b/src/NetworkNode.js
@@ -21,7 +21,7 @@ class NetworkNode extends Node {
                 new StorageNodeResendStrategy(
                     opts.protocols.trackerNode,
                     opts.protocols.nodeToNode,
-                    (streamKey) => this._getTracker(streamKey),
+                    (streamKey) => this._getTrackerId(streamKey),
                     (node) => this.streams.isNodePresent(node)
                 )
             ]

--- a/src/logic/StreamManager.js
+++ b/src/logic/StreamManager.js
@@ -93,17 +93,10 @@ module.exports = class StreamManager {
         return this.getStreamsAsKeys().map((key) => StreamIdAndPartition.fromKey(key))
     }
 
-    getStreamsWithConnections(tracker, trackersRing) {
+    getStreamsWithConnections(filterFn) {
         const result = {}
         this.streams.forEach(({ inboundNodes, outboundNodes, counter }, streamKey) => {
-            let addToStatus = true
-
-            if (tracker && trackersRing) {
-                const targetTracker = trackersRing.get(streamKey)
-                addToStatus = targetTracker === tracker
-            }
-
-            if (addToStatus) {
+            if (filterFn(streamKey)) {
                 result[streamKey] = {
                     inboundNodes: [...inboundNodes],
                     outboundNodes: [...outboundNodes],

--- a/test/integration/do-not-propagate-to-sender-optimization.test.js
+++ b/test/integration/do-not-propagate-to-sender-optimization.test.js
@@ -1,5 +1,5 @@
 const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
-const { wait } = require('streamr-test-utils')
+const { waitForCondition, wait } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker } = require('../../src/composition')
 
@@ -19,20 +19,35 @@ describe('optimization: do not propagate to sender', () => {
             port: 30410,
             id: 'tracker'
         })
-        n1 = await startNetworkNode('127.0.0.1', 30411, 'node-1')
-        n2 = await startNetworkNode('127.0.0.1', 30412, 'node-2')
-        n3 = await startNetworkNode('127.0.0.1', 30413, 'node-3')
+        n1 = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30411,
+            id: 'node-1',
+            trackers: [tracker.getAddress()]
+        })
+        n2 = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30412,
+            id: 'node-2',
+            trackers: [tracker.getAddress()]
+        })
+        n3 = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30413,
+            id: 'node-3',
+            trackers: [tracker.getAddress()]
+        })
 
-        n1.addBootstrapTracker(tracker.getAddress())
-        n2.addBootstrapTracker(tracker.getAddress())
-        n3.addBootstrapTracker(tracker.getAddress())
+        n1.start()
+        n2.start()
+        n3.start()
 
         // Become subscribers (one-by-one, for well connected graph)
         n1.subscribe('stream-id', 0)
         n2.subscribe('stream-id', 0)
         n3.subscribe('stream-id', 0)
 
-        await wait(1000)
+        await waitForCondition(() => Object.keys(tracker.getTopology()['stream-id::0'] || {}).length === 3)
     })
 
     afterAll(async () => {
@@ -45,7 +60,6 @@ describe('optimization: do not propagate to sender', () => {
     // In a fully-connected network the number of duplicates should be (n-1)(n-2) instead of (n-1)^2 when not
     // propagating received messages back to their source
     test('total duplicates == 2 in a fully-connected network of 3 nodes', async () => {
-        await wait(1000)
         n1.publish(new StreamMessage({
             messageId: new MessageID('stream-id', 0, 100, 0, 'publisher', 'session'),
             prevMsgRef: new MessageRef(99, 0),

--- a/test/integration/l1-resend-requests.test.js
+++ b/test/integration/l1-resend-requests.test.js
@@ -30,33 +30,39 @@ describe('resend requests are fulfilled at L1', () => {
             port: 28600,
             id: 'tracker'
         })
-        contactNode = await startNetworkNode('127.0.0.1', 28601, 'contactNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 666, 50, 'publisherId', 'msgChainId'),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(666, 50),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(756, 0),
-                    content: {},
-                })
-            ]),
-            requestFrom: () => intoStream.object([
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 666, 50, 'publisherId', 'msgChainId'),
-                    content: {},
-                }),
-            ]),
-            requestRange: () => intoStream.object([]),
-        }])
-        contactNode.addBootstrapTracker(tracker.getAddress())
+        contactNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28601,
+            id: 'contactNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 666, 50, 'publisherId', 'msgChainId'),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(666, 50),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(756, 0),
+                        content: {},
+                    })
+                ]),
+                requestFrom: () => intoStream.object([
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 666, 50, 'publisherId', 'msgChainId'),
+                        content: {},
+                    }),
+                ]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
+        contactNode.start()
         contactNode.subscribe('streamId', 0)
 
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)

--- a/test/integration/l2-resend-requests.test.js
+++ b/test/integration/l2-resend-requests.test.js
@@ -32,57 +32,75 @@ describe('resend requests are fulfilled at L2', () => {
             port: 28610,
             id: 'tracker'
         })
-        contactNode = await startNetworkNode('127.0.0.1', 28611, 'contactNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([]),
-            requestFrom: () => intoStream.object([]),
-            requestRange: () => intoStream.object([]),
-        }])
-        n1 = await startNetworkNode('127.0.0.1', 28612, 'n1', [{
-            store: () => {},
-            requestLast: () => intoStream.object([
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 666, 50, 'publisherId', 'msgChainId'),
-                    content: {},
-                }),
-            ]),
-            requestFrom: () => intoStream.object([]),
-            requestRange: () => intoStream.object([]),
-        }])
-        n2 = await startNetworkNode('127.0.0.1', 28613, 'n2', [{
-            store: () => {},
-            requestLast: () => intoStream.object([]),
-            requestFrom: () => intoStream.object([
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(666, 50),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(756, 0),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 900, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(800, 0),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 512012, 0, 'publisherId2', 'msgChainId'),
-                    content: {},
-                }),
-            ]),
-            requestRange: () => intoStream.object([]),
-        }])
+        contactNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28611,
+            id: 'contactNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([]),
+                requestFrom: () => intoStream.object([]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
+        n1 = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28612,
+            id: 'n1',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 666, 50, 'publisherId', 'msgChainId'),
+                        content: {},
+                    }),
+                ]),
+                requestFrom: () => intoStream.object([]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
+        n2 = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28613,
+            id: 'n2',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([]),
+                requestFrom: () => intoStream.object([
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(666, 50),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(756, 0),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 900, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(800, 0),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 512012, 0, 'publisherId2', 'msgChainId'),
+                        content: {},
+                    }),
+                ]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
 
         n1.subscribe('streamId', 0)
         n2.subscribe('streamId', 0)
         contactNode.subscribe('streamId', 0)
 
-        n1.addBootstrapTracker(tracker.getAddress())
-        n2.addBootstrapTracker(tracker.getAddress())
-        contactNode.addBootstrapTracker(tracker.getAddress())
+        n1.start()
+        n2.start()
+        contactNode.start()
 
         await Promise.all([
             waitForEvent(contactNode, Node.events.NODE_SUBSCRIBED),

--- a/test/integration/l3-resend-requests.test.js
+++ b/test/integration/l3-resend-requests.test.js
@@ -35,56 +35,80 @@ describe('resend requests are fulfilled at L3', () => {
             port: 28630,
             id: 'tracker'
         })
-        contactNode = await startNetworkNode('127.0.0.1', 28631, 'contactNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([]),
-            requestFrom: () => intoStream.object([]),
-            requestRange: () => intoStream.object([]),
-        }])
-        neighborOne = await startNetworkNode('127.0.0.1', 28632, 'neighborOne', [{
-            store: () => {},
-            requestLast: () => intoStream.object([]),
-            requestFrom: () => intoStream.object([]),
-            requestRange: () => intoStream.object([]),
-        }])
-        neighborTwo = await startNetworkNode('127.0.0.1', 28633, 'neighborTwo', [])
-        storageNode = await startStorageNode('127.0.0.1', 28634, 'storageNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(666, 50),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(756, 0),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 950, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(800, 0),
-                    content: {},
-                }),
-            ]),
-            requestFrom: () => intoStream.object([
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 666, 0, 'publisherId', 'msgChainId'),
-                    content: {},
-                }),
-            ]),
-            requestRange: () => intoStream.object([]),
-        }])
+        contactNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28631,
+            id: 'contactNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([]),
+                requestFrom: () => intoStream.object([]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
+        neighborOne = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28632,
+            id: 'neighborOne',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([]),
+                requestFrom: () => intoStream.object([]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
+        neighborTwo = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28633,
+            id: 'neighborTwo',
+            trackers: [tracker.getAddress()],
+            storages: []
+        })
+        storageNode = await startStorageNode({
+            host: '127.0.0.1',
+            port: 28634,
+            id: 'storageNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(666, 50),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(756, 0),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 950, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(800, 0),
+                        content: {},
+                    }),
+                ]),
+                requestFrom: () => intoStream.object([
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 666, 0, 'publisherId', 'msgChainId'),
+                        content: {},
+                    }),
+                ]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
 
         neighborOne.subscribe('streamId', 0)
         neighborTwo.subscribe('streamId', 0)
         contactNode.subscribe('streamId', 0)
 
         // storageNode automatically assigned (subscribed) by tracker
-        storageNode.addBootstrapTracker(tracker.getAddress())
-        neighborOne.addBootstrapTracker(tracker.getAddress())
-        neighborTwo.addBootstrapTracker(tracker.getAddress())
-        contactNode.addBootstrapTracker(tracker.getAddress())
+        storageNode.start()
+        neighborOne.start()
+        neighborTwo.start()
+        contactNode.start()
 
         await Promise.all([
             waitForEvent(contactNode, Node.events.NODE_SUBSCRIBED),

--- a/test/integration/message-duplication.test.js
+++ b/test/integration/message-duplication.test.js
@@ -19,18 +19,48 @@ describe('duplicate message detection and avoidance', () => {
             port: 30350,
             id: 'tracker'
         })
-        contactNode = await startNetworkNode('127.0.0.1', 30351, 'node-0')
-        contactNode.addBootstrapTracker(tracker.getAddress())
+        contactNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30351,
+            id: 'node-0',
+            trackers: [tracker.getAddress()]
+        })
+        contactNode.start()
 
         otherNodes = await Promise.all([
-            startNetworkNode('127.0.0.1', 30352, 'node-1'),
-            startNetworkNode('127.0.0.1', 30353, 'node-2'),
-            startNetworkNode('127.0.0.1', 30354, 'node-3'),
-            startNetworkNode('127.0.0.1', 30355, 'node-4'),
-            startNetworkNode('127.0.0.1', 30356, 'node-5'),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 30352,
+                id: 'node-1',
+                trackers: [tracker.getAddress()]
+            }),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 30353,
+                id: 'node-2',
+                trackers: [tracker.getAddress()]
+            }),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 30354,
+                id: 'node-3',
+                trackers: [tracker.getAddress()]
+            }),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 30355,
+                id: 'node-4',
+                trackers: [tracker.getAddress()]
+            }),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 30356,
+                id: 'node-5',
+                trackers: [tracker.getAddress()]
+            }),
         ])
 
-        otherNodes.forEach((node) => node.addBootstrapTracker(tracker.getAddress()))
+        otherNodes.forEach((node) => node.start())
         await Promise.all(otherNodes.map((node) => waitForEvent(node.protocols.trackerNode, TrackerNode.events.CONNECTED_TO_TRACKER)))
 
         // Become subscribers (one-by-one, for well connected graph)

--- a/test/integration/message-propagation.test.js
+++ b/test/integration/message-propagation.test.js
@@ -18,15 +18,35 @@ describe('message propagation in network', () => {
         })
 
         await Promise.all([
-            startNetworkNode('127.0.0.1', 33312, 'node-1'),
-            startNetworkNode('127.0.0.1', 33313, 'node-2'),
-            startNetworkNode('127.0.0.1', 33314, 'node-3'),
-            startNetworkNode('127.0.0.1', 33315, 'node-4')
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 33312,
+                id: 'node-1',
+                trackers: [tracker.getAddress()]
+            }),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 33313,
+                id: 'node-2',
+                trackers: [tracker.getAddress()]
+            }),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 33314,
+                id: 'node-3',
+                trackers: [tracker.getAddress()]
+            }),
+            startNetworkNode({
+                host: '127.0.0.1',
+                port: 33315,
+                id: 'node-4',
+                trackers: [tracker.getAddress()]
+            })
         ]).then((res) => {
             [n1, n2, n3, n4] = res
         });
 
-        [n1, n2, n3, n4].forEach((node) => node.addBootstrapTracker(tracker.getAddress()))
+        [n1, n2, n3, n4].forEach((node) => node.start())
     })
 
     afterAll(async () => {

--- a/test/integration/multi-storages.test.js
+++ b/test/integration/multi-storages.test.js
@@ -23,14 +23,34 @@ describe('multiple storage nodes', () => {
             id: 'tracker'
         })
 
-        node = await startNetworkNode('127.0.0.1', nodePort, 'node')
-        storageOne = await startStorageNode('127.0.0.1', storageOnePort, 'storageOne')
-        storageTwo = await startStorageNode('127.0.0.1', storageTwoPort, 'storageTwo')
-        storageThree = await startStorageNode('127.0.0.1', storageThreePort, 'storageThree')
+        node = await startNetworkNode({
+            host: '127.0.0.1',
+            port: nodePort,
+            id: 'node',
+            trackers: [tracker.getAddress()]
+        })
+        storageOne = await startStorageNode({
+            host: '127.0.0.1',
+            port: storageOnePort,
+            id: 'storageOne',
+            trackers: [tracker.getAddress()]
+        })
+        storageTwo = await startStorageNode({
+            host: '127.0.0.1',
+            port: storageTwoPort,
+            id: 'storageTwo',
+            trackers: [tracker.getAddress()]
+        })
+        storageThree = await startStorageNode({
+            host: '127.0.0.1',
+            port: storageThreePort,
+            id: 'storageThree',
+            trackers: [tracker.getAddress()]
+        })
 
-        node.addBootstrapTracker(tracker.getAddress())
-        storageOne.addBootstrapTracker(tracker.getAddress())
-        storageTwo.addBootstrapTracker(tracker.getAddress())
+        node.start()
+        storageOne.start()
+        storageTwo.start()
     })
 
     afterEach(async () => {
@@ -69,7 +89,7 @@ describe('multiple storage nodes', () => {
         node.subscribe('stream-3', 0)
 
         await waitForCondition(() => Object.keys(tracker.getTopology()).length === 3)
-        storageThree.addBootstrapTracker(tracker.getAddress())
+        storageThree.start()
 
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
 

--- a/test/integration/multi-trackers.test.js
+++ b/test/integration/multi-trackers.test.js
@@ -5,9 +5,10 @@ const { startNetworkNode, startTracker } = require('../../src/composition')
 const TrackerServer = require('../../src/protocol/TrackerServer')
 const Node = require('../../src/logic/Node')
 
+// TODO: maybe worth re-designing this in a way that isn't this arbitrary?
 const FIRST_STREAM = 'stream-1' // assigned to trackerOne (arbitrarily by hashing algo)
-const SECOND_STREAM = 'stream-3' // assigned to trackerTwo
-const THIRD_STREAM = 'stream-5' // assigned to trackerThree
+const SECOND_STREAM = 'stream-8' // assigned to trackerTwo
+const THIRD_STREAM = 'stream-9' // assigned to trackerThree
 
 describe('multi trackers', () => {
     let trackerOne

--- a/test/integration/multi-trackers.test.js
+++ b/test/integration/multi-trackers.test.js
@@ -17,9 +17,6 @@ describe('multi trackers', () => {
     let nodeTwo
 
     beforeEach(async () => {
-        nodeOne = await startNetworkNode('127.0.0.1', 49003, 'nodeOne')
-        nodeTwo = await startNetworkNode('127.0.0.1', 49004, 'nodeTwo')
-
         trackerOne = await startTracker({
             host: '127.0.0.1',
             port: 49000,
@@ -35,6 +32,19 @@ describe('multi trackers', () => {
             port: 49002,
             id: 'trackerThree'
         })
+        const trackerAddresses = [trackerOne.getAddress(), trackerTwo.getAddress(), trackerThree.getAddress()]
+        nodeOne = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 49003,
+            id: 'nodeOne',
+            trackers: trackerAddresses
+        })
+        nodeTwo = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 49004,
+            id: 'nodeTwo',
+            trackers: trackerAddresses
+        })
     })
 
     afterEach(async () => {
@@ -49,9 +59,7 @@ describe('multi trackers', () => {
     })
 
     test('node sends stream status to specific tracker', async () => {
-        nodeOne.addBootstrapTracker(trackerOne.getAddress())
-        nodeOne.addBootstrapTracker(trackerTwo.getAddress())
-        nodeOne.addBootstrapTracker(trackerThree.getAddress())
+        nodeOne.start()
 
         await Promise.all([
             waitForEvent(trackerOne.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED),
@@ -106,9 +114,7 @@ describe('multi trackers', () => {
     })
 
     test('only one specific tracker sends instructions about stream', async () => {
-        nodeOne.addBootstrapTracker(trackerOne.getAddress())
-        nodeOne.addBootstrapTracker(trackerTwo.getAddress())
-        nodeOne.addBootstrapTracker(trackerThree.getAddress())
+        nodeOne.start()
 
         await Promise.all([
             waitForEvent(trackerOne.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED),
@@ -116,9 +122,7 @@ describe('multi trackers', () => {
             waitForEvent(trackerThree.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
         ])
 
-        nodeTwo.addBootstrapTracker(trackerOne.getAddress())
-        nodeTwo.addBootstrapTracker(trackerTwo.getAddress())
-        nodeTwo.addBootstrapTracker(trackerThree.getAddress())
+        nodeTwo.start()
 
         await Promise.all([
             waitForEvent(trackerOne.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED),
@@ -186,9 +190,7 @@ describe('multi trackers', () => {
     })
 
     test('node ignores instructions from unexpected tracker', async () => {
-        nodeOne.addBootstrapTracker(trackerOne.getAddress())
-        nodeOne.addBootstrapTracker(trackerTwo.getAddress())
-        nodeOne.addBootstrapTracker(trackerThree.getAddress())
+        nodeOne.start()
 
         await Promise.all([
             waitForEvent(trackerOne.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED),

--- a/test/integration/network-stabilization.test.js
+++ b/test/integration/network-stabilization.test.js
@@ -20,9 +20,14 @@ describe('check network stabilization', () => {
         nodes = []
         for (let i = 0; i < MAX_NODES; i++) {
             // eslint-disable-next-line no-await-in-loop
-            const node = await startNetworkNode('127.0.0.1', startingPort + i, `node-${i}`)
+            const node = await startNetworkNode({
+                host: '127.0.0.1',
+                port: startingPort + i,
+                id: `node-${i}`,
+                trackers: [tracker.getAddress()]
+            })
             node.subscribe(stream, 0)
-            node.addBootstrapTracker(tracker.getAddress())
+            node.start()
             nodes.push(node)
         }
     }, 20000)

--- a/test/integration/nodeMessageBuffering.test.js
+++ b/test/integration/nodeMessageBuffering.test.js
@@ -23,13 +23,21 @@ describe('message buffering of Node', () => {
             id: 'tracker'
         })
 
-        sourceNode = await startNetworkNode('127.0.0.1', 30321, 'source-node')
-        await sourceNode.addBootstrapTracker(tracker.getAddress())
+        sourceNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30321,
+            id: 'source-node',
+            trackers: [tracker.getAddress()]
+        })
+        destinationNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30322,
+            id: 'destination-node',
+            trackers: [tracker.getAddress()]
+        })
 
-        await wait(1000)
-
-        destinationNode = await startNetworkNode('127.0.0.1', 30322, 'destination-node')
-        await destinationNode.addBootstrapTracker(tracker.getAddress())
+        sourceNode.start()
+        destinationNode.start()
     })
 
     afterAll(async () => {

--- a/test/integration/request-resend-from-uninvolved-node.test.js
+++ b/test/integration/request-resend-from-uninvolved-node.test.js
@@ -31,36 +31,54 @@ describe('request resend from uninvolved node', () => {
             port: 28640,
             id: 'tracker'
         })
-        uninvolvedNode = await startNetworkNode('127.0.0.1', 28641, 'uninvolvedNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([]),
-        }])
-        involvedNode = await startNetworkNode('127.0.0.1', 28642, 'involvedNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([]),
-        }])
-        storageNode = await startStorageNode('127.0.0.1', 28643, 'storageNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(666, 50),
-                    content: {},
-                }),
-                new StreamMessage({
-                    messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
-                    prevMsgRef: new MessageRef(756, 0),
-                    content: {},
-                }),
-            ])
-        }])
+        uninvolvedNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28641,
+            id: 'uninvolvedNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([]),
+            }]
+        })
+        involvedNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28642,
+            id: 'involvedNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([]),
+            }]
+        })
+        storageNode = await startStorageNode({
+            host: '127.0.0.1',
+            port: 28643,
+            id: 'storageNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 756, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(666, 50),
+                        content: {},
+                    }),
+                    new StreamMessage({
+                        messageId: new MessageID('streamId', 0, 800, 0, 'publisherId', 'msgChainId'),
+                        prevMsgRef: new MessageRef(756, 0),
+                        content: {},
+                    }),
+                ])
+            }]
+        })
 
         involvedNode.subscribe('streamId', 0)
         // storageNode automatically assigned (subscribed) by tracker
 
-        uninvolvedNode.addBootstrapTracker(tracker.getAddress())
-        involvedNode.addBootstrapTracker(tracker.getAddress())
-        storageNode.addBootstrapTracker(tracker.getAddress())
+        uninvolvedNode.start()
+        involvedNode.start()
+        storageNode.start()
 
         await Promise.all([
             waitForEvent(involvedNode, Node.events.NODE_SUBSCRIBED),

--- a/test/integration/resends-cancelled-on-disconnect.test.js
+++ b/test/integration/resends-cancelled-on-disconnect.test.js
@@ -61,35 +61,59 @@ describe('resend cancellation on disconnect', () => {
             port: 28650,
             id: 'tracker'
         })
-        contactNode = await startNetworkNode('127.0.0.1', 28651, 'contactNode', [{
-            store: () => {},
-            requestLast: () => intoStream.object([]),
-            requestFrom: () => intoStream.object([]),
-            requestRange: () => intoStream.object([]),
-        }])
-        neighborOne = await startNetworkNode('127.0.0.1', 28652, 'neighborOne', [{
-            store: () => {},
-            requestLast: () => createSlowStream(),
-            requestFrom: () => intoStream.object([]),
-            requestRange: () => intoStream.object([]),
-        }])
-        neighborTwo = await startNetworkNode('127.0.0.1', 28653, 'neighborTwo', [])
-        neighborThree = await startStorageNode('127.0.0.1', 28654, 'neighborThree', [{
-            store: () => {},
-            requestLast: () => createSlowStream(),
-            requestFrom: () => intoStream.object([]),
-            requestRange: () => intoStream.object([]),
-        }])
+        contactNode = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28651,
+            id: 'contactNode',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => intoStream.object([]),
+                requestFrom: () => intoStream.object([]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
+        neighborOne = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28652,
+            id: 'neighborOne',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => createSlowStream(),
+                requestFrom: () => intoStream.object([]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
+        neighborTwo = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 28653,
+            id: 'neighborTwo',
+            trackers: [tracker.getAddress()],
+            storages: []
+        })
+        neighborThree = await startStorageNode({
+            host: '127.0.0.1',
+            port: 28654,
+            id: 'neighborThree',
+            trackers: [tracker.getAddress()],
+            storages: [{
+                store: () => {},
+                requestLast: () => createSlowStream(),
+                requestFrom: () => intoStream.object([]),
+                requestRange: () => intoStream.object([]),
+            }]
+        })
 
         contactNode.subscribe('streamId', 0)
         neighborOne.subscribe('streamId', 0)
         neighborTwo.subscribe('streamId', 0)
         neighborThree.subscribe('streamId', 0)
 
-        contactNode.addBootstrapTracker(tracker.getAddress())
-        neighborOne.addBootstrapTracker(tracker.getAddress())
-        neighborTwo.addBootstrapTracker(tracker.getAddress())
-        neighborThree.addBootstrapTracker(tracker.getAddress())
+        contactNode.start()
+        neighborOne.start()
+        neighborTwo.start()
+        neighborThree.start()
 
         await Promise.all([
             waitForEvent(contactNode, Node.events.NODE_SUBSCRIBED),

--- a/test/integration/tracker-assigns-storage-node-to-streams.test.js
+++ b/test/integration/tracker-assigns-storage-node-to-streams.test.js
@@ -14,18 +14,33 @@ describe('tracker assigns storage node to streams', () => {
         tracker = await startTracker({
             host: '127.0.0.1',
             port: 31950,
-            id: 'tracker'
+            id: 'tracker',
         })
-        storageNode = await startStorageNode('127.0.0.1', 31951, 'storageNode')
-        subscriberOne = await startNetworkNode('127.0.0.1', 31952, 'subscriberOne')
-        subscriberTwo = await startNetworkNode('127.0.0.1', 31953, 'subscriberTwo')
+        storageNode = await startStorageNode({
+            host: '127.0.0.1',
+            port: 31951,
+            id: 'storageNode',
+            trackers: [tracker.getAddress()]
+        })
+        subscriberOne = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 31952,
+            id: 'subscriberOne',
+            trackers: [tracker.getAddress()]
+        })
+        subscriberTwo = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 31953,
+            id: 'subscriberTwo',
+            trackers: [tracker.getAddress()]
+        })
 
         subscriberOne.subscribe('stream-1', 0)
         subscriberTwo.subscribe('stream-2', 0)
 
-        subscriberOne.addBootstrapTracker(tracker.getAddress())
-        subscriberTwo.addBootstrapTracker(tracker.getAddress())
-        storageNode.addBootstrapTracker(tracker.getAddress())
+        subscriberOne.start()
+        subscriberTwo.start()
+        storageNode.start()
     })
 
     afterAll(async () => {

--- a/test/integration/tracker-endpoints.test.js
+++ b/test/integration/tracker-endpoints.test.js
@@ -24,18 +24,31 @@ describe('tracker endpoint', () => {
             host: '127.0.0.1',
             port: trackerPort,
             id: 'tracker',
-            exposeHttpEndpoints: true
+            attachHttpEndpoints: true
         })
-        nodeOne = await startNetworkNode('127.0.0.1', 31751, 'node-1', [], null, 'node-1', null, 100)
-        nodeTwo = await startNetworkNode('127.0.0.1', 31752, 'node-2', [], null, 'node-2', location, 100)
+        nodeOne = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 31751,
+            id: 'node-1',
+            trackers: [tracker.getAddress()],
+            pingInterval: 100
+        })
+        nodeTwo = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 31752,
+            id: 'node-2',
+            trackers: [tracker.getAddress()],
+            location,
+            pingInterval: 100
+        })
 
         nodeOne.subscribe(streamId, 0)
         nodeTwo.subscribe(streamId, 0)
 
         nodeOne.subscribe(streamId2, 0)
 
-        nodeOne.addBootstrapTracker(tracker.getAddress())
-        nodeTwo.addBootstrapTracker(tracker.getAddress())
+        nodeOne.start()
+        nodeTwo.start()
 
         await waitForCondition(() => Object.keys(tracker.overlayPerStream).length === 2)
     })

--- a/test/integration/tracker-instructions.test.js
+++ b/test/integration/tracker-instructions.test.js
@@ -27,14 +27,24 @@ describe('check tracker, nodes and statuses from nodes', () => {
         // disable trackers formAndSendInstructions function
         // eslint-disable-next-line no-underscore-dangle
         tracker._formAndSendInstructions = () => {}
-        node1 = await startNetworkNode('127.0.0.1', port1, 'node1')
-        node2 = await startNetworkNode('127.0.0.1', port2, 'node2')
+        node1 = await startNetworkNode({
+            host: '127.0.0.1',
+            port: port1,
+            id: 'node1',
+            trackers: [tracker.getAddress()]
+        })
+        node2 = await startNetworkNode({
+            host: '127.0.0.1',
+            port: port2,
+            id: 'node2',
+            trackers: [tracker.getAddress()]
+        })
 
         node1.subscribeToStreamIfHaveNotYet(s1)
         node2.subscribeToStreamIfHaveNotYet(s1)
 
-        node1.addBootstrapTracker(tracker.getAddress())
-        node2.addBootstrapTracker(tracker.getAddress())
+        node1.start()
+        node2.start()
 
         await Promise.all([
             waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED),

--- a/test/integration/tracker-node-reconnect-instructions.test.js
+++ b/test/integration/tracker-node-reconnect-instructions.test.js
@@ -24,8 +24,18 @@ describe('Check tracker instructions to node', () => {
             id: 'tracker'
         })
 
-        nodeOne = await startNetworkNode('127.0.0.1', 30952, 'node-1')
-        nodeTwo = await startNetworkNode('127.0.0.1', 30953, 'node-2')
+        nodeOne = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30952,
+            id: 'node-1',
+            trackers: [tracker.getAddress()]
+        })
+        nodeTwo = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30953,
+            id: 'node-2',
+            trackers: [tracker.getAddress()]
+        })
 
         // TODO: a better way of achieving this would be to pass via constructor, but currently not possible when using
         // startNetworkNode function
@@ -35,8 +45,8 @@ describe('Check tracker instructions to node', () => {
         nodeOne.subscribe(streamId, 0)
         nodeTwo.subscribe(streamId, 0)
 
-        nodeOne.addBootstrapTracker(tracker.getAddress())
-        nodeTwo.addBootstrapTracker(tracker.getAddress())
+        nodeOne.start()
+        nodeTwo.start()
     })
 
     afterAll(async () => {

--- a/test/integration/tracker.test.js
+++ b/test/integration/tracker.test.js
@@ -19,8 +19,18 @@ describe('check tracker, nodes and statuses from nodes', () => {
             port: 32400,
             id: 'tracker'
         })
-        subscriberOne = await startNetworkNode('127.0.0.1', 33371, 'subscriberOne')
-        subscriberTwo = await startNetworkNode('127.0.0.1', 33372, 'subscriberTwo')
+        subscriberOne = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 33371,
+            id: 'subscriberOne',
+            trackers: [tracker.getAddress()]
+        })
+        subscriberTwo = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 33372,
+            id: 'subscriberTwo',
+            trackers: [tracker.getAddress()]
+        })
 
         subscriberOne.subscribeToStreamIfHaveNotYet(s1)
         subscriberOne.subscribeToStreamIfHaveNotYet(s2)
@@ -39,7 +49,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
         expect(tracker.protocols.trackerServer.endpoint.connections.size).toBe(0)
         expect(tracker.overlayPerStream).toEqual({})
 
-        subscriberOne.addBootstrapTracker(tracker.getAddress())
+        subscriberOne.start()
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
         expect(tracker.protocols.trackerServer.endpoint.connections.size).toBe(1)
 
@@ -51,7 +61,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
             subscriberOne: []
         })
 
-        subscriberTwo.addBootstrapTracker(tracker.getAddress())
+        subscriberTwo.start()
 
         await Promise.all([
             waitForEvent(subscriberOne, Node.events.NODE_SUBSCRIBED),
@@ -74,8 +84,8 @@ describe('check tracker, nodes and statuses from nodes', () => {
     })
 
     it('tracker should update correctly overlayPerStream on subscribe/unsubscribe', async () => {
-        subscriberOne.addBootstrapTracker(tracker.getAddress())
-        subscriberTwo.addBootstrapTracker(tracker.getAddress())
+        subscriberOne.start()
+        subscriberTwo.start()
 
         await Promise.all([
             waitForEvent(subscriberOne, Node.events.NODE_SUBSCRIBED),
@@ -116,7 +126,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
 
     it('tracker getTopology should report correct topology based on parameters and current state', async () => {
         expect(tracker.getTopology()).toEqual({})
-        subscriberOne.addBootstrapTracker(tracker.getAddress())
+        subscriberOne.start()
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
         expect(tracker.getTopology()).toEqual({
             'stream-1::0': {
@@ -138,7 +148,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
             }
         })
 
-        subscriberTwo.addBootstrapTracker(tracker.getAddress())
+        subscriberTwo.start()
 
         await Promise.all([
             waitForEvent(subscriberOne, Node.events.NODE_SUBSCRIBED),

--- a/test/integration/unsubscribe-from-stream.test.js
+++ b/test/integration/unsubscribe-from-stream.test.js
@@ -16,11 +16,18 @@ describe('node unsubscribing from a stream', () => {
             port: 30450,
             id: 'tracker'
         })
-        nodeA = await startNetworkNode('127.0.0.1', 30451, 'a')
-        nodeB = await startNetworkNode('127.0.0.1', 30452, 'b')
-
-        nodeA.addBootstrapTracker(tracker.getAddress())
-        nodeB.addBootstrapTracker(tracker.getAddress())
+        nodeA = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30451,
+            id: 'a',
+            trackers: [tracker.getAddress()]
+        })
+        nodeB = await startNetworkNode({
+            host: '127.0.0.1',
+            port: 30452,
+            id: 'b',
+            trackers: [tracker.getAddress()]
+        })
 
         // TODO: a better way of achieving this would be to pass via constructor, but currently not possible when using
         // startNetworkNode function
@@ -31,6 +38,9 @@ describe('node unsubscribing from a stream', () => {
         nodeB.subscribe('s', 1)
         nodeA.subscribe('s', 2)
         nodeB.subscribe('s', 2)
+
+        nodeA.start()
+        nodeB.start()
 
         await Promise.all([
             waitForEvent(nodeA, Node.events.NODE_SUBSCRIBED),

--- a/test/unit/StreamManager.test.js
+++ b/test/unit/StreamManager.test.js
@@ -116,7 +116,7 @@ describe('StreamManager', () => {
         expect(manager.getInboundNodesForStream(streamId)).toEqual(['node-1', 'node-2'])
         expect(manager.getOutboundNodesForStream(streamId)).toEqual(['node-1', 'node-3'])
         expect(manager.getOutboundNodesForStream(streamId)).toEqual(['node-1', 'node-3'])
-        expect(manager.getStreamsWithConnections()).toEqual({
+        expect(manager.getStreamsWithConnections((streamKey) => ['stream-id-2::0', 'stream-id::0'].includes(streamKey))).toEqual({
             'stream-id-2::0': {
                 inboundNodes: ['node-1', 'node-2'],
                 outboundNodes: ['node-3'],
@@ -172,7 +172,7 @@ describe('StreamManager', () => {
 
         expect(manager.getInboundNodesForStream(streamId)).toEqual(['node-2'])
         expect(manager.getOutboundNodesForStream(streamId)).toEqual(['node-3'])
-        expect(manager.getStreamsWithConnections()).toEqual({
+        expect(manager.getStreamsWithConnections((streamKey) => ['stream-id-2::0', 'stream-id::0'].includes(streamKey))).toEqual({
             'stream-id-2::0': {
                 inboundNodes: ['node-1', 'node-2'],
                 outboundNodes: [],
@@ -219,7 +219,7 @@ describe('StreamManager', () => {
         expect(manager.getOutboundNodesForStream(new StreamIdAndPartition('stream-1', 1))).toEqual(['should-not-be-removed'])
         expect(manager.getInboundNodesForStream(new StreamIdAndPartition('stream-2', 0))).toEqual(['should-not-be-removed'])
         expect(manager.getOutboundNodesForStream(new StreamIdAndPartition('stream-2', 0))).toEqual([])
-        expect(manager.getStreamsWithConnections()).toEqual({
+        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
             'stream-1::0': {
                 inboundNodes: [],
                 outboundNodes: ['should-not-be-removed'],
@@ -262,7 +262,7 @@ describe('StreamManager', () => {
             new StreamIdAndPartition('stream-2', 0)
         ])
 
-        expect(manager.getStreamsWithConnections()).toEqual({
+        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
             'stream-2::0': {
                 inboundNodes: ['n1'],
                 outboundNodes: ['n1'],
@@ -275,7 +275,7 @@ describe('StreamManager', () => {
         manager.setUpStream(new StreamIdAndPartition('stream-1', 0))
         manager.setUpStream(new StreamIdAndPartition('stream-2', 0))
 
-        expect(manager.getStreamsWithConnections()).toEqual({
+        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
             'stream-1::0': {
                 inboundNodes: [],
                 outboundNodes: [],
@@ -291,7 +291,7 @@ describe('StreamManager', () => {
         manager.updateCounter(new StreamIdAndPartition('stream-1', 0), 50)
         manager.updateCounter(new StreamIdAndPartition('stream-2', 0), 100)
 
-        expect(manager.getStreamsWithConnections()).toEqual({
+        expect(manager.getStreamsWithConnections((streamKey) => ['stream-2::0', 'stream-1::0', 'stream-1::1'].includes(streamKey))).toEqual({
             'stream-1::0': {
                 inboundNodes: [],
                 outboundNodes: [],


### PR DESCRIPTION
- _Breaking change_: Functions `startNetworkNode` and `startStorageNode` now take a single object argument instead of a list of arguments. This is (a) to be consistent with `startTracker` and also (b)  the number of positional arguments was getting quite unruly.
```js
// before
n1 = await startNetworkNode('127.0.0.1', 30411, 'node-1')

// after
n1 = await startNetworkNode({
    host: '127.0.0.1',
    port: 30411,
    id: 'node-1',
    trackers: ['ws://tracker-address:30300']
})
```

- _Breaking change_: Method `Node#addBoostrapTracker()` is removed. List of trackers is now given when a Node is created (e.g. with `startNetworkNode`)
- _Breaking change_: Method `Node#start()` added to make an instance of `Node` connect to its trackers. Before this is called, the Node will not yet do anything.
- _Breaking change_: Option `exposeHttpEndpoints` is now called `attachHttpEndpoints`.