### PR TITLE
NET-56: handle Buffer type on websocket 'message' event

### DIFF
--- a/src/connection/WsEndpoint.js
+++ b/src/connection/WsEndpoint.js
@@ -513,7 +513,8 @@ class WsEndpoint extends EventEmitter {
             this.metrics.speed('_msgSpeed')(1)
             this.metrics.speed('_msgInSpeed')(1)
 
-            setImmediate(() => this.onReceive(peerInfo, address, message))
+            // toString() needed for SSL connections as message will be Buffer instead of String
+            setImmediate(() => this.onReceive(peerInfo, address, message.toString()))
         })
 
         ws.on('pong', () => {


### PR DESCRIPTION
Handle weird behaviour I encountered with WebSocket client and uWS server.

When receiving a message at a (pure) WebSocket client from a SSL-enabled uWS server, the message will be received as type `Buffer` instead of `string`. However this is not the case if SSL is disabled: the message will be `string`. To ensure that we always deal with a string in the rest of the application, simply `toString`...