### PR TITLE
replace throw with promise reject

### DIFF
--- a/src/connection/WebRtcEndpoint.js
+++ b/src/connection/WebRtcEndpoint.js
@@ -148,7 +148,7 @@ class WebRtcEndpoint extends EventEmitter {
 
     send(targetPeerId, message) {
         if (!this.connections[targetPeerId]) {
-            throw new WebRtcError(`Not connected to ${targetPeerId}.`)
+            return Promise.reject(new WebRtcError(`Not connected to ${targetPeerId}.`))
         }
         return this.connections[targetPeerId].send(message).then(
             () => {


### PR DESCRIPTION
Replacing Throw with promise reject here as it is the expected behavior. This fixes crash issue. Further logic for retrying failed connections needs to be implemented.