### PR TITLE
NET-116: Add tracker endpoint /topology-union/

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "commander": "^6.2.0",
     "geoip-lite": "^1.4.2",
     "heap": "^0.2.6",
+    "lodash": "^4.17.20",
     "lru-cache": "^6.0.0",
     "node-datachannel": "0.0.17",
     "pino": "^6.7.0",

--- a/src/helpers/trackerHttpEndpoints.js
+++ b/src/helpers/trackerHttpEndpoints.js
@@ -15,17 +15,20 @@ const respondWithError = (res, req, errorMessage) => {
 }
 
 const trackerHttpEndpoints = (wss, tracker, metricsContext) => {
-    wss.cachedJsonGet = (endpoint, maxAge, jsonFactory) => {
-        let cache = undefined
+    wss.cachedJsonGet = (endpoint, maxAge, jsonFactory) => { // eslint-disable-line no-param-reassign
+        let cache
         return wss.get(endpoint, (res, req) => {
             extraLogger.debug('request to ' + endpoint)
             writeCorsHeaders(res, req)
             if ((cache === undefined) || (Date.now() > (cache.timestamp + maxAge))) {
-                cache = { json: jsonFactory(), timestamp: Date.now() }
+                cache = {
+                    json: jsonFactory(),
+                    timestamp: Date.now()
+                }
             }
             res.end(JSON.stringify(cache.json))
         })
-    };
+    }
     wss.get('/topology/', (res, req) => {
         extraLogger.debug('request to /topology/')
         writeCorsHeaders(res, req)

--- a/src/helpers/trackerHttpEndpoints.js
+++ b/src/helpers/trackerHttpEndpoints.js
@@ -1,5 +1,7 @@
 const _ = require('lodash')
 
+const { getTopology, getTopologyUnion } = require('../logic/TopologyFactory')
+
 const extraLogger = require('./logger')('streamr:tracker:http-endpoints')
 
 const writeCorsHeaders = (res, req) => {
@@ -34,7 +36,7 @@ const trackerHttpEndpoints = (wss, tracker, metricsContext) => {
     wss.get('/topology/', (res, req) => {
         extraLogger.debug('request to /topology/')
         writeCorsHeaders(res, req)
-        res.end(JSON.stringify(tracker.getTopology()))
+        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream())))
     }).get('/topology/:streamId/', (res, req) => {
         const streamId = decodeURIComponent(req.getParameter(0)).trim()
         if (streamId.length === 0) {
@@ -45,7 +47,7 @@ const trackerHttpEndpoints = (wss, tracker, metricsContext) => {
 
         extraLogger.debug(`request to /topology/${streamId}/`)
         writeCorsHeaders(res, req)
-        res.end(JSON.stringify(tracker.getTopology(streamId, null)))
+        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream(), streamId, null)))
     }).get('/topology/:streamId/:partition/', (res, req) => {
         const streamId = decodeURIComponent(req.getParameter(0)).trim()
         if (streamId.length === 0) {
@@ -63,9 +65,9 @@ const trackerHttpEndpoints = (wss, tracker, metricsContext) => {
 
         extraLogger.debug(`request to /topology/${streamId}/${askedPartition}/`)
         writeCorsHeaders(res, req)
-        res.end(JSON.stringify(tracker.getTopology(streamId, askedPartition)))
+        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream(), streamId, askedPartition)))
     }).cachedJsonGet('/topology-union/', 15 * 1000, () => {
-        const topologyUnion = tracker.getTopologyUnion()
+        const topologyUnion = getTopologyUnion(tracker.getOverlayPerStream())
         return _.mapValues(topologyUnion, (targetNodes) => Array.from(targetNodes))
     }).get('/location/', (res, req) => {
         extraLogger.debug('request to /location/')

--- a/src/helpers/trackerHttpEndpoints.js
+++ b/src/helpers/trackerHttpEndpoints.js
@@ -48,6 +48,12 @@ const trackerHttpEndpoints = (wss, tracker, metricsContext) => {
         extraLogger.debug(`request to /topology/${streamId}/${askedPartition}/`)
         writeCorsHeaders(res, req)
         res.end(JSON.stringify(tracker.getTopology(streamId, askedPartition)))
+    }).get('/topology-union/', (res, req) => {
+        extraLogger.debug('request to /topology-union/')
+        writeCorsHeaders(res, req)
+        const topologyUnion = tracker.getTopologyUnion()
+        const json = Object.fromEntries(new Map(Array.from(topologyUnion, ([key, value]) => [key, Array.from(value)])))
+        res.end(JSON.stringify(json))
     }).get('/location/', (res, req) => {
         extraLogger.debug('request to /location/')
         writeCorsHeaders(res, req)

--- a/src/helpers/trackerHttpEndpoints.js
+++ b/src/helpers/trackerHttpEndpoints.js
@@ -1,5 +1,6 @@
+const _ = require('lodash')
+
 const extraLogger = require('./logger')('streamr:tracker:http-endpoints')
-const _ = require('lodash');
 
 const writeCorsHeaders = (res, req) => {
     const origin = req.getHeader('origin')

--- a/src/helpers/trackerHttpEndpoints.js
+++ b/src/helpers/trackerHttpEndpoints.js
@@ -1,4 +1,5 @@
 const extraLogger = require('./logger')('streamr:tracker:http-endpoints')
+const _ = require('lodash');
 
 const writeCorsHeaders = (res, req) => {
     const origin = req.getHeader('origin')
@@ -64,7 +65,7 @@ const trackerHttpEndpoints = (wss, tracker, metricsContext) => {
         res.end(JSON.stringify(tracker.getTopology(streamId, askedPartition)))
     }).cachedJsonGet('/topology-union/', 15 * 1000, () => {
         const topologyUnion = tracker.getTopologyUnion()
-        return Object.fromEntries(new Map(Array.from(topologyUnion, ([key, value]) => [key, Array.from(value)])))
+        return _.mapValues(topologyUnion, (targetNodes) => Array.from(targetNodes))
     }).get('/location/', (res, req) => {
         extraLogger.debug('request to /location/')
         writeCorsHeaders(res, req)

--- a/src/logic/OverlayTopology.js
+++ b/src/logic/OverlayTopology.js
@@ -17,6 +17,10 @@ class OverlayTopology {
         this.pickRandomElement = pickRandomElementFunction || pickRandomElement
     }
 
+    getNodes() {
+        return this.nodes
+    }
+
     hasNode(nodeId) {
         return nodeId in this.nodes
     }

--- a/src/logic/TopologyFactory.js
+++ b/src/logic/TopologyFactory.js
@@ -1,0 +1,45 @@
+const { StreamIdAndPartition } = require('../identifiers')
+
+const getTopology = (overlayPerStream, streamId = null, partition = null) => {
+    const topology = {}
+
+    let streamKeys = []
+
+    if (streamId && partition === null) {
+        streamKeys = Object.keys(overlayPerStream).filter((streamKey) => streamKey.includes(streamId))
+    } else {
+        let askedStreamKey = null
+        if (streamId && Number.isSafeInteger(partition) && partition >= 0) {
+            askedStreamKey = new StreamIdAndPartition(streamId, Number.parseInt(partition, 10))
+        }
+
+        streamKeys = askedStreamKey
+            ? Object.keys(overlayPerStream).filter((streamKey) => streamKey === askedStreamKey.toString())
+            : Object.keys(overlayPerStream)
+    }
+
+    streamKeys.forEach((streamKey) => {
+        topology[streamKey] = overlayPerStream[streamKey].state()
+    })
+
+    return topology
+}
+
+const getTopologyUnion = (overlayPerStream) => {
+    const mergeSetMapInto = (target, source) => { // merges each source value (a Set object) into the target value with the same key
+        Object.keys(source).forEach((key) => {
+            const sourceSet = source[key]
+            const targetSet = target[key]
+            const mergedSet = (targetSet !== undefined) ? new Set([...targetSet, ...sourceSet]) : sourceSet
+            target[key] = mergedSet // eslint-disable-line no-param-reassign
+        })
+        return target
+    }
+    const nodeMaps = Object.values(overlayPerStream).map((topology) => topology.getNodes())
+    return nodeMaps.reduce((accumulator, current) => mergeSetMapInto(accumulator, current), {})
+}
+
+module.exports = {
+    getTopology,
+    getTopologyUnion
+}

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -219,15 +219,16 @@ module.exports = class Tracker extends EventEmitter {
 
     getTopologyUnion() {
         const mergeSetMapInto = (target, source) => { // merges each source value (a Set object) into the target value with the same key
-            source.forEach((sourceSet, key) => {
-                const targetSet = target.get(key)
+            for (let key in source) {
+                const sourceSet = source[key]
+                const targetSet = target[key]
                 const mergedSet = (targetSet !== undefined) ? new Set([...targetSet, ...sourceSet]) : sourceSet
-                target.set(key, mergedSet)
-            })
+                target[key] = mergedSet
+            }
             return target
         }
-        const nodeMaps = Object.values(this.overlayPerStream).map((topology) => new Map(Object.entries(topology.getNodes())))
-        return nodeMaps.reduce((accumulator, current) => mergeSetMapInto(accumulator, current))
+        const nodeMaps = Object.values(this.overlayPerStream).map((topology) => topology.getNodes())
+        return nodeMaps.reduce((accumulator, current) => mergeSetMapInto(accumulator, current), {})
     }
 
     getStreams() {

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -217,6 +217,19 @@ module.exports = class Tracker extends EventEmitter {
         return topology
     }
 
+    getTopologyUnion() {
+        const mergeSetMapInto = (target, source) => {  // merges each source value (a Set object) into the target value with the same key
+            source.forEach((sourceSet, key) => {
+                const targetSet = target.get(key)
+                const mergedSet = (targetSet !== undefined) ? new Set([...targetSet, ...sourceSet]) : sourceSet
+                target.set(key, mergedSet)
+            })
+            return target
+        }
+        const nodeMaps = Object.values(this.overlayPerStream).map(topology => new Map(Object.entries(topology.nodes)))
+        return nodeMaps.reduce((accumulator, current) => mergeSetMapInto(accumulator, current))
+    }
+
     getStreams() {
         return Object.keys(this.overlayPerStream)
     }

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -219,12 +219,12 @@ module.exports = class Tracker extends EventEmitter {
 
     getTopologyUnion() {
         const mergeSetMapInto = (target, source) => { // merges each source value (a Set object) into the target value with the same key
-            for (let key in source) {
+            Object.keys(source).forEach((key) => {
                 const sourceSet = source[key]
                 const targetSet = target[key]
                 const mergedSet = (targetSet !== undefined) ? new Set([...targetSet, ...sourceSet]) : sourceSet
-                target[key] = mergedSet
-            }
+                target[key] = mergedSet // eslint-disable-line no-param-reassign
+            })
             return target
         }
         const nodeMaps = Object.values(this.overlayPerStream).map((topology) => topology.getNodes())

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -218,7 +218,7 @@ module.exports = class Tracker extends EventEmitter {
     }
 
     getTopologyUnion() {
-        const mergeSetMapInto = (target, source) => {  // merges each source value (a Set object) into the target value with the same key
+        const mergeSetMapInto = (target, source) => { // merges each source value (a Set object) into the target value with the same key
             source.forEach((sourceSet, key) => {
                 const targetSet = target.get(key)
                 const mergedSet = (targetSet !== undefined) ? new Set([...targetSet, ...sourceSet]) : sourceSet
@@ -226,7 +226,7 @@ module.exports = class Tracker extends EventEmitter {
             })
             return target
         }
-        const nodeMaps = Object.values(this.overlayPerStream).map(topology => new Map(Object.entries(topology.nodes)))
+        const nodeMaps = Object.values(this.overlayPerStream).map((topology) => new Map(Object.entries(topology.nodes)))
         return nodeMaps.reduce((accumulator, current) => mergeSetMapInto(accumulator, current))
     }
 

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -226,7 +226,7 @@ module.exports = class Tracker extends EventEmitter {
             })
             return target
         }
-        const nodeMaps = Object.values(this.overlayPerStream).map((topology) => new Map(Object.entries(topology.nodes)))
+        const nodeMaps = Object.values(this.overlayPerStream).map((topology) => new Map(Object.entries(topology.getNodes())))
         return nodeMaps.reduce((accumulator, current) => mergeSetMapInto(accumulator, current))
     }
 

--- a/src/logic/Tracker.js
+++ b/src/logic/Tracker.js
@@ -192,45 +192,6 @@ module.exports = class Tracker extends EventEmitter {
         }
     }
 
-    getTopology(streamId = null, partition = null) {
-        const topology = {}
-
-        let streamKeys = []
-
-        if (streamId && partition === null) {
-            streamKeys = Object.keys(this.overlayPerStream).filter((streamKey) => streamKey.includes(streamId))
-        } else {
-            let askedStreamKey = null
-            if (streamId && Number.isSafeInteger(partition) && partition >= 0) {
-                askedStreamKey = new StreamIdAndPartition(streamId, Number.parseInt(partition, 10))
-            }
-
-            streamKeys = askedStreamKey
-                ? Object.keys(this.overlayPerStream).filter((streamKey) => streamKey === askedStreamKey.toString())
-                : Object.keys(this.overlayPerStream)
-        }
-
-        streamKeys.forEach((streamKey) => {
-            topology[streamKey] = this.overlayPerStream[streamKey].state()
-        })
-
-        return topology
-    }
-
-    getTopologyUnion() {
-        const mergeSetMapInto = (target, source) => { // merges each source value (a Set object) into the target value with the same key
-            Object.keys(source).forEach((key) => {
-                const sourceSet = source[key]
-                const targetSet = target[key]
-                const mergedSet = (targetSet !== undefined) ? new Set([...targetSet, ...sourceSet]) : sourceSet
-                target[key] = mergedSet // eslint-disable-line no-param-reassign
-            })
-            return target
-        }
-        const nodeMaps = Object.values(this.overlayPerStream).map((topology) => topology.getNodes())
-        return nodeMaps.reduce((accumulator, current) => mergeSetMapInto(accumulator, current), {})
-    }
-
     getStreams() {
         return Object.keys(this.overlayPerStream)
     }
@@ -245,5 +206,9 @@ module.exports = class Tracker extends EventEmitter {
 
     getStorageNodes() {
         return [...this.storageNodes.keys()]
+    }
+
+    getOverlayPerStream() {
+        return this.overlayPerStream
     }
 }

--- a/test/integration/counter-filtering-in-tracker.test.js
+++ b/test/integration/counter-filtering-in-tracker.test.js
@@ -5,6 +5,7 @@ const { startTracker } = require('../../src/composition')
 const TrackerNode = require('../../src/protocol/TrackerNode')
 const TrackerServer = require('../../src/protocol/TrackerServer')
 const { startEndpoint } = require('../../src/connection/WsEndpoint')
+const { getTopology } = require('../../src/logic/TopologyFactory')
 
 const WAIT_TIME = 200
 
@@ -96,16 +97,16 @@ describe('tracker: counter filtering', () => {
     })
 
     test('NET-36: tracker receiving status with old counter should not affect topology', async () => {
-        const topologyBefore = tracker.getTopology()
+        const topologyBefore = getTopology(tracker.getOverlayPerStream())
         trackerNode1.sendStatus('tracker', formStatus(0, 0, [], []))
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
-        expect(tracker.getTopology()).toEqual(topologyBefore)
+        expect(getTopology(tracker.getOverlayPerStream())).toEqual(topologyBefore)
     })
 
     test('NET-36: tracker receiving status with partial old counter should not affect topology', async () => {
-        const topologyBefore = tracker.getTopology()
+        const topologyBefore = getTopology(tracker.getOverlayPerStream())
         trackerNode1.sendStatus('tracker', formStatus(1, 0, [], []))
         await waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
-        expect(tracker.getTopology()).toEqual(topologyBefore)
+        expect(getTopology(tracker.getOverlayPerStream())).toEqual(topologyBefore)
     })
 })

--- a/test/integration/multi-storages.test.js
+++ b/test/integration/multi-storages.test.js
@@ -3,6 +3,7 @@ const { waitForEvent, waitForCondition } = require('streamr-test-utils')
 const { startStorageNode, startNetworkNode, startTracker } = require('../../src/composition')
 const TrackerServer = require('../../src/protocol/TrackerServer')
 const Node = require('../../src/logic/Node')
+const { getTopology } = require('../../src/logic/TopologyFactory')
 
 describe('multiple storage nodes', () => {
     let tracker
@@ -66,9 +67,9 @@ describe('multiple storage nodes', () => {
         node.subscribe('stream-1', 0)
         node.subscribe('stream-2', 0)
 
-        await waitForCondition(() => Object.keys(tracker.getTopology()).length === 2)
+        await waitForCondition(() => Object.keys(getTopology(tracker.getOverlayPerStream())).length === 2)
 
-        expect(tracker.getTopology()).toEqual({
+        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
             'stream-1::0': {
                 node: ['storageOne', 'storageTwo'],
                 storageOne: ['node', 'storageTwo'],
@@ -89,7 +90,7 @@ describe('multiple storage nodes', () => {
         node.subscribe('stream-2', 0)
         node.subscribe('stream-3', 0)
 
-        await waitForCondition(() => Object.keys(tracker.getTopology()).length === 3)
+        await waitForCondition(() => Object.keys(getTopology(tracker.getOverlayPerStream())).length === 3)
         storageThree.start()
 
         await Promise.all([
@@ -97,13 +98,13 @@ describe('multiple storage nodes', () => {
             waitForEvent(storageThree, Node.events.NODE_SUBSCRIBED)
         ])
 
-        expect(tracker.getTopology()['stream-1::0'].storageThree).toEqual([
+        expect(getTopology(tracker.getOverlayPerStream())['stream-1::0'].storageThree).toEqual([
             'node', 'storageOne', 'storageTwo'
         ])
-        expect(tracker.getTopology()['stream-2::0'].storageThree).toEqual([
+        expect(getTopology(tracker.getOverlayPerStream())['stream-2::0'].storageThree).toEqual([
             'node', 'storageOne', 'storageTwo'
         ])
-        expect(tracker.getTopology()['stream-3::0'].storageThree).toEqual([
+        expect(getTopology(tracker.getOverlayPerStream())['stream-3::0'].storageThree).toEqual([
             'node', 'storageOne', 'storageTwo'
         ])
     })

--- a/test/integration/network-stabilization.test.js
+++ b/test/integration/network-stabilization.test.js
@@ -3,6 +3,7 @@ const assert = require('assert')
 const { wait } = require('streamr-test-utils')
 
 const { startNetworkNode, startTracker } = require('../../src/composition')
+const { getTopology } = require('../../src/logic/TopologyFactory')
 
 function areEqual(a, b) {
     try {
@@ -54,10 +55,10 @@ describe('check network stabilization', () => {
 
     it('network must become stable in less than 10 seconds', async (done) => {
         for (let i = 0; i < 10; ++i) {
-            const beforeTopology = tracker.getTopology()
+            const beforeTopology = getTopology(tracker.getOverlayPerStream())
             // eslint-disable-next-line no-await-in-loop
             await wait(800)
-            const afterTopology = tracker.getTopology()
+            const afterTopology = getTopology(tracker.getOverlayPerStream())
             if (areEqual(beforeTopology, afterTopology)) {
                 done()
                 return

--- a/test/integration/tracker-endpoints.test.js
+++ b/test/integration/tracker-endpoints.test.js
@@ -161,6 +161,15 @@ describe('tracker endpoint', () => {
         })
     })
 
+    it('/topology-union/', async () => {
+        const [status, jsonResult] = await getHttp(`http://127.0.0.1:${trackerPort}/topology-union/`)
+        expect(status).toEqual(200)
+        expect(jsonResult).toEqual({
+            'node-1': ['node-2'],
+            'node-2': ['node-1']
+        })
+    })
+
     it('/location/', async () => {
         const [status, jsonResult] = await getHttp(`http://127.0.0.1:${trackerPort}/location/`)
         expect(status).toEqual(200)

--- a/test/integration/tracker-instructions.test.js
+++ b/test/integration/tracker-instructions.test.js
@@ -5,6 +5,7 @@ const { startNetworkNode, startTracker } = require('../../src/composition')
 const TrackerServer = require('../../src/protocol/TrackerServer')
 const Node = require('../../src/logic/Node')
 const { StreamIdAndPartition } = require('../../src/identifiers')
+const { getTopology } = require('../../src/logic/TopologyFactory')
 
 describe('check tracker, nodes and statuses from nodes', () => {
     let tracker
@@ -90,7 +91,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
             waitForEvent(tracker.protocols.trackerServer, TrackerServer.events.NODE_STATUS_RECEIVED)
         ])
 
-        expect(tracker.getTopology()).toEqual({
+        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
             'stream-1::0': {
                 node1: ['node2'],
                 node2: ['node1'],

--- a/test/unit/TopologyFactory.test.js
+++ b/test/unit/TopologyFactory.test.js
@@ -1,0 +1,34 @@
+const _ = require('lodash')
+
+const { getTopologyUnion } = require('../../src/logic/TopologyFactory')
+
+const createMockOverlayTopology = (mapping) => {
+    return {
+        getNodes: () => _.mapValues(mapping, (value) => new Set(value))
+    }
+}
+
+describe('TopologyFactory', () => {
+    it('happy path', () => {
+        const overlayPerStream = {
+            'stream-a::0': createMockOverlayTopology({
+                node1: ['node2', 'node3']
+            }),
+            'stream-b::0': createMockOverlayTopology({
+                node2: ['node4']
+            }),
+            'stream-c::0': createMockOverlayTopology({}),
+            'stream-d::0': createMockOverlayTopology({
+                node1: ['node3', 'node5']
+            }),
+            'stream-e::0': createMockOverlayTopology({
+                node6: []
+            })
+        }
+        const union = getTopologyUnion(overlayPerStream)
+        expect(Object.keys(union)).toEqual(['node1', 'node2', 'node6'])
+        expect(union.node1).toEqual(new Set(['node2', 'node3', 'node5']))
+        expect(union.node2).toEqual(new Set(['node4']))
+        expect(union.node6).toEqual(new Set([]))
+    })
+})


### PR DESCRIPTION
Returns all known connections between nodes, across all streams. Cache the result for 15 seconds.