### PR TITLE
Small fixes

### DIFF
--- a/src/connection/WebRtcEndpoint.ts
+++ b/src/connection/WebRtcEndpoint.ts
@@ -166,7 +166,8 @@ export class WebRtcEndpoint extends EventEmitter {
             },
             onClose: () => {
                 this.emit(Event.PEER_DISCONNECTED, connection.getPeerInfo())
-                this.emit(`disconnected:${connection.getPeerId()}`, connection.getPeerInfo())
+                const err = new Error(`disconnected ${connection.getPeerId()}`)
+                this.emit(`disconnected:${connection.getPeerId()}`, err)
                 this.metrics.record('close', 1)
                 delete this.connections[targetPeerId]
             },

--- a/src/logic/InstructionThrottler.ts
+++ b/src/logic/InstructionThrottler.ts
@@ -1,5 +1,8 @@
 import { StreamIdAndPartition, StreamKey } from "../identifiers"
 import { TrackerLayer } from "streamr-client-protocol"
+import getLogger from "../helpers/logger"
+
+const logger = getLogger('streamr:logic:InstructionThrottler')
 
 interface Queue {
     [key: string]: {
@@ -33,7 +36,9 @@ export class InstructionThrottler {
             trackerId
         }
         if (!this.handling) {
-            this.invokeHandleFnWithLock()
+            this.invokeHandleFnWithLock().catch((err) => {
+                logger.warn("Error handling instruction %s", err)
+            })
         }
     }
 
@@ -61,9 +66,13 @@ export class InstructionThrottler {
             if (this.isQueueEmpty()) {
                 this.handling = false
             }
-            this.handleFn(instructionMessage, trackerId)
+            this.handleFn(instructionMessage, trackerId).catch((err) => {
+                logger.warn("Error handling instruction %s", err)
+            })
 
-            this.invokeHandleFnWithLock()
+            this.invokeHandleFnWithLock().catch((err) => {
+                logger.warn("Error handling instruction %s", err)
+            })
         }
     }
 

--- a/test/integration/do-not-propagate-to-sender-optimization.test.js
+++ b/test/integration/do-not-propagate-to-sender-optimization.test.js
@@ -1,7 +1,6 @@
 const { StreamMessage, MessageID, MessageRef } = require('streamr-client-protocol').MessageLayer
-const { waitForCondition, waitForEvent, wait } = require('streamr-test-utils')
+const { waitForCondition } = require('streamr-test-utils')
 
-const Node = require('../../src/logic/Node')
 const { startNetworkNode, startTracker } = require('../../src/composition')
 
 /**
@@ -57,10 +56,12 @@ describe('optimization: do not propagate to sender', () => {
     })
 
     afterAll(async () => {
-        await n1.stop()
-        await n2.stop()
-        await n3.stop()
-        await tracker.stop()
+        await Promise.allSettled([
+            tracker.stop(),
+            n1.stop(),
+            n2.stop(),
+            n3.stop()
+        ])
     })
 
     // In a fully-connected network the number of duplicates should be (n-1)(n-2) instead of (n-1)^2 when not

--- a/test/integration/message-duplication.test.js
+++ b/test/integration/message-duplication.test.js
@@ -109,9 +109,11 @@ describe('duplicate message detection and avoidance', () => {
     }, 10000)
 
     afterAll(async () => {
-        await contactNode.stop()
-        await Promise.all(otherNodes.map((node) => node.stop()))
-        await tracker.stop()
+        await Promise.allSettled([
+            tracker.stop(),
+            contactNode.stop(),
+            otherNodes.map((node) => node.stop())
+        ])
     })
 
     test('same message is emitted by a node exactly once', () => {

--- a/test/integration/message-propagation.test.js
+++ b/test/integration/message-propagation.test.js
@@ -52,11 +52,13 @@ describe('message propagation in network', () => {
     })
 
     afterAll(async () => {
-        await n1.stop()
-        await n2.stop()
-        await n3.stop()
-        await n4.stop()
-        await tracker.stop()
+        await Promise.allSettled([
+            tracker.stop(),
+            n1.stop(),
+            n2.stop(),
+            n3.stop(),
+            n4.stop()
+        ])
     })
 
     it('messages are delivered to nodes in the network according to stream subscriptions', async () => {

--- a/test/integration/network-stabilization.test.js
+++ b/test/integration/network-stabilization.test.js
@@ -40,17 +40,16 @@ describe('check network stabilization', () => {
                 trackers: [tracker.getAddress()]
             })
             node.subscribe('stream', 0)
-            node.start()
             nodes.push(node)
         }
+        nodes.forEach((node) => node.start())
     })
 
     afterEach(async () => {
-        for (let i = 0; i < MAX_NODES; i++) {
-            // eslint-disable-next-line no-await-in-loop
-            await nodes[i].stop()
-        }
-        await tracker.stop()
+        await Promise.allSettled([
+            tracker.stop(),
+            ...nodes.map((node) => node.stop())
+        ])
     })
 
     it('network must become stable in less than 10 seconds', async (done) => {

--- a/test/unit/WebRtcEndpoint.test.js
+++ b/test/unit/WebRtcEndpoint.test.js
@@ -52,8 +52,8 @@ describe('WebRtcEndpoint', () => {
     })
 
     it('connection between nodes is established when both nodes invoke connect()', async () => {
-        endpoint1.connect('node-2', 'tracker', true)
-        endpoint2.connect('node-1', 'tracker', false)
+        endpoint1.connect('node-2', 'tracker', true).catch(() => null)
+        endpoint2.connect('node-1', 'tracker', false).catch(() => null)
 
         await Promise.all([
             waitForEvent(endpoint1, Event.PEER_CONNECTED),
@@ -91,7 +91,7 @@ describe('WebRtcEndpoint', () => {
     })
 
     it('connection between nodes is established when only one node invokes connect()', async () => {
-        endpoint1.connect('node-2', 'tracker')
+        endpoint1.connect('node-2', 'tracker').catch(() => null)
 
         await Promise.all([
             waitForEvent(endpoint1, Event.PEER_CONNECTED),

--- a/test/unit/WebRtcEndpoint.test.js
+++ b/test/unit/WebRtcEndpoint.test.js
@@ -42,11 +42,13 @@ describe('WebRtcEndpoint', () => {
     })
 
     afterEach(async () => {
-        await trackerNode1.stop()
-        await trackerNode2.stop()
-        await endpoint1.stop()
-        await endpoint2.stop()
-        await tracker.stop()
+        await Promise.allSettled([
+            tracker.stop(),
+            trackerNode1.stop(),
+            trackerNode2.stop(),
+            endpoint1.stop(),
+            endpoint2.stop()
+        ])
     })
 
     it('connection between nodes is established when both nodes invoke connect()', async () => {


### PR DESCRIPTION
- Fix situation where a `PeerInfo` was thrown (rejected) instead of an `Error`.
- Reduce flakyness of
    - test/integration/network-stabilization.test.js
    - test/integration/message-duplication.test.js
    - test/integration/message-propagation.test.js
    - test/unit/WebRtcEndpoint.test.js
    - test/integration/do-not-propagate-to-sender-optimization.test.js
 - Prevent new connections from being opened after WebRtcEndpoint has been stopped. Fixes NET-69.
 - InstructionThrottler: add some `catch()` to Promises
 - add missing `catch` to WebRtcEndpoint