### PR TITLE
NET-120: test case for publishing messages exceeding WebRTC limit

### DIFF
--- a/src/connection/PeerInfo.ts
+++ b/src/connection/PeerInfo.ts
@@ -15,15 +15,15 @@ interface ObjectRepresentation {
 }
 
 export class PeerInfo {
-    static newTracker(peerId: string, peerName: string | null | undefined, location: Location | null | undefined) {
+    static newTracker(peerId: string, peerName?: string | null | undefined, location?: Location | null | undefined) {
         return new PeerInfo(peerId, PeerType.Tracker, peerName, location)
     }
 
-    static newNode(peerId: string, peerName: string | null | undefined, location: Location | null | undefined) {
+    static newNode(peerId: string, peerName?: string | null | undefined, location?: Location | null | undefined) {
         return new PeerInfo(peerId, PeerType.Node, peerName, location)
     }
 
-    static newStorage(peerId: string, peerName: string | null | undefined, location: Location | null | undefined) {
+    static newStorage(peerId: string, peerName?: string | null | undefined, location?: Location | null | undefined) {
         return new PeerInfo(peerId, PeerType.Storage, peerName, location)
     }
 

--- a/src/connection/WebRtcEndpoint.ts
+++ b/src/connection/WebRtcEndpoint.ts
@@ -201,16 +201,16 @@ export class WebRtcEndpoint extends EventEmitter {
         if (!this.connections[targetPeerId]) {
             return Promise.reject(new WebRtcError(`Not connected to ${targetPeerId}.`))
         }
-        return this.connections[targetPeerId].send(message).then(
-            () => {
+        return this.connections[targetPeerId].send(message)
+            .then(() => {
                 this.metrics.record('outSpeed', message.length)
                 this.metrics.record('msgSpeed', 1)
                 this.metrics.record('msgOutSpeed', 1)
-            },
-            (err) => {
+            })
+            .catch((err) => {
                 this.metrics.record('sendFailed', 1)
-            }
-        )
+                throw err
+            })
     }
 
     close(receiverNodeId: string, reason: string): void {

--- a/src/logic/Tracker.ts
+++ b/src/logic/Tracker.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events"
 import getLogger from "../helpers/logger"
 import { Metrics, MetricsContext } from "../helpers/MetricsContext"
 import { TrackerServer, Event as TrackerServerEvent } from "../protocol/TrackerServer"
-import { OverlayTopology, TopologyState } from "./OverlayTopology"
+import { OverlayTopology } from "./OverlayTopology"
 import { InstructionCounter } from "./InstructionCounter"
 import { LocationManager } from "./LocationManager"
 import { attachRtcSignalling } from "./rtcSignallingHandlers"
@@ -13,6 +13,10 @@ import pino from "pino"
 
 type NodeId = string
 type StreamId = string
+
+export enum Event {
+    NODE_CONNECTED = 'streamr:tracker:node-connected'
+}
 
 export interface TrackerOptions {
     maxNeighborsPerNode: number
@@ -25,6 +29,10 @@ export interface TrackerOptions {
 
 // streamKey => overlayTopology, where streamKey = streamId::partition
 export type OverlayPerStream = { [key: string]: OverlayTopology }
+
+export interface Tracker {
+    on(event: Event.NODE_CONNECTED, listener: (nodeId: NodeId) => void): this
+}
 
 export class Tracker extends EventEmitter {
     private readonly maxNeighborsPerNode: number
@@ -92,6 +100,7 @@ export class Tracker extends EventEmitter {
         if (isStorage) {
             this.storageNodes.add(node)
         }
+        this.emit(Event.NODE_CONNECTED, node)
     }
 
     onNodeDisconnected(node: NodeId): void {


### PR DESCRIPTION
- Make sure `send` function rejects when attempting to send too large message
- Test case for sending too large message (as well as converting test to TS and doing necessary changes elsewhere)