### PR TITLE
NET-131: add back pressure handling to WebRTC

### DIFF
--- a/bin/network.js
+++ b/bin/network.js
@@ -42,7 +42,7 @@ spawn('node', args, {
     stdio: [process.stdin, process.stdout, process.stderr]
 })
 
-setTimeout(async () => {
+setTimeout(() => {
     for (let i = 0; i < parseInt(numberOfNodes, 10); i++) {
         args = [
             path.resolve('./bin/subscriber.js'),
@@ -59,8 +59,5 @@ setTimeout(async () => {
             env: productionEnv,
             stdio: [process.stdin, process.stdout, process.stderr]
         })
-
-        // eslint-disable-next-line no-await-in-loop
-        await new Promise((resolve) => setTimeout(resolve, 10))
     }
 }, 1000)

--- a/bin/network.js
+++ b/bin/network.js
@@ -42,7 +42,7 @@ spawn('node', args, {
     stdio: [process.stdin, process.stdout, process.stderr]
 })
 
-setTimeout(() => {
+setTimeout(async () => {
     for (let i = 0; i < parseInt(numberOfNodes, 10); i++) {
         args = [
             path.resolve('./bin/subscriber.js'),
@@ -59,5 +59,8 @@ setTimeout(() => {
             env: productionEnv,
             stdio: [process.stdin, process.stdout, process.stderr]
         })
+
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 10))
     }
 }, 1000)

--- a/src/connection/WebRtcEndpoint.ts
+++ b/src/connection/WebRtcEndpoint.ts
@@ -57,7 +57,7 @@ export class WebRtcEndpoint extends EventEmitter {
         stunUrls: string[],
         rtcSignaller: RtcSignaller,
         metricsContext: MetricsContext,
-        pingIntervalInMs = 30 * 1000,
+        pingIntervalInMs = 5 * 1000,
         newConnectionTimeout = 5000
     ) {
         super()

--- a/src/connection/WebRtcEndpoint.ts
+++ b/src/connection/WebRtcEndpoint.ts
@@ -57,7 +57,7 @@ export class WebRtcEndpoint extends EventEmitter {
         stunUrls: string[],
         rtcSignaller: RtcSignaller,
         metricsContext: MetricsContext,
-        pingIntervalInMs = 5 * 1000,
+        pingIntervalInMs = 30 * 1000,
         newConnectionTimeout = 5000
     ) {
         super()
@@ -183,6 +183,12 @@ export class WebRtcEndpoint extends EventEmitter {
             onError: (err) => {
                 this.emit(Event.PEER_DISCONNECTED, connection.getPeerInfo())
                 this.emit(`errored:${connection.getPeerId()}`, err)
+            },
+            onBufferLow: () => {
+                this.emit(Event.LOW_BACK_PRESSURE, connection.getPeerInfo())
+            },
+            onBufferHigh: () => {
+                this.emit(Event.HIGH_BACK_PRESSURE, connection.getPeerInfo())
             }
         })
         this.connections[targetPeerId] = connection

--- a/src/protocol/NodeToNode.ts
+++ b/src/protocol/NodeToNode.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events"
 import { ControlLayer, MessageLayer } from "streamr-client-protocol"
 import getLogger from "../helpers/logger"
 import { decode } from '../helpers/MessageEncoder'
-import { WebRtcEndpoint, Event as WsEndpointEvent } from '../connection/WebRtcEndpoint'
+import { WebRtcEndpoint, Event as WebRtcEndpointEvent } from '../connection/WebRtcEndpoint'
 import { PeerInfo } from "../connection/PeerInfo"
 import { ResendRequest, ResendResponse, Rtts } from "../identifiers"
 import pino from "pino"
@@ -46,11 +46,11 @@ export class NodeToNode extends EventEmitter {
     constructor(endpoint: WebRtcEndpoint) {
         super()
         this.endpoint = endpoint
-        endpoint.on(WsEndpointEvent.PEER_CONNECTED, (peerInfo) => this.onPeerConnected(peerInfo))
-        endpoint.on(WsEndpointEvent.PEER_DISCONNECTED, (peerInfo) => this.onPeerDisconnected(peerInfo))
-        endpoint.on(WsEndpointEvent.MESSAGE_RECEIVED, (peerInfo, message) => this.onMessageReceived(peerInfo, message))
-        endpoint.on(WsEndpointEvent.LOW_BACK_PRESSURE, (peerInfo) => this.onLowBackPressure(peerInfo))
-        endpoint.on(WsEndpointEvent.HIGH_BACK_PRESSURE, (peerInfo) => this.onHighBackPressure(peerInfo))
+        endpoint.on(WebRtcEndpointEvent.PEER_CONNECTED, (peerInfo) => this.onPeerConnected(peerInfo))
+        endpoint.on(WebRtcEndpointEvent.PEER_DISCONNECTED, (peerInfo) => this.onPeerDisconnected(peerInfo))
+        endpoint.on(WebRtcEndpointEvent.MESSAGE_RECEIVED, (peerInfo, message) => this.onMessageReceived(peerInfo, message))
+        endpoint.on(WebRtcEndpointEvent.LOW_BACK_PRESSURE, (peerInfo) => this.onLowBackPressure(peerInfo))
+        endpoint.on(WebRtcEndpointEvent.HIGH_BACK_PRESSURE, (peerInfo) => this.onHighBackPressure(peerInfo))
         this.logger = getLogger(`streamr:NodeToNode:${endpoint.getAddress()}`)
     }
 

--- a/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
+++ b/test/integration/webrtc-endpoint-back-pressure-handling.test.ts
@@ -1,0 +1,86 @@
+import { WebRtcEndpoint, Event } from "../../src/connection/WebRtcEndpoint"
+import { PeerInfo } from "../../src/connection/PeerInfo"
+import { MetricsContext } from "../../src/helpers/MetricsContext"
+import { RtcSignaller } from "../../src/logic/RtcSignaller"
+import { Tracker } from "../../src/logic/Tracker"
+import { startTracker } from "../../src/composition"
+import { startEndpoint } from "../../src/connection/WsEndpoint"
+import { TrackerNode } from "../../src/protocol/TrackerNode"
+import { wait } from "streamr-test-utils"
+
+describe('WebRtcEndpoint: back pressure handling', () => {
+    let tracker: Tracker
+    let trackerNode1: TrackerNode
+    let trackerNode2: TrackerNode
+    let ep1: WebRtcEndpoint
+    let ep2: WebRtcEndpoint
+
+    beforeEach(async () => {
+        tracker = await startTracker({
+            host: '127.0.0.1',
+            port: 28710,
+            id: 'tracker'
+        })
+
+        const peerInfo1 = PeerInfo.newNode("ep1")
+        const peerInfo2 = PeerInfo.newNode("ep2")
+
+        // Need to set up TrackerNodes and WsEndpoint(s) to exchange RelayMessage(s) via tracker
+        const wsEp1 = await startEndpoint("127.0.0.1", 28711, peerInfo1, null, new MetricsContext(peerInfo1.peerId))
+        const wsEp2 = await startEndpoint("127.0.0.1", 28712, peerInfo2, null, new MetricsContext(peerInfo2.peerId))
+        trackerNode1 = new TrackerNode(wsEp1)
+        trackerNode2 = new TrackerNode(wsEp2)
+        await trackerNode1.connectToTracker(tracker.getAddress())
+        await trackerNode2.connectToTracker(tracker.getAddress())
+
+        // Set up WebRTC endpoints
+        ep1 = new WebRtcEndpoint(
+            peerInfo1.peerId,
+            ["stun:stun.l.google.com:19302"],
+            new RtcSignaller(peerInfo1, trackerNode1),
+            new MetricsContext("ep1")
+        )
+        ep2 = new WebRtcEndpoint(
+            peerInfo2.peerId,
+            ["stun:stun.l.google.com:19302"],
+            new RtcSignaller(peerInfo2, trackerNode2),
+            new MetricsContext("ep")
+        )
+        await ep1.connect("ep2", "tracker")
+    })
+
+    afterEach(async () => {
+        await Promise.allSettled([
+            tracker.stop(),
+            trackerNode1.stop(),
+            trackerNode2.stop(),
+            ep1.stop(),
+            ep2.stop()
+        ])
+    })
+
+    function inflictHighBackPressure(): Promise<void> {
+        for (let i=0; i <= 25; ++i) {
+            ep1.send('ep2', new Array(1024 * 256).fill('X').join(''))
+        }
+        return wait(0) // Relinquish control to allow for setImmediate(() => this.attemptToFlushMessages())
+    }
+
+    it('emits HIGH_BACK_PRESSURE on high back pressure', async (done) => {
+        ep1.once(Event.HIGH_BACK_PRESSURE, (peerInfo) => {
+            expect(peerInfo).toEqual(PeerInfo.newNode('ep2'))
+            done()
+        })
+        await inflictHighBackPressure()
+    })
+
+    it('emits LOW_BACK_PRESSURE after high back pressure', async (done) => {
+        ep1.once(Event.HIGH_BACK_PRESSURE, () => {
+            ep1.once(Event.LOW_BACK_PRESSURE, (peerInfo) => {
+                expect(peerInfo).toEqual(PeerInfo.newNode('ep2'))
+                done()
+            })
+        })
+        await inflictHighBackPressure()
+    })
+})


### PR DESCRIPTION
Add back pressure handling to WebRTC in the same vein as WsEndpoint. Add an integration test verifying behaviour.