### PR TITLE
NET-140: messageQueue set max limit & other fixes

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -373,7 +373,7 @@ export class Connection {
                 const errorMessage = 'Dropping message due to size '
                     + queueItem.getMessage().length
                     + ' exceeding the limit of '
-                    + this.dataChannel!.maxMessageSize()
+                    + this.getMaxMessageSize()
                 queueItem.immediateFail(errorMessage)
                 this.logger.warn(errorMessage)
                 this.messageQueue.pop()

--- a/src/connection/MessageQueue.ts
+++ b/src/connection/MessageQueue.ts
@@ -1,6 +1,9 @@
 import Heap from 'heap'
+import getLogger from "../helpers/logger"
 
 type Info = Object
+
+const logger = getLogger("streamr:webrtc:MessageQueue")
 
 export class QueueItem<M> {
     private static nextNumber = 0
@@ -69,6 +72,7 @@ export class MessageQueue<M> {
 
     add(message: M): Promise<void> {
         if (this.size() === this.maxSize) {
+            logger.warn("Queue full. Dropping message.")
             this.pop().immediateFail("Message queue full, dropping message.")
         }
         return new Promise((resolve, reject) => {

--- a/src/connection/MessageQueue.ts
+++ b/src/connection/MessageQueue.ts
@@ -1,0 +1,94 @@
+import Heap from 'heap'
+
+type Info = Object
+
+export class QueueItem<M> {
+    private static nextNumber = 0
+
+    private readonly message: M
+    private readonly onSuccess: () => void
+    private readonly onError: (err: Error) => void
+    private readonly infos: Info[]
+    public readonly no: number
+    private tries: number
+    private failed: boolean
+
+    constructor(message: M, onSuccess: () => void, onError: (err: Error) => void) {
+        this.message = message
+        this.onSuccess = onSuccess
+        this.onError = onError
+        this.infos = []
+        this.no = QueueItem.nextNumber++
+        this.tries = 0
+        this.failed = false
+    }
+
+    getMessage(): M {
+        return this.message
+    }
+
+    getInfos(): ReadonlyArray<Info> {
+        return this.infos
+    }
+
+    isFailed(): boolean {
+        return this.failed
+    }
+
+    delivered(): void {
+        this.onSuccess()
+    }
+
+    incrementTries(info: Info): void | never {
+        this.tries += 1
+        this.infos.push(info)
+        if (this.tries >= MessageQueue.MAX_TRIES) {
+            this.failed = true
+        }
+        if (this.isFailed()) {
+            this.onError(new Error('Failed to deliver message.'))
+        }
+    }
+
+    immediateFail(errMsg: string): void {
+        this.failed = true
+        this.onError(new Error(errMsg))
+    }
+}
+
+export class MessageQueue<M> {
+    public static readonly MAX_TRIES = 10
+
+    private readonly heap: Heap<QueueItem<M>>
+    private readonly maxSize: number
+
+    constructor(maxSize: number = 5000) {
+        this.heap = new Heap<QueueItem<M>>((a, b) => a.no - b.no)
+        this.maxSize = maxSize
+    }
+
+    add(message: M): Promise<void> {
+        if (this.size() === this.maxSize) {
+            this.pop().immediateFail("Message queue full, dropping message.")
+        }
+        return new Promise((resolve, reject) => {
+            this.heap.push(new QueueItem(message, resolve, reject))
+        })
+    }
+
+    peek(): QueueItem<M> {
+        return this.heap.peek()
+    }
+
+    pop(): QueueItem<M> {
+        return this.heap.pop()
+    }
+
+    size(): number {
+        return this.heap.size()
+    }
+
+    empty(): boolean {
+        return this.heap.empty()
+    }
+}

--- a/test/unit/MessageQueue.test.ts
+++ b/test/unit/MessageQueue.test.ts
@@ -1,0 +1,73 @@
+import { MessageQueue, QueueItem } from "../../src/connection/MessageQueue"
+import { wait } from "streamr-test-utils"
+
+describe(MessageQueue, () => {
+    let messageQueue: MessageQueue<string>
+
+    beforeEach(() => {
+        messageQueue = new MessageQueue<string>(10)
+    })
+
+    it('starts out empty', () => {
+        expect(messageQueue.size()).toEqual(0)
+        expect(messageQueue.empty()).toEqual(true)
+    })
+
+    it('not empty after adding elements', () => {
+        messageQueue.add('hello')
+        messageQueue.add('world')
+
+        expect(messageQueue.size()).toEqual(2)
+        expect(messageQueue.empty()).toEqual(false)
+    })
+
+    it('peek does not drop message', () => {
+        messageQueue.add('hello')
+        messageQueue.add('world')
+
+        expect(messageQueue.peek().getMessage()).toEqual('hello')
+        expect(messageQueue.peek().getMessage()).toEqual('hello')
+        expect(messageQueue.size()).toEqual(2)
+    })
+
+    it('preserves FIFO insertion order (add & pop)', () => {
+        messageQueue.add("hello")
+        messageQueue.add("world")
+        messageQueue.add("!")
+        messageQueue.add("lorem")
+        messageQueue.add("ipsum")
+        expect(messageQueue.pop().getMessage()).toEqual('hello')
+        expect(messageQueue.pop().getMessage()).toEqual('world')
+        expect(messageQueue.pop().getMessage()).toEqual('!')
+        expect(messageQueue.pop().getMessage()).toEqual('lorem')
+        expect(messageQueue.pop().getMessage()).toEqual('ipsum')
+    })
+
+    it('drops message in FIFO order when adding to full queue', async () => {
+        const recordedErrors: object[] = []
+        for (let i=1; i <= 10; ++i) {
+            messageQueue.add(`message ${i}`).catch((err: Error) => {
+                recordedErrors.push({
+                    i,
+                    err
+                })
+            })
+        }
+        messageQueue.add('message 11')
+        messageQueue.add('message 12')
+        await wait(0) // yield execution to error handlers
+
+        expect(messageQueue.size()).toEqual(10)
+        expect(messageQueue.peek().getMessage()).toEqual('message 3')
+        expect(recordedErrors).toEqual([
+            {
+                i: 1,
+                err: new Error("Message queue full, dropping message.")
+            },
+            {
+                i: 2,
+                err: new Error("Message queue full, dropping message.")
+            }
+        ])
+    })
+})

--- a/test/unit/QueueItem.test.ts
+++ b/test/unit/QueueItem.test.ts
@@ -1,0 +1,100 @@
+import { MessageQueue, QueueItem } from "../../src/connection/MessageQueue"
+import Mock = jest.Mock
+
+describe(QueueItem, () => {
+    it("starts as non-failed", () => {
+        const item = new QueueItem("message", () => {}, () => {})
+        expect(item.isFailed()).toEqual(false)
+        expect(item.getInfos()).toEqual([])
+    })
+
+    it("does not become failed if incrementTries invoked less than MAX_RETRIES times", () => {
+        const item = new QueueItem("message", () => {}, () => {})
+        for (let i=0; i < MessageQueue.MAX_TRIES - 1; ++i) {
+            item.incrementTries({ error: 'error' })
+        }
+        expect(item.isFailed()).toEqual(false)
+    })
+
+    it("becomes failed if incrementTries invoked MAX_RETRIES times", () => {
+        const item = new QueueItem("message", () => {}, () => {})
+        for (let i=0; i < MessageQueue.MAX_TRIES; ++i) {
+            item.incrementTries({ error: 'error' })
+        }
+        expect(item.isFailed()).toEqual(true)
+        expect(item.getInfos()).toEqual(Array(MessageQueue.MAX_TRIES).fill({ error: 'error' }))
+    })
+
+    it("becomes failed immediately if immediateFail invoked", () => {
+        const item = new QueueItem("message", () => {}, () => {})
+        item.immediateFail("error")
+        expect(item.isFailed()).toEqual(true)
+        expect(item.getInfos()).toEqual([])
+    })
+
+    describe("when method delivered() invoked", () => {
+        let successFn: Mock
+        let errorFn: Mock
+
+        beforeEach(() => {
+            successFn = jest.fn()
+            errorFn = jest.fn()
+            const item = new QueueItem<string>("message", successFn, errorFn)
+            item.delivered()
+        })
+
+        it("onSuccess callback invoked", () => {
+            expect(successFn).toHaveBeenCalledTimes(1)
+        })
+
+        it("onError callback not invoked", () => {
+            expect(errorFn).toHaveBeenCalledTimes(0)
+        })
+    })
+
+    describe("after method incrementTries invoked() MAX_RETRIES times", () => {
+        let successFn: Mock
+        let errorFn: Mock
+
+        beforeEach(() => {
+            successFn = jest.fn()
+            errorFn = jest.fn()
+            const item = new QueueItem<string>("message", successFn, errorFn)
+            for (let i=0; i < MessageQueue.MAX_TRIES; ++i) {
+                item.incrementTries({ error: `error ${i}` })
+            }
+        })
+
+        it("onSuccess callback invoked", () => {
+            expect(successFn).toHaveBeenCalledTimes(0)
+        })
+
+        it("onError callback invoked with supplied error message", () => {
+            expect(errorFn.mock.calls).toEqual([
+                [new Error("Failed to deliver message.")]
+            ])
+        })
+    })
+
+    describe("when method immediateFail() invoked", () => {
+        let successFn: Mock
+        let errorFn: Mock
+
+        beforeEach(() => {
+            successFn = jest.fn()
+            errorFn = jest.fn()
+            const item = new QueueItem<string>("message", successFn, errorFn)
+            item.immediateFail("here is error message")
+        })
+
+        it("onSuccess callback invoked", () => {
+            expect(successFn).toHaveBeenCalledTimes(0)
+        })
+
+        it("onError callback invoked with supplied error message", () => {
+            expect(errorFn.mock.calls).toEqual([
+                [new Error("here is error message")]
+            ])
+        })
+    })
+})


### PR DESCRIPTION
- Extract MessageQueue as its own class to a new file
- MessageQueue has max limit
- Refactor `attemptToFlushMessages` logic
- Ensure `attemptToFlushMessages` increments send retries even if connection not opened
- Ability to set `flushRetryTimeout` for re-trying flushing