### PR TITLE
Improve flaky tests

### DIFF
--- a/src/logic/Node.ts
+++ b/src/logic/Node.ts
@@ -88,7 +88,7 @@ export class Node extends EventEmitter {
     private connectToBoostrapTrackersInterval?: NodeJS.Timeout | null
     private handleBufferedMessagesTimeoutRef?: NodeJS.Timeout | null
 
-        constructor(opts: NodeOptions) {
+    constructor(opts: NodeOptions) {
         super()
 
         if (!(opts.protocols.trackerNode instanceof TrackerNode) || !(opts.protocols.nodeToNode instanceof NodeToNode)) {

--- a/src/logic/Node.ts
+++ b/src/logic/Node.ts
@@ -136,7 +136,7 @@ export class Node extends EventEmitter {
         this.nodeToNode.on(NodeToNodeEvent.NODE_DISCONNECTED, (nodeId) => this.onNodeDisconnected(nodeId))
         this.nodeToNode.on(NodeToNodeEvent.RESEND_REQUEST, (request, source) => this.requestResend(request, source))
         this.on(Event.NODE_SUBSCRIBED, (nodeId, streamId) => {
-            this.handleBufferedMessagesTimeoutRef = setTimeout(() => this.handleBufferedMessages(streamId), 10)
+            this.handleBufferedMessagesTimeoutRef = setTimeout(() => this.handleBufferedMessages(streamId), 50)
             this.sendStreamStatus(streamId)
         })
         this.nodeToNode.on(NodeToNodeEvent.LOW_BACK_PRESSURE, (nodeId) => {

--- a/src/logic/Node.ts
+++ b/src/logic/Node.ts
@@ -136,7 +136,7 @@ export class Node extends EventEmitter {
         this.nodeToNode.on(NodeToNodeEvent.NODE_DISCONNECTED, (nodeId) => this.onNodeDisconnected(nodeId))
         this.nodeToNode.on(NodeToNodeEvent.RESEND_REQUEST, (request, source) => this.requestResend(request, source))
         this.on(Event.NODE_SUBSCRIBED, (nodeId, streamId) => {
-            this.handleBufferedMessagesTimeoutRef = setTimeout(() => this.handleBufferedMessages(streamId), 50)
+            this.handleBufferedMessagesTimeoutRef = setTimeout(() => this.handleBufferedMessages(streamId), 20)
             this.sendStreamStatus(streamId)
         })
         this.nodeToNode.on(NodeToNodeEvent.LOW_BACK_PRESSURE, (nodeId) => {

--- a/src/logic/Node.ts
+++ b/src/logic/Node.ts
@@ -136,6 +136,7 @@ export class Node extends EventEmitter {
         this.nodeToNode.on(NodeToNodeEvent.NODE_DISCONNECTED, (nodeId) => this.onNodeDisconnected(nodeId))
         this.nodeToNode.on(NodeToNodeEvent.RESEND_REQUEST, (request, source) => this.requestResend(request, source))
         this.on(Event.NODE_SUBSCRIBED, (nodeId, streamId) => {
+            // timeout needed to get around bug in WebRTC library
             this.handleBufferedMessagesTimeoutRef = setTimeout(() => this.handleBufferedMessages(streamId), 20)
             this.sendStreamStatus(streamId)
         })

--- a/test/integration/message-propagation.test.ts
+++ b/test/integration/message-propagation.test.ts
@@ -1,7 +1,7 @@
 import { Tracker } from '../../src/logic/Tracker'
 import { NetworkNode } from '../../src/NetworkNode'
 import { MessageLayer } from 'streamr-client-protocol'
-import { wait, waitForCondition, waitForEvent } from 'streamr-test-utils'
+import { waitForCondition, waitForEvent } from 'streamr-test-utils'
 
 import { Event as NodeEvent } from '../../src/logic/Node'
 import { startTracker, startNetworkNode } from '../../src/composition'

--- a/test/integration/message-propagation.test.ts
+++ b/test/integration/message-propagation.test.ts
@@ -1,7 +1,7 @@
 import { Tracker } from '../../src/logic/Tracker'
 import { NetworkNode } from '../../src/NetworkNode'
 import { MessageLayer } from 'streamr-client-protocol'
-import { waitForCondition, waitForEvent } from 'streamr-test-utils'
+import { wait, waitForCondition, waitForEvent } from 'streamr-test-utils'
 
 import { Event as NodeEvent } from '../../src/logic/Node'
 import { startTracker, startNetworkNode } from '../../src/composition'
@@ -27,25 +27,29 @@ describe('message propagation in network', () => {
                 host: '127.0.0.1',
                 port: 33312,
                 id: 'node-1',
-                trackers: [tracker.getAddress()]
+                trackers: [tracker.getAddress()],
+                disconnectionWaitTime: 200
             }),
             startNetworkNode({
                 host: '127.0.0.1',
                 port: 33313,
                 id: 'node-2',
-                trackers: [tracker.getAddress()]
+                trackers: [tracker.getAddress()],
+                disconnectionWaitTime: 200
             }),
             startNetworkNode({
                 host: '127.0.0.1',
                 port: 33314,
                 id: 'node-3',
-                trackers: [tracker.getAddress()]
+                trackers: [tracker.getAddress()],
+                disconnectionWaitTime: 200
             }),
             startNetworkNode({
                 host: '127.0.0.1',
                 port: 33315,
                 id: 'node-4',
-                trackers: [tracker.getAddress()]
+                trackers: [tracker.getAddress()],
+                disconnectionWaitTime: 200
             })
         ]).then((res) => {
             [n1, n2, n3, n4] = res

--- a/test/integration/tracker-instructions.test.ts
+++ b/test/integration/tracker-instructions.test.ts
@@ -33,13 +33,15 @@ describe('check tracker, nodes and statuses from nodes', () => {
             host: '127.0.0.1',
             port: port1,
             id: 'node1',
-            trackers: [tracker.getAddress()]
+            trackers: [tracker.getAddress()],
+            disconnectionWaitTime: 200
         })
         node2 = await startNetworkNode({
             host: '127.0.0.1',
             port: port2,
             id: 'node2',
-            trackers: [tracker.getAddress()]
+            trackers: [tracker.getAddress()],
+            disconnectionWaitTime: 200
         })
 
         node1.subscribeToStreamIfHaveNotYet(s1)


### PR DESCRIPTION
Improve performance of flaky tests

1. tracker-instructions.test.js stability increased
2. message-propagation.test.js stability increased
3. most resend tests' stabilities have been increased

- Timeout added when a new subscription is formed for sending buffered messages. This change might need to be replaced with a ping pong to ensure that connections have been properly established on both ends in the future.