### PR TITLE
disconnect timeout on connecting state, reduce logging

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -341,10 +341,11 @@ export class Connection {
             this.close(new Error(e))
         })
         dataChannel.onBufferedAmountLow(() => {
-            this.paused = false
-            this.attemptToFlushMessages()
-            this.onBufferLow()
-            console.log("BUFFER LOW")
+            if (this.paused) {
+                this.paused = false
+                this.attemptToFlushMessages()
+                this.onBufferLow()
+            }
         })
         dataChannel.onMessage((msg) => {
             this.logger.debug('dataChannel.onmessage: %s', this.peerInfo.peerId)
@@ -385,7 +386,6 @@ export class Connection {
                 if (!this.paused) {
                     this.paused = true
                     this.onBufferHigh()
-                    console.log('BUFFER HIGH')
                 }
                 return // method eventually re-scheduled by `onBufferedAmountLow`
             } else {

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -413,8 +413,7 @@ export class Connection {
         queueItem.incrementTries({
             error: e.toString(),
             'connection.iceConnectionState': this.lastGatheringState,
-            'connection.connectionState': this.lastState,
-            message: queueItem.getMessage()
+            'connection.connectionState': this.lastState
         })
         if (queueItem.isFailed()) {
             const infoText = queueItem.getErrorInfos().map((i) => JSON.stringify(i)).join('\n\t')

--- a/src/logic/Node.ts
+++ b/src/logic/Node.ts
@@ -367,7 +367,7 @@ export class Node extends EventEmitter {
             subscribers.forEach((subscriber) => {
                 this.nodeToNode.sendData(subscriber, streamMessage).catch((e) => {
                     this.logger.error(`Failed to propagateMessage ${streamMessage} to subscriber ${subscriber}, because of ${e}`)
-                    this.emit(Event.MESSAGE_PROPAGATION_FAILED, streamMessage, subscriber, e)
+                    this.emit(Event.MESSAGE_PROPAGATION_FAILED, streamMessage.getMessageID(), subscriber, e)
                 })
             })
 


### PR DESCRIPTION
- Add disconnect timeout to connected -> connecting state
- Significantly reduce debug logging (All incoming messages were logged in debug mode, all failed propagation messages were logged)
- Solves logging memory leak