### PR TITLE
Keep datachannel open on errors

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -338,7 +338,6 @@ export class Connection {
         })
         dataChannel.onError((e) => {
             this.logger.warn('dataChannel.onError: %s', e)
-            this.close(new Error(e))
         })
         dataChannel.onBufferedAmountLow(() => {
             this.paused = false

--- a/src/logic/Node.ts
+++ b/src/logic/Node.ts
@@ -367,7 +367,7 @@ export class Node extends EventEmitter {
             subscribers.forEach((subscriber) => {
                 this.nodeToNode.sendData(subscriber, streamMessage).catch((e) => {
                     this.logger.error(`Failed to propagateMessage ${streamMessage} to subscriber ${subscriber}, because of ${e}`)
-                    this.emit(Event.MESSAGE_PROPAGATION_FAILED, streamMessage, subscriber, e)
+                    this.emit(Event.MESSAGE_PROPAGATION_FAILED, streamMessage.getMessageID(), subscriber, e)
                 })
             })
 


### PR DESCRIPTION
- Only log datachannel errors
- Major stability improvement especially in high throughput scenarios