### PR TITLE
Per stream instruction throttler

### DIFF
--- a/bin/network.js
+++ b/bin/network.js
@@ -46,7 +46,7 @@ setTimeout(() => {
     for (let i = 0; i < parseInt(numberOfNodes, 10); i++) {
         args = [
             path.resolve('./bin/subscriber.js'),
-            '--streamId=' + streams[Math.floor(Math.random() * streams.length)],
+            '--streamIds=' + streams,
             '--port=' + (startingPort + i),
             `--trackers=ws://127.0.0.1:${trackerPort}`
         ]

--- a/bin/network.js
+++ b/bin/network.js
@@ -26,7 +26,7 @@ for (let i = 0; i < parseInt(program.opts().streams, 10); i++) {
 let debug = false
 
 const productionEnv = Object.create(process.env)
-productionEnv.LOG_LEVEL = productionEnv.LOG_LEVEL || 'debug'
+// productionEnv.LOG_LEVEL = productionEnv.LOG_LEVEL || 'debug'
 
 // create tracker
 const tracker = path.resolve('./bin/tracker.js')

--- a/bin/network.js
+++ b/bin/network.js
@@ -26,7 +26,7 @@ for (let i = 0; i < parseInt(program.opts().streams, 10); i++) {
 let debug = false
 
 const productionEnv = Object.create(process.env)
-// productionEnv.LOG_LEVEL = productionEnv.LOG_LEVEL || 'debug'
+productionEnv.LOG_LEVEL = productionEnv.LOG_LEVEL || 'debug'
 
 // create tracker
 const tracker = path.resolve('./bin/tracker.js')

--- a/bin/publisher.js
+++ b/bin/publisher.js
@@ -5,7 +5,6 @@ const { MessageLayer } = require('streamr-client-protocol')
 const getLogger = require('../dist/helpers/logger').default
 const { version: CURRENT_VERSION } = require('../package.json')
 const { startNetworkNode } = require('../dist/composition')
-const { StreamIdAndPartition } = require('../dist/identifiers')
 const { MetricsContext } = require('../dist/helpers/MetricsContext')
 
 const { StreamMessage, MessageID, MessageRef } = MessageLayer

--- a/bin/publisher.js
+++ b/bin/publisher.js
@@ -19,7 +19,7 @@ program
     .option('--port <port>', 'port', '30302')
     .option('--ip <ip>', 'ip', '127.0.0.1')
     .option('--trackers <trackers>', 'trackers', (value) => value.split(','), ['ws://127.0.0.1:27777'])
-    .option('--streamId <streamId>', 'streamId to publish', 'stream-0')
+    .option('--streamIds <streamIds>', 'streamId to publish',  (value) => value.split(','), ['stream-0'])
     .option('--metrics <metrics>', 'log metrics', false)
     .option('--intervalInMs <intervalInMs>', 'interval to publish in ms', '2000')
     .option('--noise <noise>', 'bytes to add to messages', '64')
@@ -31,8 +31,6 @@ const name = program.opts().nodeName || publisherId
 const noise = parseInt(program.opts().noise, 10)
 
 const messageChainId = `message-chain-id-${program.opts().port}`
-const streamObj = new StreamIdAndPartition(program.opts().streamId, 0)
-const { id: streamId, partition } = streamObj
 
 function generateString(length) {
     let result = ''
@@ -65,17 +63,17 @@ startNetworkNode({
         setInterval(() => {
             const timestamp = Date.now()
             const msg = 'Hello world, ' + new Date().toLocaleString()
-
-            const streamMessage = new StreamMessage({
-                messageId: new MessageID(streamId, partition, timestamp, sequenceNumber, publisherId, messageChainId),
-                prevMsgRef: lastTimestamp == null ? null : new MessageRef(lastTimestamp, sequenceNumber - 1),
-                content: {
-                    msg,
-                    noise: generateString(noise)
-                },
+            program.opts().streamIds.forEach((streamId) => {
+                const streamMessage = new StreamMessage({
+                    messageId: new MessageID(streamId, 0, timestamp, sequenceNumber, publisherId, messageChainId),
+                    prevMsgRef: lastTimestamp == null ? null : new MessageRef(lastTimestamp, sequenceNumber - 1),
+                    content: {
+                        msg,
+                        noise: generateString(noise)
+                    },
+                })
+                publisher.publish(streamMessage)
             })
-            publisher.publish(streamMessage)
-
             sequenceNumber += 1
             lastTimestamp = timestamp
         }, program.opts().intervalInMs)

--- a/bin/subscriber.js
+++ b/bin/subscriber.js
@@ -16,7 +16,7 @@ program
     .option('--port <port>', 'port', '30304')
     .option('--ip <ip>', 'ip', '127.0.0.1')
     .option('--trackers <trackers>', 'trackers', (value) => value.split(','), ['ws://127.0.0.1:27777'])
-    .option('--streamId <streamId>', 'streamId to publish', 'stream-0')
+    .option('--streamIds <streamIds>', 'streamId to publish', (value) => value.split(','), ['stream-0'])
     .option('--metrics <metrics>', 'log metrics', false)
     .description('Run subscriber')
     .parse(process.argv)
@@ -36,7 +36,7 @@ startNetworkNode({
     logger.info('started subscriber id: %s, name: %s, port: %d, ip: %s, trackers: %s, streamId: %s, metrics: %s',
         id, name, program.opts().port, program.opts().ip, program.opts().trackers.join(', '), program.opts().streamId, program.opts().metrics)
     subscriber.start()
-    subscriber.subscribe(program.opts().streamId, 0)
+    program.opts().streamIds.forEach((stream) => subscriber.subscribe(stream, 0))
 
     let messageNo = 0
     let lastReported = 0
@@ -56,6 +56,7 @@ startNetworkNode({
             logger.info(JSON.stringify(await metricsContext.report(true), null, 3))
         }, 5000)
     }
+
     return true
 }).catch((err) => {
     throw err

--- a/src/logic/InstructionThrottler.ts
+++ b/src/logic/InstructionThrottler.ts
@@ -2,7 +2,6 @@ import { cancelable, CancelablePromiseType } from 'cancelable-promise'
 import { StreamIdAndPartition, StreamKey } from '../identifiers'
 import { TrackerLayer } from 'streamr-client-protocol'
 import getLogger from '../helpers/logger'
-import { startTracker } from "../composition"
 
 const logger = getLogger('streamr:logic:InstructionThrottler')
 

--- a/src/logic/InstructionThrottler.ts
+++ b/src/logic/InstructionThrottler.ts
@@ -36,7 +36,7 @@ export class InstructionThrottler {
 
     add(instructionMessage: TrackerLayer.InstructionMessage, trackerId: string): void {
         const streamId = StreamIdAndPartition.fromMessage(instructionMessage).key()
-        if (!this.instructionCounter[streamId] || this.instructionCounter[streamId]) {
+        if (!this.instructionCounter[streamId] || this.instructionCounter[streamId] <= instructionMessage.counter) {
             this.instructionCounter[streamId] = instructionMessage.counter
             this.queue[StreamIdAndPartition.fromMessage(instructionMessage).key()] = {
                 instructionMessage,
@@ -67,14 +67,7 @@ export class InstructionThrottler {
     }
 
     isIdle(): boolean {
-        let idle = true
-        Object.values(this.ongoingPromises).forEach((promises) => {
-            if (promises.handling) {
-                idle = false
-                return
-            }
-        })
-        return idle
+        return !Object.values(this.ongoingPromises).some((p) => p.handling)
     }
 
     reset(): void {

--- a/src/logic/InstructionThrottler.ts
+++ b/src/logic/InstructionThrottler.ts
@@ -2,6 +2,7 @@ import { cancelable, CancelablePromiseType } from 'cancelable-promise'
 import { StreamIdAndPartition, StreamKey } from '../identifiers'
 import { TrackerLayer } from 'streamr-client-protocol'
 import getLogger from '../helpers/logger'
+import { startTracker } from "../composition"
 
 const logger = getLogger('streamr:logic:InstructionThrottler')
 
@@ -22,23 +23,35 @@ export class InstructionThrottler {
     private readonly handleFn: (instructionMessage: TrackerLayer.InstructionMessage, trackerId: string) => Promise<void>
     private queue: Queue = {} // streamId => instructionMessage
     private instructionCounter: { [key: string]: number } = {} // streamId => counter
-    private handling = false
-    private ongoingPromise: CancelablePromiseType<void> | null = null
+    private ongoingPromises: {
+        [key: string]: {
+            promise: CancelablePromiseType<void> | null
+            handling: boolean
+        }
+    }
 
     constructor(handleFn: (instructionMessage: TrackerLayer.InstructionMessage, trackerId: string) => Promise<void>) {
         this.handleFn = handleFn
+        this.ongoingPromises = {}
     }
 
     add(instructionMessage: TrackerLayer.InstructionMessage, trackerId: string): void {
         const streamId = StreamIdAndPartition.fromMessage(instructionMessage).key()
-        if (!this.instructionCounter[streamId] || this.instructionCounter[streamId] <= instructionMessage.counter) {
+        if (!this.instructionCounter[streamId] || this.instructionCounter[streamId]) {
             this.instructionCounter[streamId] = instructionMessage.counter
             this.queue[StreamIdAndPartition.fromMessage(instructionMessage).key()] = {
                 instructionMessage,
                 trackerId
             }
-            if (!this.handling) {
-                this.invokeHandleFnWithLock().catch((err) => {
+
+            if (!this.ongoingPromises[streamId]) {
+                this.ongoingPromises[streamId] = {
+                    promise: null,
+                    handling: false
+                }
+            }
+            if (!this.ongoingPromises[streamId].handling) {
+                this.invokeHandleFnWithLock(streamId).catch((err) => {
                     logger.warn("Error handling instruction %s", err)
                 })
             }
@@ -48,40 +61,53 @@ export class InstructionThrottler {
     removeStreamId(streamId: StreamKey): void {
         delete this.queue[streamId]
         delete this.instructionCounter[streamId]
+        if (this.ongoingPromises[streamId]) {
+            this.ongoingPromises[streamId].promise!.cancel()
+        }
+        delete this.ongoingPromises[streamId]
     }
 
     isIdle(): boolean {
-        return !this.handling
+        let idle = true
+        Object.values(this.ongoingPromises).forEach((promises) => {
+            if (promises.handling) {
+                idle = false
+                return
+            }
+        })
+        return idle
     }
 
     reset(): void {
         this.queue = {}
         this.instructionCounter = {}
-        if (this.ongoingPromise) {
-            this.ongoingPromise.cancel()
-        }
+        Object.keys(this.ongoingPromises).forEach((streamId) => {
+            if (this.ongoingPromises[streamId]) {
+                this.ongoingPromises[streamId].promise!.cancel()
+            }
+            delete this.ongoingPromises[streamId]
+        })
+        this.ongoingPromises = {}
     }
 
-    private async invokeHandleFnWithLock(): Promise<void> {
-        const streamIds = Object.keys(this.queue)
-        const streamId: StreamKey = streamIds[0]
+    private async invokeHandleFnWithLock(streamId: string): Promise<void> {
+        if (!this.queue[streamId]) {
+            this.ongoingPromises[streamId].handling = false
+            return
+        }
+        this.ongoingPromises[streamId].handling = true
+
         const { instructionMessage, trackerId } = this.queue[streamId]
         delete this.queue[streamId]
 
-        this.handling = true
         try {
-            this.ongoingPromise = cancelable(this.handleFn(instructionMessage, trackerId))
-            await this.ongoingPromise
+            this.ongoingPromises[streamId].promise = cancelable(this.handleFn(instructionMessage, trackerId))
+            await this.ongoingPromises[streamId].promise
         } catch (err) {
             logger.warn('InstructionMessage handling threw error %s', err)
             logger.warn(err)
         } finally {
-            this.ongoingPromise = null
-            if (this.isQueueEmpty()) {
-                this.handling = false
-            } else {
-                this.invokeHandleFnWithLock()
-            }
+            this.invokeHandleFnWithLock(streamId)
         }
     }
 

--- a/test/integration/tracker-node-reconnect-instructions.test.ts
+++ b/test/integration/tracker-node-reconnect-instructions.test.ts
@@ -68,6 +68,12 @@ describe('Check tracker instructions to node', () => {
             waitForEvent(nodeOne, NodeEvent.NODE_SUBSCRIBED),
             waitForEvent(nodeTwo, NodeEvent.NODE_SUBSCRIBED)
         ])
+
+        // @ts-expect-error private field
+        expect(Object.keys(nodeOne.nodeToNode.endpoint.connections).length).toBe(1)
+        // @ts-expect-error private field
+        expect(Object.keys(nodeTwo.nodeToNode.endpoint.connections).length).toBe(1)
+
         // send empty list
         // @ts-expect-error private field
         await tracker.trackerServer.endpoint.send(

--- a/test/integration/tracker-node-reconnect-instructions.test.ts
+++ b/test/integration/tracker-node-reconnect-instructions.test.ts
@@ -6,8 +6,6 @@ import { TrackerLayer } from 'streamr-client-protocol'
 import { startNetworkNode, startTracker } from '../../src/composition'
 import { Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 import { Event as NodeEvent } from '../../src/logic/Node'
-import { Event as TrackerNodeEvent } from '../../src/protocol/TrackerNode'
-import { Event } from '../../src/connection/WsEndpoint'
 
 /**
  * This test verifies that tracker can send instructions to node and node will connect and disconnect based on the instructions
@@ -82,18 +80,15 @@ describe('Check tracker instructions to node', () => {
                 counter: 3
             }).serialize()
         )
-        // @ts-expect-error private field
-        await waitForEvent(nodeOne.trackerNode, TrackerNodeEvent.TRACKER_INSTRUCTION_RECEIVED)
-        await waitForEvent(nodeOne, NodeEvent.NODE_DISCONNECTED)
+        await waitForEvent(nodeOne, NodeEvent.NODE_UNSUBSCRIBED)
 
         // @ts-expect-error private field
         expect(nodeOne.trackerNode.endpoint.getPeers().size).toBe(1)
 
         nodeOne.unsubscribe(streamId, 0)
+        await waitForEvent(nodeTwo, NodeEvent.NODE_UNSUBSCRIBED)
 
         // @ts-expect-error private field
-        await waitForEvent(nodeTwo.nodeToNode.endpoint, Event.PEER_DISCONNECTED)
-        // @ts-expect-error private field
-        expect(nodeTwo.trackerNode.endpoint.getPeers().size).toBe(1)
+        expect(Object.keys(nodeTwo.nodeToNode.endpoint.connections).length).toBe(1)
     })
 })

--- a/test/integration/unsubscribe-from-stream.test.ts
+++ b/test/integration/unsubscribe-from-stream.test.ts
@@ -2,11 +2,10 @@ import { Tracker } from '../../src/logic/Tracker'
 import { NetworkNode } from '../../src/NetworkNode'
 
 import { MessageLayer } from 'streamr-client-protocol'
-import { wait, waitForEvent } from 'streamr-test-utils'
+import { waitForEvent } from 'streamr-test-utils'
 
 import { startNetworkNode, startTracker } from '../../src/composition'
 import { Event as NodeEvent } from '../../src/logic/Node'
-import { Event as TrackerServerEvent } from '../../src/protocol/TrackerServer'
 
 const { StreamMessage, MessageID } = MessageLayer
 

--- a/test/integration/unsubscribe-from-stream.test.ts
+++ b/test/integration/unsubscribe-from-stream.test.ts
@@ -2,7 +2,7 @@ import { Tracker } from '../../src/logic/Tracker'
 import { NetworkNode } from '../../src/NetworkNode'
 
 import { MessageLayer } from 'streamr-client-protocol'
-import { waitForEvent } from 'streamr-test-utils'
+import { wait, waitForEvent } from 'streamr-test-utils'
 
 import { startNetworkNode, startTracker } from '../../src/composition'
 import { Event as NodeEvent } from '../../src/logic/Node'
@@ -36,21 +36,21 @@ describe('node unsubscribing from a stream', () => {
             disconnectionWaitTime: 200
         })
 
-        nodeA.subscribe('s', 1)
-        nodeB.subscribe('s', 1)
-        nodeA.subscribe('s', 2)
-        nodeB.subscribe('s', 2)
-
         nodeA.start()
         nodeB.start()
 
+        nodeA.subscribe('s', 2)
+        nodeB.subscribe('s', 2)
         await Promise.all([
             waitForEvent(nodeA, NodeEvent.NODE_SUBSCRIBED),
             waitForEvent(nodeB, NodeEvent.NODE_SUBSCRIBED),
-            // @ts-expect-error private field
-            waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED),
-            // @ts-expect-error private field
-            waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
+        ])
+
+        nodeA.subscribe('s', 1)
+        nodeB.subscribe('s', 1)
+        await Promise.all([
+            waitForEvent(nodeA, NodeEvent.NODE_SUBSCRIBED),
+            waitForEvent(nodeB, NodeEvent.NODE_SUBSCRIBED),
         ])
     })
 
@@ -62,7 +62,6 @@ describe('node unsubscribing from a stream', () => {
 
     test('node still receives data for subscribed streams thru existing connections', async () => {
         const actual: string[] = []
-
         nodeB.addMessageListener((streamMessage) => {
             actual.push(`${streamMessage.getStreamId()}::${streamMessage.getStreamPartition()}`)
         })

--- a/test/unit/InstructionThrottler.test.ts
+++ b/test/unit/InstructionThrottler.test.ts
@@ -53,7 +53,6 @@ describe('InstructionThrottler', () => {
             [createInstruction('stream-1', 1), 'tracker-1'],
             [createInstruction('stream-1', 5), 'tracker-1']
         ])
-        console.log()
     })
 
     it('all instructions are handled when inserting them slowly with identical keys (no throttle)', async () => {

--- a/test/unit/InstructionThrottler.test.ts
+++ b/test/unit/InstructionThrottler.test.ts
@@ -53,6 +53,7 @@ describe('InstructionThrottler', () => {
             [createInstruction('stream-1', 1), 'tracker-1'],
             [createInstruction('stream-1', 5), 'tracker-1']
         ])
+        console.log()
     })
 
     it('all instructions are handled when inserting them slowly with identical keys (no throttle)', async () => {


### PR DESCRIPTION
- Change bin/network.js and bin/subscriber.js streams flag to subscribe all nodes to n amount of streams
- Rework InstructionThrottler to work on per stream basis. Solves churn issues with multi stream throttling