### PR TITLE
NET-184: Rtt endpoints

### DIFF
--- a/src/helpers/trackerHttpEndpoints.ts
+++ b/src/helpers/trackerHttpEndpoints.ts
@@ -43,7 +43,7 @@ export function trackerHttpEndpoints(wss: TemplatedApp, tracker: Tracker, metric
     wss.get('/topology/', (res, req) => {
         extraLogger.debug('request to /topology/')
         writeCorsHeaders(res, req)
-        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream())))
+        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())))
     })
     wss.get('/topology/:streamId/', (res, req) => {
         const streamId = decodeURIComponent(req.getParameter(0)).trim()
@@ -55,7 +55,7 @@ export function trackerHttpEndpoints(wss: TemplatedApp, tracker: Tracker, metric
 
         extraLogger.debug(`request to /topology/${streamId}/`)
         writeCorsHeaders(res, req)
-        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream(), streamId, null)))
+        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts(), streamId, null)))
     })
     wss.get('/topology/:streamId/:partition/', (res, req) => {
         const streamId = decodeURIComponent(req.getParameter(0)).trim()
@@ -74,7 +74,7 @@ export function trackerHttpEndpoints(wss: TemplatedApp, tracker: Tracker, metric
 
         extraLogger.debug(`request to /topology/${streamId}/${askedPartition}/`)
         writeCorsHeaders(res, req)
-        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream(), streamId, askedPartition)))
+        res.end(JSON.stringify(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts(), streamId, askedPartition)))
     })
     cachedJsonGet(wss,'/node-connections/', 15 * 1000, () => {
         const topologyUnion = getNodeConnections(tracker.getNodes(), tracker.getOverlayPerStream())

--- a/src/helpers/trackerHttpEndpoints.ts
+++ b/src/helpers/trackerHttpEndpoints.ts
@@ -80,6 +80,11 @@ export function trackerHttpEndpoints(wss: TemplatedApp, tracker: Tracker, metric
         const topologyUnion = getNodeConnections(tracker.getNodes(), tracker.getOverlayPerStream())
         return _.mapValues(topologyUnion, (targetNodes) => Array.from(targetNodes))
     })
+    wss.get('/node-connections/latencies/', (res, req) => {
+        extraLogger.debug('request to /node-connections/latencies/')
+        writeCorsHeaders(res, req)
+        res.end(JSON.stringify(tracker.getOverlayConnectionRtts()))
+    })
     wss.get('/location/', (res, req) => {
         extraLogger.debug('request to /location/')
         writeCorsHeaders(res, req)

--- a/src/helpers/trackerHttpEndpoints.ts
+++ b/src/helpers/trackerHttpEndpoints.ts
@@ -81,9 +81,20 @@ export function trackerHttpEndpoints(wss: TemplatedApp, tracker: Tracker, metric
         return _.mapValues(topologyUnion, (targetNodes) => Array.from(targetNodes))
     })
     wss.get('/node-to-node-latencies/', (res, req) => {
-        extraLogger.debug('request to /node-connections/latencies/')
+        extraLogger.debug('request to /node-to-node-latencies/')
         writeCorsHeaders(res, req)
         res.end(JSON.stringify(tracker.getOverlayConnectionRtts()))
+    })
+    wss.get('/node-to-node-latencies/:nodeId/', (res, req) => {
+        const nodeId = decodeURIComponent(req.getParameter(0)).trim()
+        if (nodeId.length === 0) {
+            extraLogger.error('422 nodeId must be a not empty string')
+            respondWithError(res, req, 'nodeId cannot be empty')
+            return
+        }
+        extraLogger.debug(`request to /node-to-node-latencies/${nodeId}/`)
+        writeCorsHeaders(res, req)
+        res.end(JSON.stringify(tracker.getNodeConnectionRtts(nodeId)))
     })
     wss.get('/location/', (res, req) => {
         extraLogger.debug('request to /location/')

--- a/src/helpers/trackerHttpEndpoints.ts
+++ b/src/helpers/trackerHttpEndpoints.ts
@@ -80,7 +80,7 @@ export function trackerHttpEndpoints(wss: TemplatedApp, tracker: Tracker, metric
         const topologyUnion = getNodeConnections(tracker.getNodes(), tracker.getOverlayPerStream())
         return _.mapValues(topologyUnion, (targetNodes) => Array.from(targetNodes))
     })
-    wss.get('/node-connections/latencies/', (res, req) => {
+    wss.get('/node-to-node-latencies/', (res, req) => {
         extraLogger.debug('request to /node-connections/latencies/')
         writeCorsHeaders(res, req)
         res.end(JSON.stringify(tracker.getOverlayConnectionRtts()))

--- a/src/helpers/trackerHttpEndpoints.ts
+++ b/src/helpers/trackerHttpEndpoints.ts
@@ -81,22 +81,6 @@ export function trackerHttpEndpoints(wss: TemplatedApp, tracker: Tracker, metric
             return addRttsToNodeConnections(nodeId, Array.from(neighbors), tracker.getOverlayConnectionRtts())
         }))
     })
-    wss.get('/node-to-node-latencies/', (res, req) => {
-        extraLogger.debug('request to /node-to-node-latencies/')
-        writeCorsHeaders(res, req)
-        res.end(JSON.stringify(tracker.getOverlayConnectionRtts()))
-    })
-    wss.get('/node-to-node-latencies/:nodeId/', (res, req) => {
-        const nodeId = decodeURIComponent(req.getParameter(0)).trim()
-        if (nodeId.length === 0) {
-            extraLogger.error('422 nodeId must be a not empty string')
-            respondWithError(res, req, 'nodeId cannot be empty')
-            return
-        }
-        extraLogger.debug(`request to /node-to-node-latencies/${nodeId}/`)
-        writeCorsHeaders(res, req)
-        res.end(JSON.stringify(tracker.getNodeConnectionRtts(nodeId)))
-    })
     wss.get('/location/', (res, req) => {
         extraLogger.debug('request to /location/')
         writeCorsHeaders(res, req)

--- a/src/logic/Tracker.ts
+++ b/src/logic/Tracker.ts
@@ -235,27 +235,6 @@ export class Tracker extends EventEmitter {
         return this.overlayConnectionRtts
     }
 
-    getNodeConnectionRtts(nodeId: string): { [key: string]: number } {
-        try {
-            return this.overlayConnectionRtts[nodeId]
-        } catch {
-            return {}
-        }
-    }
-
-    getNodeToNodeConnectionRtts(nodeOne: string, nodeTwo: string): number | null {
-        try {
-            return this.overlayConnectionRtts[nodeOne][nodeTwo]
-        } catch {
-            try {
-                return this.overlayConnectionRtts[nodeOne][nodeTwo]
-            } catch {
-                this.logger.warn('Overlay connection rtt', nodeOne, nodeTwo, 'not found')
-            }
-        }
-        return null
-    }
-
     getStorageNodes(): ReadonlyArray<NodeId> {
         return [...this.storageNodes]
     }

--- a/src/logic/Tracker.ts
+++ b/src/logic/Tracker.ts
@@ -231,6 +231,31 @@ export class Tracker extends EventEmitter {
         return this.locationManager.getNodeLocation(node)
     }
 
+    getOverlayConnectionRtts(): { [key: string]: { [key: string]: number } } {
+        return this.overlayConnectionRtts
+    }
+
+    getNodeConnectionRtts(nodeId: string): { [key: string]: number } {
+        try {
+            return this.overlayConnectionRtts[nodeId]
+        } catch {
+            return {}
+        }
+    }
+
+    getNodeToNodeConnectionRtts(nodeOne: string, nodeTwo: string): number | null {
+        try {
+            return this.overlayConnectionRtts[nodeOne][nodeTwo]
+        } catch {
+            try {
+                return this.overlayConnectionRtts[nodeOne][nodeTwo]
+            } catch {
+                this.logger.warn('Overlay connection rtt', nodeOne, nodeTwo, 'not found')
+            }
+        }
+        return null
+    }
+
     getStorageNodes(): ReadonlyArray<NodeId> {
         return [...this.storageNodes]
     }

--- a/src/logic/Tracker.ts
+++ b/src/logic/Tracker.ts
@@ -235,6 +235,14 @@ export class Tracker extends EventEmitter {
         return this.overlayConnectionRtts
     }
 
+    getNodeConnectionRtts(nodeId: string): { [key: string]: number } {
+        try {
+            return this.overlayConnectionRtts[nodeId]
+        } catch {
+            return {}
+        }
+    }
+
     getStorageNodes(): ReadonlyArray<NodeId> {
         return [...this.storageNodes]
     }

--- a/src/logic/Tracker.ts
+++ b/src/logic/Tracker.ts
@@ -30,6 +30,9 @@ export interface TrackerOptions {
 // streamKey => overlayTopology, where streamKey = streamId::partition
 export type OverlayPerStream = { [key: string]: OverlayTopology }
 
+// nodeId => connected nodeId => rtt
+export type OverlayConnectionRtts = { [key: string]: { [key: string]: number } }
+
 export interface Tracker {
     on(event: Event.NODE_CONNECTED, listener: (nodeId: NodeId) => void): this
 }
@@ -39,11 +42,7 @@ export class Tracker extends EventEmitter {
     private readonly trackerServer: TrackerServer
     private readonly peerInfo: PeerInfo
     private readonly overlayPerStream: OverlayPerStream
-    private readonly overlayConnectionRtts: {
-        [key: string]: {
-            [key: string]: number
-        }
-    }
+    private readonly overlayConnectionRtts: OverlayConnectionRtts
     private readonly locationManager: LocationManager
     private readonly instructionCounter: InstructionCounter
     private readonly storageNodes: Set<NodeId>
@@ -66,7 +65,7 @@ export class Tracker extends EventEmitter {
         this.peerInfo = opts.peerInfo
 
         this.overlayPerStream = {}
-        this.overlayConnectionRtts = {} // nodeId => connected nodeId => rtt
+        this.overlayConnectionRtts = {}
         this.locationManager = new LocationManager()
         this.instructionCounter = new InstructionCounter()
         this.storageNodes = new Set()

--- a/src/logic/Tracker.ts
+++ b/src/logic/Tracker.ts
@@ -234,14 +234,6 @@ export class Tracker extends EventEmitter {
         return this.overlayConnectionRtts
     }
 
-    getNodeConnectionRtts(nodeId: string): { [key: string]: number } {
-        try {
-            return this.overlayConnectionRtts[nodeId]
-        } catch {
-            return {}
-        }
-    }
-
     getStorageNodes(): ReadonlyArray<NodeId> {
         return [...this.storageNodes]
     }

--- a/src/logic/trackerSummaryUtils.ts
+++ b/src/logic/trackerSummaryUtils.ts
@@ -1,7 +1,7 @@
 import { StreamIdAndPartition } from '../identifiers'
 import { OverlayPerStream, OverlayConnectionRtts } from './Tracker'
 
-type OverLayWithRtts = { [key: string]: { [key: string]: { neighborId: string, rtt: number | null }[] }[] }
+type OverLayWithRtts = { [key: string]: { [key: string]: { neighborId: string, rtt: number | null }[] } }
 
 export function getTopology(
     overlayPerStream: OverlayPerStream,

--- a/src/logic/trackerSummaryUtils.ts
+++ b/src/logic/trackerSummaryUtils.ts
@@ -1,13 +1,15 @@
-import { TopologyState } from './OverlayTopology'
 import { StreamIdAndPartition } from '../identifiers'
-import { OverlayPerStream } from './Tracker'
+import { OverlayPerStream, OverlayConnectionRtts } from './Tracker'
+
+type OverLayWithRtts = { [key: string]: { [key: string]: { neighborId: string, rtt: number | null }[] }[] }
 
 export function getTopology(
     overlayPerStream: OverlayPerStream,
+    connectionRtts: OverlayConnectionRtts,
     streamId: string | null = null,
     partition: number | null = null
-): { [key: string]: TopologyState } {
-    const topology: { [key: string]: TopologyState } = {}
+): OverLayWithRtts {
+    const topology: OverLayWithRtts = {}
 
     let streamKeys: string[] = []
 
@@ -25,7 +27,17 @@ export function getTopology(
     }
 
     streamKeys.forEach((streamKey) => {
-        topology[streamKey] = overlayPerStream[streamKey].state()
+        const streamOverlay = overlayPerStream[streamKey].state()
+        topology[streamKey] = Object.assign({}, ...Object.entries(streamOverlay).map(([nodeId, neighbors]) => {
+            return {
+                [nodeId]: neighbors.map((neighborId) => {
+                    return {
+                        neighborId,
+                        rtt: getNodeToNodeConnectionRtts(nodeId, neighborId, connectionRtts[nodeId], connectionRtts[neighborId])
+                    }
+                })
+            }
+        }))
     })
 
     return topology
@@ -42,4 +54,12 @@ export function getNodeConnections(nodes: readonly string[], overlayPerStream: O
         })
     })
     return result
+}
+
+function getNodeToNodeConnectionRtts(nodeOne: string, nodeTwo: string, nodeOneRtts: { [key: string]: number }, nodeTwoRtts: { [key: string]: number }): number | null {
+    try {
+        return nodeOneRtts[nodeTwo] || nodeTwoRtts[nodeOne] || null
+    } catch (err) {
+        return null
+    }
 }

--- a/src/logic/trackerSummaryUtils.ts
+++ b/src/logic/trackerSummaryUtils.ts
@@ -29,14 +29,7 @@ export function getTopology(
     streamKeys.forEach((streamKey) => {
         const streamOverlay = overlayPerStream[streamKey].state()
         topology[streamKey] = Object.assign({}, ...Object.entries(streamOverlay).map(([nodeId, neighbors]) => {
-            return {
-                [nodeId]: neighbors.map((neighborId) => {
-                    return {
-                        neighborId,
-                        rtt: getNodeToNodeConnectionRtts(nodeId, neighborId, connectionRtts[nodeId], connectionRtts[neighborId])
-                    }
-                })
-            }
+            return addRttsToNodeConnections(nodeId, neighbors, connectionRtts)
         }))
     })
 
@@ -54,6 +47,17 @@ export function getNodeConnections(nodes: readonly string[], overlayPerStream: O
         })
     })
     return result
+}
+
+export function addRttsToNodeConnections(nodeId: string, neighbors: Array<string>, connectionRtts: OverlayConnectionRtts): { [key: string]: { neighborId: string, rtt: number | null }[] } {
+    return {
+        [nodeId]: neighbors.map((neighborId) => {
+            return {
+                neighborId,
+                rtt: getNodeToNodeConnectionRtts(nodeId, neighborId, connectionRtts[nodeId], connectionRtts[neighborId])
+            }
+        })
+    }
 }
 
 function getNodeToNodeConnectionRtts(nodeOne: string, nodeTwo: string, nodeOneRtts: { [key: string]: number }, nodeTwoRtts: { [key: string]: number }): number | null {

--- a/test/integration/counter-filtering-in-tracker.test.ts
+++ b/test/integration/counter-filtering-in-tracker.test.ts
@@ -98,18 +98,18 @@ describe('tracker: counter filtering', () => {
     })
 
     test('NET-36: tracker receiving status with old counter should not affect topology', async () => {
-        const topologyBefore = getTopology(tracker.getOverlayPerStream())
+        const topologyBefore = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
         trackerNode1.sendStatus('tracker', formStatus(0, 0, [], []) as Status)
         // @ts-expect-error trackerServer is private
         await waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual(topologyBefore)
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual(topologyBefore)
     })
 
     test('NET-36: tracker receiving status with partial old counter should not affect topology', async () => {
-        const topologyBefore = getTopology(tracker.getOverlayPerStream())
+        const topologyBefore = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
         trackerNode1.sendStatus('tracker', formStatus(1, 0, [], []) as Status)
         // @ts-expect-error trackerServer is private
         await waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual(topologyBefore)
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual(topologyBefore)
     })
 })

--- a/test/integration/network-stabilization.test.ts
+++ b/test/integration/network-stabilization.test.ts
@@ -57,10 +57,10 @@ describe('check network stabilization', () => {
     it('network must become stable in less than 10 seconds',  () => {
         return new Promise(async (resolve, reject) => {
             for (let i = 0; i < 10; ++i) {
-                const beforeTopology = getTopology(tracker.getOverlayPerStream())
+                const beforeTopology = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
                 // eslint-disable-next-line no-await-in-loop
                 await wait(800)
-                const afterTopology = getTopology(tracker.getOverlayPerStream())
+                const afterTopology = getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())
                 if (areEqual(beforeTopology, afterTopology)) {
                     resolve(true)
                     return

--- a/test/integration/tracker-endpoints.test.ts
+++ b/test/integration/tracker-endpoints.test.ts
@@ -170,8 +170,8 @@ describe('tracker endpoint', () => {
         const [status, jsonResult]: any = await getHttp(`http://127.0.0.1:${trackerPort}/node-connections/`)
         expect(status).toEqual(200)
         expect(jsonResult).toEqual({
-            'node-1': ['node-2'],
-            'node-2': ['node-1']
+            'node-1': [{neighborId: 'node-2', rtt: null}],
+            'node-2': [{neighborId: 'node-1', rtt: null}]
         })
     })
 

--- a/test/integration/tracker-instructions.test.ts
+++ b/test/integration/tracker-instructions.test.ts
@@ -101,10 +101,10 @@ describe('check tracker, nodes and statuses from nodes', () => {
         await waitForCondition(() => node1.getNeighbors().length > 0)
         await waitForCondition(() => node2.getNeighbors().length > 0)
 
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
             'stream-1::0': {
-                node1: ['node2'],
-                node2: ['node1'],
+                node1: [{neighborId: 'node2', rtt: null}],
+                node2: [{neighborId: 'node1', rtt: null}],
             }
         })
 

--- a/test/integration/tracker.test.ts
+++ b/test/integration/tracker.test.ts
@@ -48,7 +48,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
         subscriberOne.start()
         // @ts-expect-error private field
         await waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
             'stream-1::0': {
                 subscriberOne: [],
             },
@@ -60,14 +60,14 @@ describe('check tracker, nodes and statuses from nodes', () => {
         subscriberTwo.start()
         // @ts-expect-error private field
         await waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
             'stream-1::0': {
-                subscriberOne: ['subscriberTwo'],
-                subscriberTwo: ['subscriberOne']
+                subscriberOne: [{neighborId: 'subscriberTwo', rtt: null}],
+                subscriberTwo: [{neighborId: 'subscriberOne', rtt: null}]
             },
             'stream-2::2': {
-                subscriberOne: ['subscriberTwo'],
-                subscriberTwo: ['subscriberOne']
+                subscriberOne: [{neighborId: 'subscriberTwo', rtt: null}],
+                subscriberTwo: [{neighborId: 'subscriberOne', rtt: null}]
             }
         })
     })
@@ -87,10 +87,10 @@ describe('check tracker, nodes and statuses from nodes', () => {
         await waitForEvent(subscriberTwo, NodeEvent.NODE_UNSUBSCRIBED)
         // @ts-expect-error private field
         await waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
             'stream-1::0': {
-                subscriberOne: ['subscriberTwo'],
-                subscriberTwo: ['subscriberOne'],
+                subscriberOne: [{neighborId: 'subscriberTwo', rtt: null}],
+                subscriberTwo: [{neighborId: 'subscriberOne', rtt: null}],
             },
             'stream-2::2': {
                 subscriberTwo: []
@@ -101,7 +101,7 @@ describe('check tracker, nodes and statuses from nodes', () => {
         await waitForEvent(subscriberTwo, NodeEvent.NODE_UNSUBSCRIBED)
         // @ts-expect-error private field
         await waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
             'stream-1::0': {
                 subscriberTwo: [],
             },
@@ -111,8 +111,8 @@ describe('check tracker, nodes and statuses from nodes', () => {
         })
 
         subscriberTwo.unsubscribe('stream-1', 0)
-        await waitForCondition(() => getTopology(tracker.getOverlayPerStream())['stream-1::0'] == null)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual({
+        await waitForCondition(() => getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())['stream-1::0'] == null)
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({
             'stream-2::2': {
                 subscriberTwo: []
             }
@@ -121,6 +121,6 @@ describe('check tracker, nodes and statuses from nodes', () => {
         subscriberTwo.unsubscribe('stream-2', 2)
         // @ts-expect-error private field
         await waitForEvent(tracker.trackerServer, TrackerServerEvent.NODE_STATUS_RECEIVED)
-        expect(getTopology(tracker.getOverlayPerStream())).toEqual({})
+        expect(getTopology(tracker.getOverlayPerStream(), tracker.getOverlayConnectionRtts())).toEqual({})
     }, 10 * 1000)
 })


### PR DESCRIPTION
- Add rtts to /topology/* endpoints
- Add rtts to /node-connections/ endpoint


Format /topology/*: 

```
{"stream-0::0":
      {
          "node-1": [
                   {"neighborId": "node-2", "rtt": 10},
                   {"neighborId": "node-3", "rtt": null}
          ],
          "node-2": [
                   {"neighborId": "node-1", "rtt": 10}
                   {"neighborId": "node-3", "rtt": 120}
          ],
          "node-3": [
                   {"neighborId": "node-1", "rtt": null}
                   {"neighborId": "node-2", "rtt": 120}
          ],
      },
      ...
}
```

Format /node-connections/: 

```
{
    "node-1": [
             {"neighborId": "node-2", "rtt": 10},
             {"neighborId": "node-3", "rtt": null}
    ],
    "node-2": [
             {"neighborId": "node-1", "rtt": 10}
             {"neighborId": "node-3", "rtt": 120}
    ],
    "node-3": [
             {"neighborId": "node-1", "rtt": null}
             {"neighborId": "node-2", "rtt": 120}
    ],
 }
```