### PR TITLE
force connections on instruction reattempts

### DIFF
--- a/src/logic/InstructionRetryManager.ts
+++ b/src/logic/InstructionRetryManager.ts
@@ -5,11 +5,11 @@ import { TrackerLayer } from "streamr-client-protocol"
 const logger = getLogger('streamr:logic:InstructionRetryManager')
 
 export class InstructionRetryManager {
-    private readonly handleFn: (instructionMessage: TrackerLayer.InstructionMessage, trackerId: string) => Promise<void>
+    private readonly handleFn: (instructionMessage: TrackerLayer.InstructionMessage, trackerId: string, reattempt: boolean) => Promise<void>
     private readonly intervalInMs: number
     private instructionRetryIntervals: { [key: string]: NodeJS.Timeout }
 
-    constructor(handleFn: (instructionMessage: TrackerLayer.InstructionMessage, trackerId: string) => Promise<void>, intervalInMs: number) {
+    constructor(handleFn: (instructionMessage: TrackerLayer.InstructionMessage, trackerId: string, reattempt: boolean) => Promise<void>, intervalInMs: number) {
         this.handleFn = handleFn
         this.intervalInMs = intervalInMs
         this.instructionRetryIntervals = {}
@@ -27,7 +27,7 @@ export class InstructionRetryManager {
 
     async retryFunction(instructionMessage: TrackerLayer.InstructionMessage, trackerId: string): Promise<void> {
         try {
-            await this.handleFn(instructionMessage, trackerId)
+            await this.handleFn(instructionMessage, trackerId, true)
         } catch (err) {
             logger.warn('Instruction retry threw error', err)
         }

--- a/test/unit/InstructionRetryManager.test.ts
+++ b/test/unit/InstructionRetryManager.test.ts
@@ -31,11 +31,11 @@ describe('InstructionRetryManager', () => {
         await wait(110)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
-            [createInstruction('stream-3', 3), 'tracker-1'],
-            [createInstruction('stream-4', 4), 'tracker-1'],
-            [createInstruction('stream-5', 5), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-3', 3), 'tracker-1', true],
+            [createInstruction('stream-4', 4), 'tracker-1', true],
+            [createInstruction('stream-5', 5), 'tracker-2', true],
         ])
     })
 
@@ -49,16 +49,16 @@ describe('InstructionRetryManager', () => {
         await wait(220)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
-            [createInstruction('stream-3', 3), 'tracker-1'],
-            [createInstruction('stream-4', 4), 'tracker-1'],
-            [createInstruction('stream-5', 5), 'tracker-2'],
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
-            [createInstruction('stream-3', 3), 'tracker-1'],
-            [createInstruction('stream-4', 4), 'tracker-1'],
-            [createInstruction('stream-5', 5), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-3', 3), 'tracker-1', true],
+            [createInstruction('stream-4', 4), 'tracker-1', true],
+            [createInstruction('stream-5', 5), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-3', 3), 'tracker-1', true],
+            [createInstruction('stream-4', 4), 'tracker-1', true],
+            [createInstruction('stream-5', 5), 'tracker-2', true],
         ])
     })
     it('Instruction reattempts are updated properly per stream', async () => {
@@ -68,8 +68,8 @@ describe('InstructionRetryManager', () => {
         await wait(110)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
         ])
 
         instructionRetryManager.add(createInstruction('stream-1', 5), 'tracker-1')
@@ -78,10 +78,10 @@ describe('InstructionRetryManager', () => {
         await wait(110)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
-            [createInstruction('stream-1', 5), 'tracker-1'],
-            [createInstruction('stream-2', 8), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-1', 5), 'tracker-1', true],
+            [createInstruction('stream-2', 8), 'tracker-2', true],
         ])
     })
     it('Instructions for streams can be deleted and timeouts are cleared', async () => {
@@ -90,16 +90,16 @@ describe('InstructionRetryManager', () => {
 
         await wait(110)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
         ])
 
         instructionRetryManager.removeStreamId('stream-1::0')
         await wait(110)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
         ])
     })
     it('Instructions are no longer repeated for existing streams after reset() is called', async () => {
@@ -108,14 +108,14 @@ describe('InstructionRetryManager', () => {
 
         await wait(110)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
         ])
         instructionRetryManager.reset()
         await wait(220)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1'],
-            [createInstruction('stream-2', 2), 'tracker-2'],
+            [createInstruction('stream-1', 1), 'tracker-1', true],
+            [createInstruction('stream-2', 2), 'tracker-2', true],
         ])
     })
 })


### PR DESCRIPTION
- During churn, nodes can end up with inconsistent stream and connection states. 
- Instruction reattempts have a high probability for being triggered at different times between nodes that are instructed to connect between each other. This causes connections to timeout
- This change forces connections between nodes by using RtcConnect messages during Instruction retries.
- Ensures  (at least more likely)  that nodes connect to each other based on instructions after the first instruction retry is ran