### PR TITLE
try alternative ping/pong logic (cherry-picked)

### DIFF
--- a/src/composition.ts
+++ b/src/composition.ts
@@ -174,8 +174,7 @@ function startNode({
             peerInfo,
             stunUrls,
             webRtcSignaller, 
-            metricsContext, 
-            pingInterval, 
+            metricsContext,
             newWebrtcConnectionTimeout,
             webrtcDatachannelBufferThresholdLow,
             webrtcDatachannelBufferThresholdHigh

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -176,6 +176,7 @@ function startNode({
             webRtcSignaller, 
             metricsContext,
             newWebrtcConnectionTimeout,
+            pingInterval,
             webrtcDatachannelBufferThresholdLow,
             webrtcDatachannelBufferThresholdHigh
         ))

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -57,8 +57,8 @@ export class Connection {
     private lastGatheringState: string | null
     private flushTimeoutRef: NodeJS.Timeout | null
     private connectionTimeoutRef: NodeJS.Timeout | null
-    private peerPingTimeoutRef: NodeJS.Timeout | null
-    private peerPongTimeoutRef: NodeJS.Timeout | null
+    private pingTimeoutRef: NodeJS.Timeout | null
+    private pingAttempts = 0
     private rtt: number | null
     private respondedPong: boolean
     private rttStart: number | null
@@ -73,7 +73,7 @@ export class Connection {
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 5000,
         maxPingPongAttempts = 5,
-        pingPongTimeout = 2000,
+        pingPongTimeout = 5 * 1000,
         flushRetryTimeout = 500,
         onLocalDescription,
         onLocalCandidate,
@@ -106,8 +106,7 @@ export class Connection {
 
         this.flushTimeoutRef = null
         this.connectionTimeoutRef = null
-        this.peerPingTimeoutRef = null
-        this.peerPongTimeoutRef = null
+        this.pingTimeoutRef = setTimeout(() => this.ping(), this.pingPongTimeout)
 
         this.rtt = null
         this.respondedPong = true
@@ -217,18 +216,14 @@ export class Connection {
         if (this.connectionTimeoutRef) {
             clearTimeout(this.connectionTimeoutRef)
         }
-        if (this.peerPingTimeoutRef) {
-            clearTimeout(this.peerPingTimeoutRef)
-        }
-        if (this.peerPongTimeoutRef) {
-            clearTimeout(this.peerPongTimeoutRef)
+        if (this.pingTimeoutRef) {
+            clearTimeout(this.pingTimeoutRef)
         }
         this.dataChannel = null
         this.connection = null
         this.flushTimeoutRef = null
         this.connectionTimeoutRef = null
-        this.peerPingTimeoutRef = null
-        this.peerPongTimeoutRef = null
+        this.pingTimeoutRef = null
 
         if (err) {
             this.onError(err)
@@ -236,45 +231,25 @@ export class Connection {
         this.onClose()
     }
 
-    ping(attempt = 0): void | never {
-        if (this.peerPingTimeoutRef !== null) {
-            clearTimeout(this.peerPingTimeoutRef)
-        }
-        try {
-            if (this.isOpen()) {
-                if (!this.respondedPong) {
-                    throw new Error('dataChannel is not active')
-                }
-                this.respondedPong = false
+    ping(): void {
+        if (this.isOpen()) {
+            if (this.pingAttempts >= this.maxPingPongAttempts) {
+                this.logger.warn(`failed to receive any pong after ${this.maxPingPongAttempts} ping attempts, closing connection`)
+                this.close(new Error('pong not received'))
+            } else {
                 this.rttStart = Date.now()
                 this.dataChannel!.sendMessage('ping')
-            }
-        } catch (e) {
-            if (attempt < this.maxPingPongAttempts && this.isOpen()) {
-                this.logger.debug('failed to ping connection, error %s, re-attempting', e)
-                this.peerPingTimeoutRef = setTimeout(() => this.ping(attempt + 1), this.pingPongTimeout)
-            } else {
-                this.logger.warn('failed all ping re-attempts to connection, reattempting connection', e)
-                this.close(new Error('ping attempts failed'))
+                this.pingAttempts += 1
             }
         }
+        if (this.pingTimeoutRef) {
+            clearTimeout(this.pingTimeoutRef)
+        }
+        setTimeout(() => this.ping(), this.pingPongTimeout)
     }
 
-    pong(attempt = 0): void {
-        if (this.peerPongTimeoutRef !== null) {
-            clearTimeout(this.peerPongTimeoutRef)
-        }
-        try {
-            this.dataChannel!.sendMessage('pong')
-        } catch (e) {
-            if (attempt < this.maxPingPongAttempts && this.dataChannel && this.isOpen()) {
-                this.logger.debug('failed to pong connection, error %s, re-attempting', e)
-                this.peerPongTimeoutRef = setTimeout(() => this.pong(attempt + 1), this.pingPongTimeout)
-            } else {
-                this.logger.warn('failed all pong re-attempts to connection, reattempting connection', e)
-                this.close(new Error('pong attempts failed'))
-            }
-        }
+    pong(): void {
+        this.dataChannel!.sendMessage('pong')
     }
 
     setPeerInfo(peerInfo: PeerInfo): void {
@@ -349,7 +324,7 @@ export class Connection {
             if (msg === 'ping') {
                 this.pong()
             } else if (msg === 'pong') {
-                this.respondedPong = true
+                this.pingAttempts = 0
                 this.rtt = Date.now() - this.rttStart!
             } else {
                 this.onMessage(msg.toString()) // TODO: what if we get binary?

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -15,7 +15,7 @@ export interface ConstructorOptions {
     bufferThresholdHigh?: number
     newConnectionTimeout?: number
     maxPingPongAttempts?: number
-    pingPongTimeout?: number
+    pingInterval?: number
     flushRetryTimeout?: number
     onLocalDescription: (type: DescriptionType, description: string) => void
     onLocalCandidate: (candidate: string, mid: string) => void
@@ -37,7 +37,7 @@ export class Connection {
     private readonly bufferThresholdLow: number
     private readonly newConnectionTimeout: number
     private readonly maxPingPongAttempts: number
-    private readonly pingPongTimeout: number
+    private readonly pingInterval: number
     private readonly flushRetryTimeout: number
     private readonly onLocalDescription: (type: DescriptionType, description: string) => void
     private readonly onLocalCandidate: (candidate: string, mid: string) => void
@@ -73,7 +73,7 @@ export class Connection {
         bufferThresholdLow = 2 ** 15,
         newConnectionTimeout = 5000,
         maxPingPongAttempts = 5,
-        pingPongTimeout = 5 * 1000,
+        pingInterval = 2 * 1000,
         flushRetryTimeout = 500,
         onLocalDescription,
         onLocalCandidate,
@@ -93,7 +93,7 @@ export class Connection {
         this.bufferThresholdLow = bufferThresholdLow
         this.newConnectionTimeout = newConnectionTimeout
         this.maxPingPongAttempts = maxPingPongAttempts
-        this.pingPongTimeout = pingPongTimeout
+        this.pingInterval = pingInterval
         this.flushRetryTimeout = flushRetryTimeout
         this.logger = new Logger(['connection', 'Connection', `${this.selfId}-->${this.getPeerId()}`])
 
@@ -106,7 +106,7 @@ export class Connection {
 
         this.flushTimeoutRef = null
         this.connectionTimeoutRef = null
-        this.pingTimeoutRef = setTimeout(() => this.ping(), this.pingPongTimeout)
+        this.pingTimeoutRef = setTimeout(() => this.ping(), this.pingInterval)
 
         this.rtt = null
         this.respondedPong = true
@@ -245,7 +245,7 @@ export class Connection {
         if (this.pingTimeoutRef) {
             clearTimeout(this.pingTimeoutRef)
         }
-        setTimeout(() => this.ping(), this.pingPongTimeout)
+        setTimeout(() => this.ping(), this.pingInterval)
     }
 
     pong(): void {

--- a/src/connection/WebRtcEndpoint.ts
+++ b/src/connection/WebRtcEndpoint.ts
@@ -45,8 +45,6 @@ export class WebRtcEndpoint extends EventEmitter {
     private readonly rtcSignaller: RtcSignaller
     private connections: { [key: string]: Connection }
     private readonly newConnectionTimeout: number
-    private readonly pingIntervalInMs: number
-    private pingTimeoutRef: NodeJS.Timeout
     private readonly logger: Logger
     private readonly metrics: Metrics
     private stopped = false
@@ -58,7 +56,6 @@ export class WebRtcEndpoint extends EventEmitter {
         stunUrls: string[],
         rtcSignaller: RtcSignaller,
         metricsContext: MetricsContext,
-        pingIntervalInMs = 5 * 1000,
         newConnectionTimeout = 5000,
         webrtcDatachannelBufferThresholdLow = 2 ** 15,
         webrtcDatachannelBufferThresholdHigh = 2 ** 17
@@ -69,8 +66,6 @@ export class WebRtcEndpoint extends EventEmitter {
         this.rtcSignaller = rtcSignaller
         this.connections = {}
         this.newConnectionTimeout = newConnectionTimeout
-        this.pingIntervalInMs = pingIntervalInMs
-        this.pingTimeoutRef = setTimeout(() => this.pingConnections(), this.pingIntervalInMs)
         this.logger = new Logger(['connection', 'WebRtcEndpoint'], peerInfo)
         this.bufferThresholdLow = webrtcDatachannelBufferThresholdLow
         this.bufferThresholdHigh = webrtcDatachannelBufferThresholdHigh
@@ -259,7 +254,6 @@ export class WebRtcEndpoint extends EventEmitter {
     stop(): void {
         this.stopped = true
         Object.values(this.connections).forEach((connection) => connection.close())
-        clearTimeout(this.pingTimeoutRef)
         this.connections = {}
         this.rtcSignaller.setOfferListener(() => {})
         this.rtcSignaller.setAnswerListener(() => {})
@@ -268,11 +262,5 @@ export class WebRtcEndpoint extends EventEmitter {
         this.rtcSignaller.setConnectListener(() => {})
         this.removeAllListeners()
         nodeDataChannel.cleanup()
-    }
-
-    private pingConnections(): void {
-        const connections = Object.values(this.connections)
-        connections.forEach((connection) => connection.ping())
-        this.pingTimeoutRef = setTimeout(() => this.pingConnections(), this.pingIntervalInMs)
     }
 }

--- a/src/connection/WebRtcEndpoint.ts
+++ b/src/connection/WebRtcEndpoint.ts
@@ -45,6 +45,7 @@ export class WebRtcEndpoint extends EventEmitter {
     private readonly rtcSignaller: RtcSignaller
     private connections: { [key: string]: Connection }
     private readonly newConnectionTimeout: number
+    private readonly pingInterval: number
     private readonly logger: Logger
     private readonly metrics: Metrics
     private stopped = false
@@ -57,6 +58,7 @@ export class WebRtcEndpoint extends EventEmitter {
         rtcSignaller: RtcSignaller,
         metricsContext: MetricsContext,
         newConnectionTimeout = 5000,
+        pingInterval = 2 * 1000,
         webrtcDatachannelBufferThresholdLow = 2 ** 15,
         webrtcDatachannelBufferThresholdHigh = 2 ** 17
     ) {
@@ -66,6 +68,7 @@ export class WebRtcEndpoint extends EventEmitter {
         this.rtcSignaller = rtcSignaller
         this.connections = {}
         this.newConnectionTimeout = newConnectionTimeout
+        this.pingInterval = pingInterval
         this.logger = new Logger(['connection', 'WebRtcEndpoint'], peerInfo)
         this.bufferThresholdLow = webrtcDatachannelBufferThresholdLow
         this.bufferThresholdHigh = webrtcDatachannelBufferThresholdHigh
@@ -155,9 +158,10 @@ export class WebRtcEndpoint extends EventEmitter {
             routerId,
             isOffering,
             stunUrls: this.stunUrls,
-            newConnectionTimeout: this.newConnectionTimeout,
             bufferThresholdHigh: this.bufferThresholdHigh,
             bufferThresholdLow: this.bufferThresholdLow,
+            newConnectionTimeout: this.newConnectionTimeout,
+            pingInterval: this.pingInterval,
             onLocalDescription: (type, description) => {
                 this.rtcSignaller.onLocalDescription(routerId, connection.getPeerId(), type, description)
             },


### PR DESCRIPTION
- Instances of `Connection` handle ping/pong timers independently (before it was managed by `WebRTCEndpoint`)
    - No need for `WebRTCEndpoint` to know anything about ping/pong details.
    - It was a bit weird that there was a retry-timer being managed by `Connection`  itself, but also `WebRTCEndpoint`. Possibly leading to pings going out a bit more often than intended?
 - Only retry pings (not pongs)  and disconnect if `pingAttempts >= maxPingPongAttempts`.
    - Before we would re-try pongs, now we only send a pong once and it either goes thru or it doesn't.  We don't use pong failures as a reason to disconnect, only ping failures. This can be done since we know that each end of the connection is sending pings of their own.