### PR TITLE
Auto-generate & publish documentation.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Generate Docs
+
+on:
+  push:
+    branches:
+      - master # Set a branch name to trigger deployment
+
+jobs:
+  build:
+    name: Run build using Node 14.x
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+      - name: npm ci
+        run: npm ci
+      - name: npm run docs
+        run: npm run docs
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: docs
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,12 @@
 name: Eslint, Test and Publish
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - 'typedoc.js'
+      - '.idea'
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 bin/.idea
 
 .DS_Store
+docs

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
     <img alt="Streamr" src="https://raw.githubusercontent.com/streamr-dev/streamr-client-javascript/master/readme-header-img.png" width="1320" />
   </a>
 </p>
-<h1 align="left">
 
 # streamr-network
 
-An extendable implementation of the server-side
+An extendible implementation of the server-side
 [Streamr Protocol](https://github.com/streamr-dev/streamr-specs/blob/master/PROTOCOL.md) logic written in TypeScript.
 The package mostly acts as a library for other packages wishing to implement a broker node, but additionally
 provides a full tracker executable, and a stripped-down network node executable.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 # streamr-network
 
+[![Build Status](https://travis-ci.com/streamr-dev/network.svg?branch=master&style=flat)](https://travis-ci.com/streamr-dev/network)
+[![GitHub release](https://img.shields.io/github/release/streamr-dev/network.svg?style=flat)](https://github.com/streamr-dev/network/releases/)
+[![GitHub stars](https://img.shields.io/github/stars/streamr-dev/network.svg?style=flat&label=Star&maxAge=2592000)](https://github.com/streamr-dev/network/)
+[![Discord Chat](https://img.shields.io/discord/801574432350928907.svg?label=Discord&logo=Discord&colorB=7289da)](https://discord.gg/FVtAph9cvz)
+
+
 An extendible implementation of the server-side
 [Streamr Protocol](https://github.com/streamr-dev/streamr-specs/blob/master/PROTOCOL.md) logic written in TypeScript.
 The package mostly acts as a library for other packages wishing to implement a broker node, but additionally

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The [wiki](https://github.com/streamr-dev/network/wiki) outlines the technical a
 decisions of the project. It provides thorough explanations of some the more involved features.
 A glossary is also included.
 
+[API Documentation](https://streamr-dev.github.io/network/)
+
 ## Table of Contents
 - [Install](#install)
 - [Run](#run)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # streamr-network
 
-[![Build Status](https://travis-ci.com/streamr-dev/network.svg?branch=master&style=flat)](https://travis-ci.com/streamr-dev/network)
+[![Build Status](https://img.shields.io/github/workflow/status/streamr-dev/network/nodejs/master)](https://github.com/streamr-dev/network/actions)
 [![npm release](https://img.shields.io/npm/v/streamr-network?style=flat)](https://www.npmjs.com/package/streamr-network)
 [![GitHub stars](https://img.shields.io/github/stars/streamr-dev/network.svg?style=flat&label=Star&maxAge=2592000)](https://github.com/streamr-dev/network/)
 [![Discord Chat](https://img.shields.io/discord/801574432350928907.svg?label=Discord&logo=Discord&colorB=7289da)](https://discord.gg/FVtAph9cvz)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # streamr-network
 
 [![Build Status](https://travis-ci.com/streamr-dev/network.svg?branch=master&style=flat)](https://travis-ci.com/streamr-dev/network)
-[![GitHub release](https://img.shields.io/github/release/streamr-dev/network.svg?style=flat)](https://github.com/streamr-dev/network/releases/)
+[![npm release](https://img.shields.io/npm/v/streamr-network?style=flat)](https://www.npmjs.com/package/streamr-network)
 [![GitHub stars](https://img.shields.io/github/stars/streamr-dev/network.svg?style=flat&label=Star&maxAge=2592000)](https://github.com/streamr-dev/network/)
 [![Discord Chat](https://img.shields.io/discord/801574432350928907.svg?label=Discord&logo=Discord&colorB=7289da)](https://discord.gg/FVtAph9cvz)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1639,6 +1639,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3126,6 +3132,18 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3263,6 +3281,19 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3526,6 +3557,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "ip-address": {
       "version": "5.9.4",
@@ -4556,6 +4593,16 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4632,6 +4679,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4678,6 +4731,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -4802,6 +4861,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -4908,7 +4973,7 @@
           "bundled": true
         },
         "ini": {
-          "version": "1.3.6",
+          "version": "1.3.5",
           "bundled": true
         },
         "is-fullwidth-code-point": {
@@ -5333,6 +5398,32 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -5570,6 +5661,15 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
       }
     },
     "regex-not": {
@@ -6029,12 +6129,33 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "shiki": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
+      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -6788,6 +6909,39 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.20.34",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.34.tgz",
+      "integrity": "sha512-es+N/KyGPcHl9cAuYh1Z5m7HzwcmfNLghkmb2pzGz7HRDS5GS2uA3hu/c2cv4gCxDsw8pPUPCOvww+Hzf48Kug==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "lunr": "^2.3.9",
+        "marked": "^2.0.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "shiki": "^0.9.3",
+        "typedoc-default-themes": "^0.12.9"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
+      "dev": true
+    },
     "typescript": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
@@ -6797,6 +6951,13 @@
     "uWebSockets.js": {
       "version": "github:uNetworking/uWebSockets.js#b4bc740f46f1508c0f342b999db4d1f9dc80deab",
       "from": "github:uNetworking/uWebSockets.js#v18.14.0"
+    },
+    "uglify-js": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.2.tgz",
+      "integrity": "sha512-SbMu4D2Vo95LMC/MetNaso1194M1htEA+JrqE9Hk+G2DhI+itfS9TRu9ZKeCahLDNa/J3n4MqUJ/fOHMzQpRWw==",
+      "dev": true,
+      "optional": true
     },
     "union-value": {
       "version": "1.0.1",
@@ -6809,6 +6970,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6942,6 +7109,12 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "vscode-textmate": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
+      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w==",
+      "dev": true
+    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -7020,6 +7193,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "coverage": "jest --coverage",
     "test-integration": "jest test/integration",
     "eslint": "eslint .",
-    "network": "node $NODE_DEBUG_OPTION bin/network.js"
+    "network": "node $NODE_DEBUG_OPTION bin/network.js",
+    "docs": "typedoc --options typedoc.js"
   },
   "author": "Streamr Network AG <contact@streamr.network>",
   "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
@@ -72,6 +73,7 @@
     "streamr-test-utils": "^1.3.0",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",
+    "typedoc": "^0.20.34",
     "typescript": "^4.1.3"
   },
   "optionalDependencies": {

--- a/typedoc.js
+++ b/typedoc.js
@@ -3,7 +3,6 @@ module.exports = {
         'src/composition.ts',
     ],
     tsconfig: 'tsconfig.json',
-    readme: false,
     excludeInternal: true,
     includeVersion: true,
 }

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    entryPoints: [
+        'src/composition.ts',
+    ],
+    tsconfig: 'tsconfig.json',
+    readme: false,
+    excludeInternal: true,
+    includeVersion: true,
+}


### PR DESCRIPTION
* Adds new `npm run docs` script to generate pretty API docs from TS source using [typedoc](https://www.npmjs.com/package/typedoc).
* Adds new GH Actions workflow that generates & publishes docs on commits to `master`.  
* API Docs will be publicly available at https://streamr-dev.github.io/network/ after merge and enabling GH Pages for this repo.
* Config copied from setup in JavaScript client.
* Won't run main CI steps in `nodejs.yml` for readme changes.
* Fixes minor issues in readme.
* Adds fancy badges to readme. 🤷 

## Preview of generated docs

![image](https://user-images.githubusercontent.com/43438/112681108-a01b5c00-8e44-11eb-803c-6c72a1ce0e05.png)

![image](https://user-images.githubusercontent.com/43438/112681113-a14c8900-8e44-11eb-87db-6258d4f4b43f.png)

## Readme badges
 ![image](https://user-images.githubusercontent.com/43438/112680372-af4dda00-8e43-11eb-8728-9867fd21c624.png)
