### PR TITLE
limit status sending

### DIFF
--- a/src/logic/Node.ts
+++ b/src/logic/Node.ts
@@ -299,17 +299,21 @@ export class Node extends EventEmitter {
             this.streams.updateCounter(streamId, counter)
         }
 
-        this.prepareAndSendStreamStatus(streamId)
         // Log success / failures
         const subscribeNodeIds: string[] = []
         const unsubscribeNodeIds: string[] = []
+        let failedInstructions = false
         results.forEach((res) => {
             if (res.status === 'fulfilled') {
                 subscribeNodeIds.push(res.value)
             } else {
+                failedInstructions = true
                 this.logger.debug('failed to subscribe (or connect) to node, reason: %s', res.reason)
             }
         })
+        if (!reattempt || failedInstructions) {
+            this.prepareAndSendStreamStatus(streamId)
+        }
 
         this.logger.debug('subscribed to %j and unsubscribed from %j (streamId=%s, counter=%d)',
             subscribeNodeIds, unsubscribeNodeIds, streamId, counter)

--- a/test/unit/InstructionRetryManager.test.ts
+++ b/test/unit/InstructionRetryManager.test.ts
@@ -32,11 +32,11 @@ describe('InstructionRetryManager', () => {
         await wait(110)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
-            [createInstruction('stream-3', 3), 'tracker-1', true],
-            [createInstruction('stream-4', 4), 'tracker-1', true],
-            [createInstruction('stream-5', 5), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
+            [createInstruction('stream-3', 3), 'tracker-1', false],
+            [createInstruction('stream-4', 4), 'tracker-1', false],
+            [createInstruction('stream-5', 5), 'tracker-2', false],
         ])
     })
 
@@ -50,11 +50,11 @@ describe('InstructionRetryManager', () => {
         await wait(220)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
-            [createInstruction('stream-3', 3), 'tracker-1', true],
-            [createInstruction('stream-4', 4), 'tracker-1', true],
-            [createInstruction('stream-5', 5), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
+            [createInstruction('stream-3', 3), 'tracker-1', false],
+            [createInstruction('stream-4', 4), 'tracker-1', false],
+            [createInstruction('stream-5', 5), 'tracker-2', false],
             [createInstruction('stream-1', 1), 'tracker-1', true],
             [createInstruction('stream-2', 2), 'tracker-2', true],
             [createInstruction('stream-3', 3), 'tracker-1', true],
@@ -69,8 +69,8 @@ describe('InstructionRetryManager', () => {
         await wait(110)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
         ])
 
         instructionRetryManager.add(createInstruction('stream-1', 5), 'tracker-1')
@@ -79,10 +79,10 @@ describe('InstructionRetryManager', () => {
         await wait(110)
 
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
-            [createInstruction('stream-1', 5), 'tracker-1', true],
-            [createInstruction('stream-2', 8), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
+            [createInstruction('stream-1', 5), 'tracker-1', false],
+            [createInstruction('stream-2', 8), 'tracker-2', false],
         ])
     })
     it('Instructions for streams can be deleted and timeouts are cleared', async () => {
@@ -91,15 +91,15 @@ describe('InstructionRetryManager', () => {
 
         await wait(110)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
         ])
 
         instructionRetryManager.removeStreamId('stream-1::0')
         await wait(110)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
             [createInstruction('stream-2', 2), 'tracker-2', true],
         ])
     })
@@ -109,14 +109,14 @@ describe('InstructionRetryManager', () => {
 
         await wait(110)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
         ])
         instructionRetryManager.reset()
         await wait(220)
         expect(handlerCb.mock.calls).toEqual([
-            [createInstruction('stream-1', 1), 'tracker-1', true],
-            [createInstruction('stream-2', 2), 'tracker-2', true],
+            [createInstruction('stream-1', 1), 'tracker-1', false],
+            [createInstruction('stream-2', 2), 'tracker-2', false],
         ])
     })
 })


### PR DESCRIPTION
- Limit status sending during instruction retries
- Only send a repeat status on every 10th retry or if instruction handling fails