### PR TITLE
Update node-datachannel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4989,9 +4989,9 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-datachannel": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.0.tgz",
-      "integrity": "sha512-3lmXsnzWFzQLBOp7GcpXlsGEohRolbhccnxzE10TZmio8Szhmubs8usyuqXuHhnVIALayI92L4Suc+OvzSbnWA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.1.tgz",
+      "integrity": "sha512-2MRNfneH4Lv7a2t9O7wb3E/rw7bCLKu+2L2n4vHQ1bSQX1jnheKzTfdmzufpgYDsH3QsgZFXOMySsk+/JNd7tw==",
       "requires": {
         "prebuild-install": "^5.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "heap": "^0.2.6",
     "lodash": "^4.17.21",
     "lru-cache": "^6.0.0",
-    "node-datachannel": "^0.1.0",
+    "node-datachannel": "^0.1.1",
     "pino": "^6.11.2",
     "pino-pretty": "^4.7.1",
     "speedometer": "^1.1.0",

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -13,6 +13,7 @@ export interface ConstructorOptions {
     stunUrls: string[]
     bufferThresholdLow?: number
     bufferThresholdHigh?: number
+    maxMessageSize?: number
     newConnectionTimeout?: number
     maxPingPongAttempts?: number
     pingInterval?: number
@@ -35,6 +36,7 @@ export class Connection {
     private readonly stunUrls: string[]
     private readonly bufferThresholdHigh: number
     private readonly bufferThresholdLow: number
+    private readonly maxMessageSize: number
     private readonly newConnectionTimeout: number
     private readonly maxPingPongAttempts: number
     private readonly pingInterval: number
@@ -83,7 +85,8 @@ export class Connection {
         onClose,
         onError,
         onBufferLow,
-        onBufferHigh
+        onBufferHigh,
+        maxMessageSize = 1048576
     }: ConstructorOptions) {
         this.selfId = selfId
         this.peerInfo = PeerInfo.newUnknown(targetPeerId)
@@ -92,6 +95,7 @@ export class Connection {
         this.stunUrls = stunUrls
         this.bufferThresholdHigh = bufferThresholdHigh
         this.bufferThresholdLow = bufferThresholdLow
+        this.maxMessageSize = maxMessageSize
         this.newConnectionTimeout = newConnectionTimeout
         this.maxPingPongAttempts = maxPingPongAttempts
         this.pingInterval = pingInterval
@@ -126,7 +130,8 @@ export class Connection {
 
     connect(): void {
         this.connection = new nodeDataChannel.PeerConnection(this.selfId, {
-            iceServers: this.stunUrls
+            iceServers: this.stunUrls,
+            maxMessageSize: this.maxMessageSize
         })
         this.connection.onStateChange((state) => {
             this.lastState = state

--- a/test/unit/WebRtcEndpoint.test.ts
+++ b/test/unit/WebRtcEndpoint.test.ts
@@ -127,10 +127,10 @@ describe('WebRtcEndpoint', () => {
     })
 
     it('cannot send too large of a payload', (done) => {
-        const payload = new Array(1024 * 1024).fill('X').join('')
+        const payload = new Array(2 ** 21).fill('X').join('')
         endpoint1.connect('node-2', 'tracker')
         endpoint1.send('node-2', payload).catch((err) => {
-            expect(err.message).toMatch(/Dropping message due to size 1048576 exceeding the limit of \d+/)
+            expect(err.message).toMatch(/Dropping message due to size 2097152 exceeding the limit of \d+/)
             done()
         })
     })


### PR DESCRIPTION
- Upper limit of maxMessageSize increased to 1048576 in the libdatachannel library. (seems to be the upper limit of many browsers)
- Includes stability improvements to the forming of datachannels
- Seems to have fix the flaky test case "messages delivered again on temporary loss of connectivity" in integration/ Connection.test.ts, tested with 25 local runs