### PR TITLE
NET-143: Remove usages of msgChainId from ResendFromRequest

### DIFF
--- a/src/NetworkNode.ts
+++ b/src/NetworkNode.ts
@@ -66,8 +66,7 @@ export class NetworkNode extends Node {
         requestId: string,
         fromTimestamp: number,
         fromSequenceNo: number,
-        publisherId: string | null,
-        _msgChainId: string | null
+        publisherId: string | null
     ): ReadableStream {
         const request = new ControlLayer.ResendFromRequest({
             requestId,

--- a/test/integration/l1-resend-requests.test.ts
+++ b/test/integration/l1-resend-requests.test.ts
@@ -92,8 +92,7 @@ describe('resend requests are fulfilled at L1', () => {
             'requestId',
             666,
             0,
-            'publisherId',
-            'msgChainId'
+            'publisherId'
         )
         const events = await typesOfStreamItems(stream)
 

--- a/test/integration/l3-resend-requests.test.ts
+++ b/test/integration/l3-resend-requests.test.ts
@@ -149,8 +149,7 @@ describe('resend requests are fulfilled at L3', () => {
             'requestId',
             666,
             0,
-            'publisherId',
-            'msgChainId'
+            'publisherId'
         )
         const events = await typesOfStreamItems(stream)
         expect(events).toEqual([


### PR DESCRIPTION
https://linear.app/streamr/issue/NET-143/remove-references-to-resendfromrequestmsgchainid-from-multiple