### PR TITLE
Test types in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,6 +34,7 @@ jobs:
             ${{ runner.OS }}-
       - run: npm ci
       - run: npm run eslint
+      - run: npm run test-types
       - run: npm run build --if-present
       - run: npm test
         env:

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ src
 test
 .travis.yml
 tsconfig.json
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test-unit": "jest test/unit",
     "coverage": "jest --coverage",
     "test-integration": "jest test/integration",
+    "test-types": "tsc --noEmit --project ./tsconfig.json ",
     "eslint": "eslint .",
     "network": "node $NODE_DEBUG_OPTION bin/network.js",
     "docs": "typedoc --options typedoc.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "strict": true,
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "incremental": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
* Tests types in CI using new `npm run test-types` script.
* Allows running `npm run test-types -- --watch` locally to get simple type checking during development without running an IDE.
* Also enables incremental compilation, improves recompilation speed.