### PR TITLE
Minor setTimeout related fixes.

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -359,7 +359,7 @@ export class Connection {
 
     private openDataChannel(dataChannel: DataChannel): void {
         if (this.connectionTimeoutRef !== null) {
-            clearInterval(this.connectionTimeoutRef)
+            clearTimeout(this.connectionTimeoutRef)
         }
         this.dataChannel = dataChannel
         this.setFlushRef()

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -266,7 +266,7 @@ export class Connection {
         if (this.pingTimeoutRef) {
             clearTimeout(this.pingTimeoutRef)
         }
-        setTimeout(() => this.ping(), this.pingInterval)
+        this.pingTimeoutRef = setTimeout(() => this.ping(), this.pingInterval)
     }
 
     pong(): void {


### PR DESCRIPTION
Noticed `this.pingTimeoutRef` was never being reset after the first time it's set in the constructor.

Also was looking for `clearTimeout` on `this.connectionTimeoutRef`, thought it was missing. Turns out  `clearInterval(this.connectionTimeoutRef)` was used instead of `clearTimeout(this.connectionTimeoutRef)`. While this does work, I was confused for some time as it appeared the timeout was never cleared. I even wrote a test to confirm the behaviour was working in 64839cb, only to wonder why the test was passing, then noticed the `clearInterval` afterwards.
