### PR TITLE
tsc target es2020, add sourcemap support.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2020",
     "module": "commonjs",
     "lib": ["es2020"],
     "allowJs": true,
@@ -11,7 +11,8 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "resolveJsonModule": true,
-    "incremental": true
+    "incremental": true,
+    "sourceMap": true
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
Based on https://www.npmjs.com/package/@tsconfig/node14
node 14 should target es2020 rather than es2015/es6

e.g. this makes ts happy to use `Promise.allSettled`

Also added sourcemap generation. Node doesn't use this directly but if you run with https://github.com/evanw/node-source-map-support you can use:

```
node -r source-map-support/register tracker.js
```
