### PR TITLE
NET-129: fix flaky test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4989,9 +4989,9 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-datachannel": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.1.tgz",
-      "integrity": "sha512-2MRNfneH4Lv7a2t9O7wb3E/rw7bCLKu+2L2n4vHQ1bSQX1jnheKzTfdmzufpgYDsH3QsgZFXOMySsk+/JNd7tw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.1.2.tgz",
+      "integrity": "sha512-UeshLqHXDr9WQsCtPObMv1Us3Ojt+SpnztR8qAoPniNOebUYjdr44W5e3Q24d0hI34oHaO2YTuFUd5vO73r6HQ==",
       "requires": {
         "prebuild-install": "^5.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "heap": "^0.2.6",
     "lodash": "^4.17.21",
     "lru-cache": "^6.0.0",
-    "node-datachannel": "^0.1.1",
+    "node-datachannel": "^0.1.2",
     "pino": "^6.11.2",
     "pino-pretty": "^4.7.1",
     "speedometer": "^1.1.0",

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -517,8 +517,9 @@ export class Connection extends ConnectionEmitter {
             } else {
                 let sent = false
                 try {
-                    // Checking `this.open()` is left out on purpose. We want the message to be discarded if it was not
-                    // sent after MAX_TRIES regardless of the reason.
+                    // this.isOpen() is checked immediately after the call to node-datachannel.sendMessage() as if
+                    // this.isOpen() returns false after a "successful" send, the message is lost with a near 100% chance.
+                    // This does not work as expected if this.isOpen() is checked before sending a message
                     sent = this.dataChannel!.sendMessage(queueItem.getMessage()) && this.isOpen()
                     numOfSuccessSends += 1
                 } catch (e) {

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -519,7 +519,7 @@ export class Connection extends ConnectionEmitter {
                 try {
                     // Checking `this.open()` is left out on purpose. We want the message to be discarded if it was not
                     // sent after MAX_TRIES regardless of the reason.
-                    sent = this.dataChannel!.sendMessage(queueItem.getMessage())
+                    sent = this.dataChannel!.sendMessage(queueItem.getMessage()) && this.isOpen()
                     numOfSuccessSends += 1
                 } catch (e) {
                     this.processFailedMessage(queueItem, e)

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -521,7 +521,6 @@ export class Connection extends ConnectionEmitter {
                     // this.isOpen() returns false after a "successful" send, the message is lost with a near 100% chance.
                     // This does not work as expected if this.isOpen() is checked before sending a message
                     sent = this.dataChannel!.sendMessage(queueItem.getMessage()) && this.isOpen()
-                    numOfSuccessSends += 1
                 } catch (e) {
                     this.processFailedMessage(queueItem, e)
                     return // method rescheduled by `this.flushTimeoutRef`
@@ -530,6 +529,7 @@ export class Connection extends ConnectionEmitter {
                 if (sent) {
                     this.messageQueue.pop()
                     queueItem.delivered()
+                    numOfSuccessSends += 1
                 } else {
                     this.processFailedMessage(queueItem, new Error('sendMessage returned false'))
                 }


### PR DESCRIPTION
1. Update node-datachannel to v0.1.2
2. Check that datachannel is still open immediately after a send attempt. If isOpen() returns false and sendMessage() returns true messages were lost at a ~100% rate. It is better to to expect that messages are lost and to attempt resends after such cases. This approach fixes the flaky test case "test/unit/WebRtcEndpoint.test.ts:  messages are delivered on temporary loss of connectivity"
3. Wrapping the node-datachannel.sendMessage() call with an if check for isOpen() does not fix the issue as it is likely timing related